### PR TITLE
Let autotools know about the samples

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,5 @@
+SUBDIRS = c/samples
+
 lib_LTLIBRARIES = libplanarity.la
 
 libplanarity_la_SOURCES = \

--- a/Makefile.am
+++ b/Makefile.am
@@ -25,8 +25,7 @@ libplanarity_la_SOURCES = \
 	c/stack.c
 libplanarity_la_LDFLAGS = -no-undefined $(AM_LDFLAGS) -version-info @LT_CURRENT@:@LT_REVISION@:@LT_AGE@
 
-headersdir = $(includedir)/planarity/
-headers_HEADERS = \
+pkginclude_HEADERS = \
 	c/appconst.h \
 	c/graph.h \
 	c/graphDrawPlanar.h \

--- a/Makefile.am
+++ b/Makefile.am
@@ -53,3 +53,5 @@ planarity_SOURCES = c/planarity.c c/planarityCommandLine.c
 
 man1_MANS = planarity.1
 EXTRA_DIST=$(man1_MANS)
+
+TESTS = test-samples.sh

--- a/c/planarityCommandLine.c
+++ b/c/planarityCommandLine.c
@@ -118,9 +118,9 @@ int runSpecificGraphTest(char *command, char *infileName);
 int runQuickRegressionTests(int argc, char *argv[])
 {
 	if (runSpecificGraphTests() < 0)
-		return -1;
+		return NOTOK;
 
-	return 0;
+	return OK;
 }
 
 int runSpecificGraphTests()

--- a/c/samples/Makefile.am
+++ b/c/samples/Makefile.am
@@ -1,0 +1,39 @@
+# The @docdir@ variable will be replaced by the ./configure script.
+# This is "necessary" (that is, I don't know a better way to do it)
+# to install these samples in a "samples" subdirectory of the usual
+# documentation directory.
+docdir = @docdir@/samples
+
+dist_doc_DATA = \
+  Petersen.0-based.txt \
+  Petersen.0-based.txt.ColorVertices.out.txt \
+  Petersen.0-based.txt.K23Search.out.txt \
+  Petersen.0-based.txt.K33Search.out.txt \
+  Petersen.0-based.txt.K4Search.out.txt \
+  Petersen.0-based.txt.OuterplanarEmbed.out.txt \
+  Petersen.0-based.txt.PlanarEmbed.out.txt \
+  Petersen.txt \
+  Petersen.txt.ColorVertices.out.txt \
+  Petersen.txt.K23Search.out.txt \
+  Petersen.txt.K33Search.out.txt \
+  Petersen.txt.K4Search.out.txt \
+  Petersen.txt.OuterplanarEmbed.out.txt \
+  Petersen.txt.PlanarEmbed.out.txt \
+  drawExample.0-based.txt \
+  drawExample.0-based.txt.ColorVertices.out.txt \
+  drawExample.0-based.txt.DrawPlanar.out.txt \
+  drawExample.0-based.txt.DrawPlanar.out.txt.render.txt \
+  drawExample.txt \
+  drawExample.txt.ColorVertices.out.txt \
+  drawExample.txt.DrawPlanar.out.txt \
+  drawExample.txt.DrawPlanar.out.txt.render.txt \
+  maxPlanar5.0-based.txt \
+  maxPlanar5.0-based.txt.ColorVertices.out.txt \
+  maxPlanar5.0-based.txt.DrawPlanar.out.txt \
+  maxPlanar5.0-based.txt.DrawPlanar.out.txt.render.txt \
+  maxPlanar5.0-based.txt.PlanarEmbed.out.txt \
+  maxPlanar5.txt \
+  maxPlanar5.txt.ColorVertices.out.txt \
+  maxPlanar5.txt.DrawPlanar.out.txt \
+  maxPlanar5.txt.DrawPlanar.out.txt.render.txt \
+  maxPlanar5.txt.PlanarEmbed.out.txt

--- a/configure.ac
+++ b/configure.ac
@@ -26,4 +26,9 @@ AC_PROG_INSTALL
 
 AC_CHECK_HEADERS([ctype.h stdio.h stdlib.h string.h time.h unistd.h])
 
-AC_OUTPUT(Makefile)
+AC_CONFIG_FILES([
+  Makefile
+  c/samples/Makefile
+])
+
+AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -30,5 +30,7 @@ AC_CONFIG_FILES([
   Makefile
   c/samples/Makefile
 ])
+AC_CONFIG_FILES([test-samples.sh], [chmod +x test-samples.sh])
+
 
 AC_OUTPUT

--- a/test-samples.sh.in
+++ b/test-samples.sh.in
@@ -1,0 +1,19 @@
+#!/bin/sh
+#
+# Run "planarity -test" using planarity from the build tree and the
+# samples from the source tree. This is complicated by the fact that
+# the source tree may be read-only (as it is during "make distcheck"),
+# meaning that we have to "relocate" the samples into a writable
+# directory within the build tree rather than try to put the
+# just-built planarity executable into the source tree while the test
+# suite runs.
+#
+
+samplesdir="@abs_top_srcdir@/c/samples"
+planaritydir="@abs_top_builddir@"
+
+cd "${planaritydir}"                || exit 1
+mkdir samples                       || exit 2
+cp "${samplesdir}"/*.txt ./samples/ || exit 3
+./planarity -test                   || exit 4
+rm -rf ./samples                    || exit 5


### PR DESCRIPTION
The individual commits should explain themselves pretty well. Basically we tell autotools about the `c/samples` directory so that the samples can be installed automatically. The first commit is unrelated but trivial and should not change anything at all.