### PR TITLE
Issue 34 - Menu-driven activation of graph transformation and algorithm

### DIFF
--- a/c/g6-write-iterator.c
+++ b/c/g6-write-iterator.c
@@ -659,7 +659,6 @@ int _WriteGraphToG6String(graphP pGraph, char **g6OutputStr)
 		return exitCode;
 	}
 
-	// Take ownership of strOrFile->theStr, which may have a new address due to having been realloc'ed
 	(*g6OutputStr) = sf_getTheStr(pG6WriteIterator->g6Output);
 
 	exitCode = endG6WriteIteration(pG6WriteIterator);

--- a/c/planarity.c
+++ b/c/planarity.c
@@ -1,12 +1,12 @@
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2024, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */
 
 #include "planarity.h"
 
-void ProjectTitle()
+char * GetProjectTitle()
 {
 	// This message is the main location of the version number.
 	// The format is major.minor.maintenance.tweak
@@ -19,12 +19,156 @@ void ProjectTitle()
 	// Furthermore, a change of Major, Minor or Maintenance here should cause a change
 	// of Current, Revision and/or Age as documented in configure.ac
 
-    Message("\n=================================================="
-            "\nThe Edge Addition Planarity Suite version 3.0.2.0"
-            "\nCopyright (c) 1997-2022 by John M. Boyer"
-    		"\nContact info: jboyer at acm.org"
-            "\n=================================================="
-            "\n");
+	return "\n=================================================="
+			"\nThe Edge Addition Planarity Suite version 3.0.2.0"
+			"\nCopyright (c) 1997-2024 by John M. Boyer"
+			"\nContact info: jboyer at acm.org"
+			"\n=================================================="
+			"\n";
+}
+
+/****************************************************************************
+ ALGORITHM FLAGS/SPECIFIERS
+****************************************************************************/
+
+char * GetAlgorithmFlags(void)
+{
+	return  "C = command (algorithm implementation to run)\n"
+			"    -p = Planar embedding and Kuratowski subgraph isolation\n"
+			"    -d = Planar graph drawing by visibility representation\n"
+			"    -o = Outerplanar embedding and obstruction isolation\n"
+			"    -2 = Search for subgraph homeomorphic to K_{2,3}\n"
+			"    -3 = Search for subgraph homeomorphic to K_{3,3}\n"
+			"    -4 = Search for subgraph homeomorphic to K_4\n"
+			"\n";
+}
+
+char * GetAlgorithmSpecifiers(void)
+{
+	return  "P. Planar embedding and Kuratowski subgraph isolation\n"
+			"D. Planar graph drawing by visibility representation\n"
+			"O. Outerplanar embedding and obstruction isolation\n"
+			"2. Search for subgraph homeomorphic to K_{2,3}\n"
+			"3. Search for subgraph homeomorphic to K_{3,3}\n"
+			"4. Search for subgraph homeomorphic to K_4\n";
+}
+
+char * GetAlgorithmChoices(void)
+{
+	return "pdo234";
+}
+
+char * GetSupportedOutputFormats(void)
+{
+	return "gam";
+}
+
+/****************************************************************************
+ helpMessage()
+ ****************************************************************************/
+
+int helpMessage(char *param)
+{
+	Message(GetProjectTitle());
+
+	if (param == NULL)
+	{
+		Message(
+			"'planarity': if no command-line, then menu-driven\n"
+			"'planarity (-h|-help)': this message\n"
+			"'planarity (-h|-help) -menu': more help with menu-based command line\n"
+			"'planarity (-i|-info): copyright and license information\n"
+			"'planarity -test [-q] [samples dir]': runs tests (optional quiet mode)\n"
+			"\n"
+		);
+
+		Message(
+			"Common usages\n"
+			"-------------\n"
+			"planarity -s -q -p infile.txt embedding.out [obstruction.out]\n"
+			"Process infile.txt in quiet mode (-q), putting planar embedding in \n"
+			"embedding.out or (optionally) a Kuratowski subgraph in Obstruction.out\n"
+			"Process returns 0=planar, 1=nonplanar, -1=error\n"
+			"\n"
+			"planarity -s -q -d infile.txt embedding.out [drawing.out]\n"
+			"If graph in infile.txt is planar, then put embedding in embedding.out \n"
+			"and (optionally) an ASCII art drawing in drawing.out\n"
+			"Process returns 0=planar, 1=nonplanar, -1=error\n"
+		);
+	}
+
+	else if (strcmp(param, "-i") == 0 || strcmp(param, "-info") == 0)
+	{
+		Message(
+			"The Edge Addition Planarity Suite version 3.0.2.0\n"
+			"Copyright (c) 1997-2022, John M. Boyer\n"
+			"All rights reserved. \n"
+			"See the LICENSE.TXT file for licensing information. \n"
+			"\n"
+			"Includes a reference implementation of the following:\n"
+			"\n"
+			"* John M. Boyer. \"Subgraph Homeomorphism via the Edge Addition Planarity \n"
+			"  Algorithm\".  Journal of Graph Algorithms and Applications, Vol. 16, \n"
+			"  no. 2, pp. 381-410, 2012. http://dx.doi.org/10.7155/jgaa.00268\n"
+			"\n"
+			"* John M. Boyer. \"A New Method for Efficiently Generating Planar Graph\n"
+			"  Visibility Representations\". In P. Eades and P. Healy, editors,\n"
+			"  Proceedings of the 13th International Conference on Graph Drawing 2005,\n"
+			"  Lecture Notes Comput. Sci., Volume 3843, pp. 508-511, Springer-Verlag, 2006.\n"
+			"  http://dx.doi.org/10.1007/11618058_47\n"
+			"\n"
+			"* John M. Boyer and Wendy J. Myrvold. \"On the Cutting Edge: Simplified O(n)\n"
+			"  Planarity by Edge Addition\". Journal of Graph Algorithms and Applications,\n"
+			"  Vol. 8, No. 3, pp. 241-273, 2004. http://dx.doi.org/10.7155/jgaa.00091\n"
+			"\n"
+			"* John M. Boyer. \"Simplified O(n) Algorithms for Planar Graph Embedding,\n"
+			"  Kuratowski Subgraph Isolation, and Related Problems\". Ph.D. Dissertation,\n"
+			"  University of Victoria, 2001. https://dspace.library.uvic.ca/handle/1828/9918\n"
+			"\n"
+		);
+	}
+
+	else if (strcmp(param, "-menu") == 0)
+	{
+		Message(
+			"'planarity -r [-q] C K N': Random graphs\n"
+			"'planarity -s [-q] C I O [O2]': Specific graph\n"
+			"'planarity -rm [-q] N O [O2]': Random maximal planar graph\n"
+			"'planarity -rn [-q] N O [O2]': Random nonplanar graph (maximal planar + edge)\n"
+			"'planarity -t [-q] C|-t(gam) I O': Test algorithm on graphs or transform graph\n"
+			"'planarity I O [-n O2]': Legacy command-line (default -s -p)\n"
+			"\n"
+		);
+
+		Message("-q is for quiet mode (no messages to stdout and stderr)\n\n");
+
+		Message(GetAlgorithmFlags());
+
+		Message(
+			"K = # of graphs to randomly generate\n"
+			"N = # of vertices in each randomly generated graph\n"
+			"I = Input file (for work on a specific graph)\n"
+			"O = Primary output file\n"
+			"    For example, if C=-p then O receives the planar embedding\n"
+			"    If C=-3, then O receives a subgraph containing a K_{3,3}\n"
+			"O2= Secondary output file\n"
+			"    For -s, if C=-p or -o, then O2 receives the embedding obstruction\n"
+		   	"    For -s, if C=-d, then O2 receives a drawing of the planar graph\n"
+			"    For -rm and -rn, O2 contains the original randomly generated graph\n"
+			"\n"
+		);
+
+		Message(
+			"planarity process results: 0=OK, -1=NOTOK, 1=NONEMBEDDABLE\n"
+			"    1 result only produced by specific graph mode (-s)\n"
+			"      with command -2,-3,-4: found K_{2,3}, K_{3,3} or K_4\n"
+			"      with command -p,-d: found planarity obstruction\n"
+			"      with command -o: found outerplanarity obstruction\n"
+		);
+	}
+
+	FlushConsole(stdout);
+	return OK;
 }
 
 /****************************************************************************
@@ -51,192 +195,231 @@ int main(int argc, char *argv[])
 }
 
 /****************************************************************************
- helpMessage()
- ****************************************************************************/
-
-int helpMessage(char *param)
-{
-	char *commandStr =
-    	"C = command (algorithm implementation to run)\n"
-    	"    -p = Planar embedding and Kuratowski subgraph isolation\n"
-        "    -d = Planar graph drawing by visibility representation\n"
-        "    -o = Outerplanar embedding and obstruction isolation\n"
-        "    -2 = Search for subgraph homeomorphic to K_{2,3}\n"
-        "    -3 = Search for subgraph homeomorphic to K_{3,3}\n"
-        "    -4 = Search for subgraph homeomorphic to K_4\n"
-    	"\n";
-
-	ProjectTitle();
-
-	if (param == NULL)
-	{
-	    Message(
-            "'planarity': if no command-line, then menu-driven\n"
-            "'planarity (-h|-help)': this message\n"
-            "'planarity (-h|-help) -menu': more help with menu-based command line\n"
-	        "'planarity (-i|-info): copyright and license information\n"
-    	    "'planarity -test [-q] [samples dir]': runs tests (optional quiet mode)\n"
-	    	"\n"
-	    );
-
-	    Message(
-	    	"Common usages\n"
-	    	"-------------\n"
-            "planarity -s -q -p infile.txt embedding.out [obstruction.out]\n"
-	    	"Process infile.txt in quiet mode (-q), putting planar embedding in \n"
-	    	"embedding.out or (optionally) a Kuratowski subgraph in Obstruction.out\n"
-	    	"Process returns 0=planar, 1=nonplanar, -1=error\n"
-	    	"\n"
-            "planarity -s -q -d infile.txt embedding.out [drawing.out]\n"
-            "If graph in infile.txt is planar, then put embedding in embedding.out \n"
-            "and (optionally) an ASCII art drawing in drawing.out\n"
-            "Process returns 0=planar, 1=nonplanar, -1=error\n"
-	    );
-	}
-
-	else if (strcmp(param, "-i") == 0 || strcmp(param, "-info") == 0)
-	{
-	    Message(
-		    "The Edge Addition Planarity Suite version 3.0.2.0\n"
-	    	"Copyright (c) 1997-2022, John M. Boyer\n"
-		    "All rights reserved. \n"
-	    	"See the LICENSE.TXT file for licensing information. \n"
-            "\n"
-	    	"Includes a reference implementation of the following:\n"
-            "\n"
-	    	"* John M. Boyer. \"Subgraph Homeomorphism via the Edge Addition Planarity \n"
-	    	"  Algorithm\".  Journal of Graph Algorithms and Applications, Vol. 16, \n"
-	    	"  no. 2, pp. 381-410, 2012. http://dx.doi.org/10.7155/jgaa.00268\n"
-            "\n"
-		    "* John M. Boyer. \"A New Method for Efficiently Generating Planar Graph\n"
-		    "  Visibility Representations\". In P. Eades and P. Healy, editors,\n"
-		    "  Proceedings of the 13th International Conference on Graph Drawing 2005,\n"
-		    "  Lecture Notes Comput. Sci., Volume 3843, pp. 508-511, Springer-Verlag, 2006.\n"
-	    	"  http://dx.doi.org/10.1007/11618058_47\n"
-            "\n"
-		    "* John M. Boyer and Wendy J. Myrvold. \"On the Cutting Edge: Simplified O(n)\n"
-		    "  Planarity by Edge Addition\". Journal of Graph Algorithms and Applications,\n"
-		    "  Vol. 8, No. 3, pp. 241-273, 2004. http://dx.doi.org/10.7155/jgaa.00091\n"
-            "\n"
-		    "* John M. Boyer. \"Simplified O(n) Algorithms for Planar Graph Embedding,\n"
-		    "  Kuratowski Subgraph Isolation, and Related Problems\". Ph.D. Dissertation,\n"
-		    "  University of Victoria, 2001. https://dspace.library.uvic.ca/handle/1828/9918\n"
-            "\n"
-	    );
-	}
-
-	else if (strcmp(param, "-menu") == 0)
-	{
-	    Message(
-	    	"'planarity -r [-q] C K N': Random graphs\n"
-	    	"'planarity -s [-q] C I O [O2]': Specific graph\n"
-	        "'planarity -rm [-q] N O [O2]': Random maximal planar graph\n"
-	        "'planarity -rn [-q] N O [O2]': Random nonplanar graph (maximal planar + edge)\n"
-			"'planarity -t [-q] C|-t(gam) I O': Test algorithm on graphs or transform graph\n"
-	        "'planarity I O [-n O2]': Legacy command-line (default -s -p)\n"
-	    	"\n"
-	    );
-
-	    Message("-q is for quiet mode (no messages to stdout and stderr)\n\n");
-
-	    Message(commandStr);
-
-	    Message(
-	    	"K = # of graphs to randomly generate\n"
-	    	"N = # of vertices in each randomly generated graph\n"
-	        "I = Input file (for work on a specific graph)\n"
-	        "O = Primary output file\n"
-	        "    For example, if C=-p then O receives the planar embedding\n"
-	    	"    If C=-3, then O receives a subgraph containing a K_{3,3}\n"
-	        "O2= Secondary output file\n"
-	    	"    For -s, if C=-p or -o, then O2 receives the embedding obstruction\n"
-	       	"    For -s, if C=-d, then O2 receives a drawing of the planar graph\n"
-	    	"    For -rm and -rn, O2 contains the original randomly generated graph\n"
-	    	"\n"
-	    );
-
-	    Message(
-	        "planarity process results: 0=OK, -1=NOTOK, 1=NONEMBEDDABLE\n"
-	    	"    1 result only produced by specific graph mode (-s)\n"
-	        "      with command -2,-3,-4: found K_{2,3}, K_{3,3} or K_4\n"
-	    	"      with command -p,-d: found planarity obstruction\n"
-	    	"      with command -o: found outerplanarity obstruction\n"
-	    );
-	}
-
-    FlushConsole(stdout);
-    return OK;
-}
-
-/****************************************************************************
  MENU-DRIVEN PROGRAM
  ****************************************************************************/
