### PR TITLE
Makefile.am: ship the documentation and install it to $(docdir).

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -55,3 +55,7 @@ man1_MANS = planarity.1
 EXTRA_DIST=$(man1_MANS)
 
 TESTS = test-samples.sh
+
+# The @docdir@ variable will be replaced by the ./configure script.
+docdir = @docdir@
+dist_doc_DATA = README.md LICENSE.TXT


### PR DESCRIPTION
Autotools didn't know about the README.md or LICENSE.TXT files, so
they were neither included in the distribution tarball nor installed
to the user's system with "make install." Here we add the relevant
bits to the Makefile.am to include them in the release tarball,
and install them to the user's preferred --docdir.