### PR TITLE
Issue 33 - Make man Page and help updates for .g6 format addition

### DIFF
--- a/planarity.1
+++ b/planarity.1
@@ -23,6 +23,8 @@ planarity - The Edge Addition Planarity Suite
 
 .B planarity -rn [-q] \fIN\fR \fIOUTPUT\fR [\fICOMPLEMENT\fR]
 
+.B planarity -t [-q] \fICOMMAND\fR|\fB-t(gam)\fR \fIN\fR \fIOUTPUT\fR
+
 .SH DESCRIPTION
 Invokes the Edge Addition Planarity Suite command-line tool, either in
 interactive mode or in batch mode.
@@ -67,12 +69,20 @@ Run the \fICOMMAND\fR (see below) on \fIK\fR random graphs with
 Generate a random maximal planar graph with \fIN\fR vertices, then output
 its planar embedding in the primary \fIOUTPUT\fR file and optionally the
 generated graph in the \fICOMPLEMENT\fR file.
+
 .TP
 .B -rn [-q] \fIN\fR \fIOUTPUT\fR [\fICOMPLEMENT\fR]
 Generate a random nonplanar graph (maximal planar plus one edge) with
 \fIN\fR vertices, then output a Kuratowski subgraph of the generated graph
 in the primary \fIOUTPUT\fR file and optionally the gnerated graph in
 the \fICOMPLEMENT\fR file.
+
+.TP
+.B [-q] \fICOMMAND\fR|\fB-t(gam)\fR \fIINPUT\fR \fIOUTPUT\fR
+Run the \fICOMMAND\fR (see below) on graphs in .g6 encoded \fIINPUT\fR,
+file then output summary statistics to \fIOUTPUT\fR file or transform
+single graph in \fIINPUT\fR file to .g6 (\fBg\fR), adjacency list (\fBa\fR), or
+adjacency matrix (\fBm\fR) format and output to \fIOUTPUT\fR file.
 
 .SH COMMANDS
 Determine which algorithm implementation to run:


### PR DESCRIPTION
Resolves #33 

For ease of verification, one may use `man -l planarity.1` to view the expected output of the man page.

## Relevant resources
* [`man-pages` - conventions for writing Linux man pages](https://linux.die.net/man/7/man-pages)
* [`man` - macros to format man pages](https://linux.die.net/man/7/man)
* [Utility Argument Syntax](https://pubs.opengroup.org/onlinepubs/9699919799/) - specify use of `|`:
  > Arguments separated by the '|' ( <vertical-line>) bar notation are mutually-exclusive. Conforming applications shall not include the '|' symbol in data submitted to the utility. 
* [How to write a UNIX man page](https://technicalprose.blogspot.com/2011/06/how-to-write-unix-man-page.html) - use `\fB<text>\fR` to write bold text:
  > Alternatively, the macro \fB starts bold face, \fR returns to Roman