+void TransformOrTestMenu(void);
+void TransformMenu(void);
+void TestMenu(void);
 
 int menu()
 {
 char Choice;
 
-     do {
-    	ProjectTitle();
+	 do {
+		Message(GetProjectTitle());
 
-        Message("\n"
-                "P. Planar embedding and Kuratowski subgraph isolation\n"
-                "D. Planar graph drawing by visibility representation\n"
-                "O. Outerplanar embedding and obstruction isolation\n"
-                "2. Search for subgraph homeomorphic to K_{2,3}\n"
-                "3. Search for subgraph homeomorphic to K_{3,3}\n"
-                "4. Search for subgraph homeomorphic to K_4\n"
-        		"H. Help message for command line version\n"
-                "R. Reconfigure options\n"
-                "X. Exit\n"
-        		"\n"
-        );
+		Message("\n");
 
-        Prompt("Enter Choice: ");
-        fflush(stdin);
-        scanf(" %c", &Choice);
-        Choice = tolower(Choice);
+		Message(GetAlgorithmSpecifiers());
 
-        if (Choice == 'h')
-        	helpMessage(NULL);
+		Message(
+				"T. Test graph functionality\n"
+				"H. Help message for command line version\n"
+				"R. Reconfigure options\n"
+				"X. Exit\n"
+				"\n"
+		);
 
-        else if (Choice == 'r')
-        	Reconfigure();
+		Prompt("Enter Choice: ");
+		fflush(stdin);
+		scanf(" %c", &Choice);
+		Choice = tolower(Choice);
 
-        else if (Choice != 'x')
-        {
-        	char *secondOutfile = NULL;
-        	if (Choice == 'p'  || Choice == 'd' || Choice == 'o')
-        		secondOutfile ="";
+		if (Choice == 'h')
+			helpMessage(NULL);
 
-            if (!strchr("pdo234", Choice)) {
-            	Message("Invalid menu choice, please try again.");
-            } else {
-            	switch (tolower(Mode))
-                {
-                    case 's' : SpecificGraph(Choice, NULL, NULL, secondOutfile, NULL, NULL, NULL); break;
-                    case 'r' : RandomGraphs(Choice, 0, 0); break;
-                    case 'm' : RandomGraph(Choice, 0, 0, NULL, NULL); break;
-                    case 'n' : RandomGraph(Choice, 1, 0, NULL, NULL); break;
-                }
-            }
-        }
+		else if (Choice == 'r')
+			Reconfigure();
 
-        if (Choice != 'r' && Choice != 'x')
-        {
-            Prompt("\nPress a key then hit ENTER to continue...");
-            fflush(stdin);
-            scanf(" %*c");
-            fflush(stdin);
-            Message("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
-            FlushConsole(stdout);
-        }
+		else if (Choice == 't')
+			TransformOrTestMenu();
 
-     }  while (Choice != 'x');
+		else if (Choice != 'x')
+		{
+			char *secondOutfile = NULL;
+			if (Choice == 'p'  || Choice == 'd' || Choice == 'o')
+				secondOutfile ="";
 
-     // Certain debuggers don't terminate correctly with pending output content
-     FlushConsole(stdout);
-     FlushConsole(stderr);
+			if (!strchr(GetAlgorithmChoices(), Choice)) {
+				Message("Invalid menu choice, please try again.");
+			} else {
+				switch (tolower(Mode))
+				{
+					case 's' : SpecificGraph(Choice, NULL, NULL, secondOutfile, NULL, NULL, NULL); break;
+					case 'r' : RandomGraphs(Choice, 0, 0); break;
+					case 'm' : RandomGraph(Choice, 0, 0, NULL, NULL); break;
+					case 'n' : RandomGraph(Choice, 1, 0, NULL, NULL); break;
+				}
+			}
+		}
 
-     return 0;
+		if (Choice != 'r' && Choice != 'x')
+		{
+			Prompt("\nPress a key then hit ENTER to continue...");
+			fflush(stdin);
+			scanf(" %*c");
+			fflush(stdin);
+			Message("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
+			FlushConsole(stdout);
+		}
+
+	 }  while (Choice != 'x');
+
+	 // Certain debuggers don't terminate correctly with pending output content
+	 FlushConsole(stdout);
+	 FlushConsole(stderr);
+
+	 return 0;
+}
+
+void TransformOrTestMenu()
+{
+	char Choice;
+	char *messageFormat;
+	char messageContents[MAXLINE + 1];
+
+	do
+	{
+		Message("\n");
+		Message("T. Transform single graph in supported file to .g6, adjacency list, or adjacency matrix\n");
+		Message("A. Perform an algorithm test on all graphs in .g6 input file\n");
+		Message("B. Back out to main menu\n");
+		Message("\n");
+
+		Prompt("Enter Choice: ");
+		fflush(stdin);
+		scanf(" %c", &Choice);
+		Choice = tolower(Choice);
+
+		switch(Choice)
+		{
+			case 't':TransformMenu(); return;
+			case 'a': TestMenu(); return;
+			case 'b': Message("Returning to main menu.\n"); break;
+			default: {
+				messageFormat = "Unrecognized choice: \"%c\"";
+				sprintf(messageContents, messageFormat, Choice);
+				ErrorMessage(messageContents);
+			}
+		}
+	} while (Choice != 'b');
+}
+
+void TransformMenu()
+{
+	int Result = OK;
+
+	char infileName[MAXLINE + 1];
+	infileName[0] = '\0';
+	char outfileName[MAXLINE + 1];
+	outfileName[0] = '\0';
+	char *outputStr = NULL;
+	char outputFormat = '\0';
+	char commandStr[4];
+	commandStr[0] = '\0';
+
+	do
+	{
+		Prompt("Enter input filename:\n");
+		fflush(stdin);
+		fgets(infileName, MAXLINE, stdin);
+	}
+	while(strlen(infileName) == 0);
+
+	infileName[strcspn(infileName, "\n\r")] = '\0';
+	
+	Prompt("Enter output filename, or press return to output to console:\n");
+	fflush(stdin);
+	fgets(outfileName, MAXLINE, stdin);
+	outfileName[strcspn(outfileName, "\n\r")] = '\0';
+
+	do
+	{
+		Prompt("Enter output format: ");
+		fflush(stdin);
+		scanf(" %c", &outputFormat);
+		if (strchr(GetSupportedOutputFormats(), outputFormat))
+			sprintf(commandStr, "-t%c", outputFormat);
+	}
+	while(strlen(commandStr) == 0);
+
+	if (strlen(outfileName) == 0)
+	{
+		Result = TestGraphFunctionality(commandStr, infileName, NULL, NULL, NULL, &outputStr);
+		if (Result != OK || outputStr == NULL)
+			ErrorMessage("Failed to perform transformation.\n");
+		else
+		{
+			Message("Output:\n");
+			Message(outputStr);
+			Message("\n");
+		}
+	}
+	else
+	{
+		Result = TestGraphFunctionality(commandStr, infileName, NULL, NULL, outfileName, NULL);
+		if (Result != OK)
+			ErrorMessage("Failed to perform transformation.\n");
+	}
+}
+
+void TestMenu()
+{
+	int Result = OK;
+
+	char infileName[MAXLINE + 1];
+	infileName[0] = '\0';
+	char outfileName[MAXLINE + 1];
+	outfileName[0] = '\0';
+	char *outputStr = NULL;
+	char algorithmSpecifier = '\0';
+	char commandStr[3];
+	commandStr[0] = '\0';
+
+	do
+	{
+		Prompt("Enter input filename:\n");
+		fflush(stdin);
+		fgets(infileName, MAXLINE, stdin);
+	}
+	while(strlen(infileName) == 0);
+	
+	infileName[strcspn(infileName, "\n\r")] = '\0';
+
+	Prompt("Enter output filename, or press return to output to console:\n");
+	fflush(stdin);
+	fgets(outfileName, MAXLINE, stdin);
+	outfileName[strcspn(outfileName, "\n\r")] = '\0';
+
+	do
+	{
+		Message(GetAlgorithmSpecifiers());
+
+		Prompt("Enter algorithm specifier: ");
+		fflush(stdin);
+		scanf(" %c", &algorithmSpecifier);
+		algorithmSpecifier = tolower(algorithmSpecifier);
+		if (strchr(GetAlgorithmChoices(), algorithmSpecifier))
+			sprintf(commandStr, "-%c", algorithmSpecifier);
+	}
+	while(strlen(commandStr) == 0);
+
+	if (strlen(outfileName) == 0)
+	{
+		Result = TestGraphFunctionality(commandStr, infileName, NULL, NULL, NULL, &outputStr);
+		if (Result != OK || outputStr == NULL)
+			ErrorMessage("Algorithm test on all graphs in .g6 input file failed.\n");
+		else
+		{
+			Message("Output:\n");
+			Message(outputStr);
+			Message("\n");
+		}
+	}
+	else
+	{
+		Result = TestGraphFunctionality(commandStr, infileName, NULL, NULL, outfileName, NULL);
+		if (Result != OK)
+			ErrorMessage("Algorithm test on all graphs in .g6 input file failed.\n");
+	}
 }

--- a/c/planarity.c
+++ b/c/planarity.c
@@ -19,12 +19,13 @@ char * GetProjectTitle()
 	// Furthermore, a change of Major, Minor or Maintenance here should cause a change
 	// of Current, Revision and/or Age as documented in configure.ac
 
-	return "\n=================================================="
+	return  "\n=================================================="
 			"\nThe Edge Addition Planarity Suite version 3.0.2.0"
 			"\nCopyright (c) 1997-2024 by John M. Boyer"
+			"\nAll rights reserved."
+			"\nSee the LICENSE.TXT file for licensing information."
 			"\nContact info: jboyer at acm.org"
-			"\n=================================================="
-			"\n";
+			"\n==================================================\n";
 }
 
 /****************************************************************************
@@ -100,11 +101,6 @@ int helpMessage(char *param)
 	else if (strcmp(param, "-i") == 0 || strcmp(param, "-info") == 0)
 	{
 		Message(
-			"The Edge Addition Planarity Suite version 3.0.2.0\n"
-			"Copyright (c) 1997-2022, John M. Boyer\n"
-			"All rights reserved. \n"
-			"See the LICENSE.TXT file for licensing information. \n"
-			"\n"
 			"Includes a reference implementation of the following:\n"
 			"\n"
 			"* John M. Boyer. \"Subgraph Homeomorphism via the Edge Addition Planarity \n"
@@ -208,8 +204,6 @@ char Choice;
 	 do {
 		Message(GetProjectTitle());
 
-		Message("\n");
-
 		Message(GetAlgorithmSpecifiers());
 
 		Message(
@@ -278,31 +272,22 @@ void TransformOrTestMenu()
 	char *messageFormat;
 	char messageContents[MAXLINE + 1];
 
-	do
+	Message("\n");
+	Message("T. Transform single graph in supported file to .g6, adjacency list, or adjacency matrix\n");
+	Message("A. Perform an algorithm test on all graphs in .g6 input file\n");
+	Message("\nPress any other key to return to the main menu.\n");
+	Message("\n");
+
+	Prompt("Enter Choice: ");
+	fflush(stdin);
+	scanf(" %c", &Choice);
+	Choice = tolower(Choice);
+
+	switch(Choice)
 	{
-		Message("\n");
-		Message("T. Transform single graph in supported file to .g6, adjacency list, or adjacency matrix\n");
-		Message("A. Perform an algorithm test on all graphs in .g6 input file\n");
-		Message("B. Back out to main menu\n");
-		Message("\n");
-
-		Prompt("Enter Choice: ");
-		fflush(stdin);
-		scanf(" %c", &Choice);
-		Choice = tolower(Choice);
-
-		switch(Choice)
-		{
-			case 't':TransformMenu(); return;
-			case 'a': TestMenu(); return;
-			case 'b': Message("Returning to main menu.\n"); break;
-			default: {
-				messageFormat = "Unrecognized choice: \"%c\"";
-				sprintf(messageContents, messageFormat, Choice);
-				ErrorMessage(messageContents);
-			}
-		}
-	} while (Choice != 'b');
+		case 't':TransformMenu(); return;
+		case 'a': TestMenu(); return;
+	}
 }
 
 void TransformMenu()

--- a/c/planarity.h
+++ b/c/planarity.h
@@ -23,7 +23,12 @@ extern "C" {
 #include "graphK4Search.h"
 #include "graphDrawPlanar.h"
 
-void ProjectTitle();
+char * GetProjectTitle(void);
+char * GetAlgorithmFlags(void);
+char * GetAlgorithmSpecifiers(void);
+char * GetAlgorithmChoices(void);
+char * GetSupportedOutputFormats(void);
+
 int helpMessage(char *param);
 
 /* Functions that call the Graph Library */
@@ -37,9 +42,9 @@ int RandomGraphs(char command, int NumGraphs, int SizeOfGraphs);
 int TestGraphFunctionality(char *commandString, char *infileName, char *inputStr, int *outputBase, char *outfileName, char **outputStr);
 
 /* Command line, Menu, and Configuration */
+int menu();
 int commandLine(int argc, char *argv[]);
 int legacyCommandLine(int argc, char *argv[]);
-int menu();
 
 extern char Mode,
      OrigOut,

--- a/c/planarityRandomGraphs.c
+++ b/c/planarityRandomGraphs.c
@@ -89,7 +89,7 @@ int writeErrorReported_Random=FALSE, writeErrorReported_Embedded=FALSE,
 
               gp_CopyGraph(origGraph, theGraph);
 
-              if (strchr("pdo234", command))
+              if (strchr(GetAlgorithmChoices(), command))
               {
                   Result = gp_Embed(theGraph, embedFlags);
 
@@ -394,7 +394,7 @@ char saveEdgeListFormat;
      Message("Now processing\n");
      FlushConsole(stdout);
 
-     if (strchr("pdo234", command))
+     if (strchr(GetAlgorithmChoices(), command))
      {
          platform_GetTime(start);
          Result = gp_Embed(theGraph, embedFlags);

--- a/c/planaritySpecificGraph.c
+++ b/c/planaritySpecificGraph.c
@@ -72,7 +72,7 @@ int Result = OK;
 	{
 		Message("The graph contains too many edges.\n");
 		// Some of the algorithms will still run correctly with some edges removed.
-		if (strchr("pdo234", command))
+		if (strchr(GetAlgorithmChoices(), command))
 		{
 			Message("Some edges were removed, but the algorithm will still run correctly.\n");
 			Result = OK;
@@ -91,7 +91,7 @@ int Result = OK;
         origGraph = gp_DupGraph(theGraph);
 
         // Run the algorithm
-        if (strchr("pdo234", command))
+        if (strchr(GetAlgorithmChoices(), command))
         {
     		int embedFlags = GetEmbedFlags(command);
 	        platform_GetTime(start);
@@ -131,7 +131,7 @@ int Result = OK;
 	else
 	{
         // Restore the vertex ordering of the original graph (undo DFS numbering)
-        if (strchr("pdo234", command))
+        if (strchr(GetAlgorithmChoices(), command))
             gp_SortVertices(theGraph);
 
         // Determine the name of the primary output file

--- a/c/planarityTestGraphFunctionality.c
+++ b/c/planarityTestGraphFunctionality.c
@@ -166,9 +166,9 @@ int TestGraphFunctionality(char *commandString, char *infileName, char *inputStr
 						inputStr = NULL;
 					}
 					
-					// Take ownership of strOrFile->theStr, which may have a new address due to having been realloc'ed
 					if (outputStr != NULL)
 						(*outputStr) = sf_getTheStr(testOutput);
+					
 					sf_Free(&testOutput);
 				}
 			}

--- a/c/planarityTestGraphFunctionality.c
+++ b/c/planarityTestGraphFunctionality.c
@@ -79,7 +79,7 @@ int TestGraphFunctionality(char *commandString, char *infileName, char *inputStr
 			}
 	
 		}
-		else if (strchr("pdo234", commandString[1]))
+		else if (strchr(GetAlgorithmChoices(), commandString[1]))
 		{
 			if (inputStr != NULL)
 			{
@@ -165,7 +165,10 @@ int TestGraphFunctionality(char *commandString, char *infileName, char *inputStr
 						free(inputStr);
 						inputStr = NULL;
 					}
-
+					
+					// Take ownership of strOrFile->theStr, which may have a new address due to having been realloc'ed
+					if (outputStr != NULL)
+						(*outputStr) = sf_getTheStr(testOutput);
 					sf_Free(&testOutput);
 				}
 			}


### PR DESCRIPTION
Resolves #34

Confirmed both menu-driven transform and graph test flows work as their command-line flag-driven counterparts.

Fixed bug where `outputStr` didn't take ownership of string from the `testOutput` `strOrFile` after we `testAllGraphs`.