### PR TITLE
Rewrite manpage

### DIFF
--- a/planarity.1
+++ b/planarity.1
@@ -4,62 +4,84 @@
 planarity - The Edge Addition Planarity Suite
 
 .SH SYNOPSIS
+
+.SS Getting help
+.B planarity -h|-help [-menu]
+
+.B planarity -i|-info
+
+.SS Menu-driven mode
 .B planarity
-.B [-q]
-.B [-h|-help]
-.B [-i|-info]
-.B [-r]
-.B [-s]
-.B [-rm]
-.B [-rn]
+
+.SS Batch modes
+
+.B planarity -s [-q] \fICOMMAND\fR \fIINPUT\fR \fIOUTPUT\fR [\fICOMPLEMENT\fR]
+
+.B planarity -r [-q] \fICOMMAND\fR \fIK\fR \fIN\fR
+
+.B planarity -rm [-q] \fIN\fR \fIOUTPUT\fR [\fICOMPLEMENT\fR]
+
+.B planarity -rn [-q] \fIN\fR \fIOUTPUT\fR [\fICOMPLEMENT\fR]
 
 .SH DESCRIPTION
-Invokes the Edge Addition Planarity Suite commandline tool.
+Invokes the Edge Addition Planarity Suite command-line tool, either in
+interactive mode or in batch mode.
 
-Without argument, the tool presents a menu-driven interactive
+Without a parameter, the tool presents a menu-driven interactive
 interface.
 
-When used in batch mode, the tool returns 0 for a planar graph, 1 for
-a nonplanar graph and -1 on error.
+When a parameter is given, it runs in batch mode and returns 0 or 1
+for a successful result and -1 on error.
 
 .SH OPTIONS
+
 .TP
-.B -q
-Quiet mode
-.TP
-.B -h, -help
-Display some help
+.B -h, -help [-menu]
+Display some help, with \fB-menu\fR triggering even more detailed output.
+
 .TP
 .B -i, -info
-Display copyright, license and reference articles information
+Display version, copyright, license, and reference articles information.
 
-.SH FEATURES
-Features in batch mode.
 .TP
-.B -r C K N
-Run the C command (see below) on K random graphs with N vertices
+.B -q
+Quiet mode optional modifier, see below which options accept it.
+
 .TP
-.B -s C I O [O2]
-Run the C command (see below) on a specific graph given in the I input
-file, with output in the primary O file and complementary information
-in the secondary O2 file.
+.B -s [-q] \fICOMMAND\fR \fIINPUT\fR \fIOUTPUT\fR [\fICOMPLEMENT\fR]
+Run the \fICOMMAND\fR (see below) on a specific graph given in the
+\fIINPUT\fR file, with output in the primary \fIOUTPUT\fR file and
+complementary information, if any, in the secondary \fICOMPLEMENT\fR file
+(e.g. an ASCII art rendition for the planar graph drawing command). The
+return value is 0 if the specific graph is embeddable (e.g. it is
+planar or doesn't contain a homeomorphic subgraph) and 1 if it isn't
+embeddable (e.g. non planar or does contain a homeomorphic subgraph).
+
 .TP
-.B -rm N O [O2]
-Compute a maximal planar random graph on N vertices with output in the
-primary O file and optionally the chosen graph in the O2 file.
+.B -r [-q] \fICOMMAND\fR \fIK\fR \fIN\fR
+Run the \fICOMMAND\fR (see below) on \fIK\fR random graphs with
+\fIN\fR vertices.
+
 .TP
-.B -rn N O [O2]
-Compute a nonplanar random graph (maximal planar and an edge) on N
-vertices with output in the primary O file and optionally the chosen
-graph in the O2 file.
+.B -rm [-q] \fIN\fR \fIOUTPUT\fR [\fICOMPLEMENT\fR]
+Generate a random maximal planar graph with \fIN\fR vertices, then output
+its planar embedding in the primary \fIOUTPUT\fR file and optionally the
+generated graph in the \fICOMPLEMENT\fR file.
+.TP
+.B -rn [-q] \fIN\fR \fIOUTPUT\fR [\fICOMPLEMENT\fR]
+Generate a random nonplanar graph (maximal planar plus one edge) with
+\fIN\fR vertices, then output a Kuratowski subgraph of the generated graph
+in the primary \fIOUTPUT\fR file and optionally the gnerated graph in
+the \fICOMPLEMENT\fR file.
+
 .SH COMMANDS
-Determine which algorithm implementation to run
+Determine which algorithm implementation to run:
 .TP
 .B -p
 Planar embedding and Kuratowski subgraph isolation
 .TP
 .B -d
-Planar graph drawing by visibility representation
+Planar graph drawing by visibility representation (and optional ASCII art rendition)
 .TP
 .B -o
 Outerplanar embedding and obstruction isolation
@@ -72,21 +94,21 @@ Search for subgraph homeomorphic to K_{3,3}
 .TP
 .B -4
 Search for subgraph homeomorphic to K_4
-.TP
-.B -a
-All of the above
 
 .SH EXAMPLES
 .TP
 .B planarity -s -q -p infile.txt embedding.out [obstruction.out]
-Process infile.txt in quiet mode (-q), putting planar embedding in 
-embedding.out or (optionally) a Kuratowski subgraph in Obstruction.out
+Process infile.txt in quiet mode (-q), putting planar embedding in
+embedding.out or (optionally) a Kuratowski subgraph in obstruction.out.
 Process returns 0=planar, 1=nonplanar, -1=error
 .TP
 .B planarity -s -q -d infile.txt embedding.out [drawing.out]
-If graph in infile.txt is planar, then put embedding in embedding.out 
-and (optionally) an ASCII art drawing in drawing.out
+If graph in infile.txt is planar, then put embedding in embedding.out
+and (optionally) an ASCII art drawing in drawing.out.
 Process returns 0=planar, 1=nonplanar, -1=error
 
 .SH SEE ALSO
-\fBplanarity -h -menu\fR for more information.
+
+The full inline help: \fBplanarity -h -menu\fR
+
+The project homepage: \fBhttps://github.com/graph-algorithms/edge-addition-planarity-suite\fR


### PR DESCRIPTION
Here is the rewritten version, including your changes, with only a trivial added change: I removed the trailing whitespaces you added.

The question "why .1 ?" has a simple answer: 1 is the relevant [section](https://en.wikipedia.org/wiki/Man_page#Manual_sections).

Cheers!