### PR TITLE
Issue 64 and Issue 67 - `EnsureArcCapacity()` before attaching `-(d34)` algorithm extensions in `SpecificGraph()` and `testAllGraphs()`

### DIFF
--- a/TestSupport/generate_graphs.bat
+++ b/TestSupport/generate_graphs.bat
@@ -15,6 +15,6 @@ SET /A MAXM = (%N% * (%N% - 1^)) / 2
 IF NOT EXIST "%graphOutputDir%\%N%" mkdir "%graphOutputDir%\%N%"
 
 REM Make sure to update the path to the geng executable and the directory to which you wish to write the generated graphs
-FOR /L %%M IN (1,1,%MAXM%) DO (
+FOR /L %%M IN (0,1,%MAXM%) DO (
 	START /B "geng%%M" %gengPath% %N% %%M:%%M > "%graphOutputDir%\%N%\test.n%N%.m%%M.g6"
 )

--- a/TestSupport/planarity_runner.bat
+++ b/TestSupport/planarity_runner.bat
@@ -22,6 +22,6 @@ IF NOT EXIST "%outputDir%\%N%\%C%" mkdir "%outputDir%\%N%\%C%"
 
 SET /A MAXM = (%N% * (%N% - 1^)) / 2
 
-FOR /L %%M IN (1,1,%MAXM%) DO (
+FOR /L %%M IN (0,1,%MAXM%) DO (
 	CALL %planarityPath% -t -%C% "%graphFilesDir%\%N%\test.n%N%.m%%M.g6" "%outputDir%\%N%\%C%\n%N%.m%%M.%C%.out.txt"
 )

--- a/TestSupport/testTableGenerator.py
+++ b/TestSupport/testTableGenerator.py
@@ -27,14 +27,16 @@ class TestTableGenerator():
     
     def getOrderAndCommandFromInputDir(self):
         parts = self.input_dir.parts
-        order = int(parts[-2])
+        try:
+            order = int(parts[-2])
+        except ValueError:
+            order = None
+
         command = parts[-1]
         # You may reference class attributes either by the name of the class,
         # seen here, or by using "self"
         if command not in TestTableGenerator.__planarity_commands:
             command = None
-        if (not isinstance(order, int) or (order < 2) or (order > 100000)):
-            order = None
 
         self.order = order
         self.max_num_edges = ((order * (order - 1)) / 2) if order else None

--- a/c/planaritySpecificGraph.c
+++ b/c/planaritySpecificGraph.c
@@ -50,14 +50,6 @@ int Result = OK;
     // Create the graph and, if needed, attach the correct algorithm to it
     theGraph = gp_New();
 
-	switch (command)
-	{
-		case 'd' : gp_AttachDrawPlanar(theGraph); break;
-		case '2' : gp_AttachK23Search(theGraph); break;
-		case '3' : gp_AttachK33Search(theGraph); break;
-		case '4' : gp_AttachK4Search(theGraph); break;
-	}
-
     // Read the graph into memory
 	if (inputStr == NULL)
 	{
@@ -66,17 +58,6 @@ int Result = OK;
 	else
 	{
 		Result = gp_ReadFromString(theGraph, inputStr);
-	}
-
-	if (Result == NONEMBEDDABLE)
-	{
-		Message("The graph contains too many edges.\n");
-		// Some of the algorithms will still run correctly with some edges removed.
-		if (strchr(GetAlgorithmChoices(), command))
-		{
-			Message("Some edges were removed, but the algorithm will still run correctly.\n");
-			Result = OK;
-		}
 	}
 
 	// If there was an unrecoverable error, report it
@@ -88,11 +69,19 @@ int Result = OK;
 	else
 	{
 		// Copy the graph for integrity checking
-        origGraph = gp_DupGraph(theGraph);
+		origGraph = gp_DupGraph(theGraph);
 
         // Run the algorithm
         if (strchr(GetAlgorithmChoices(), command))
         {
+			switch (command)
+			{
+				case 'd' : gp_AttachDrawPlanar(theGraph); break;
+				case '2' : gp_AttachK23Search(theGraph); break;
+				case '3' : gp_AttachK33Search(theGraph); break;
+				case '4' : gp_AttachK4Search(theGraph); break;
+			}
+
     		int embedFlags = GetEmbedFlags(command);
 	        platform_GetTime(start);
 
@@ -114,8 +103,8 @@ int Result = OK;
 
         // Write what the algorithm determined and how long it took
         WriteAlgorithmResults(theGraph, Result, command, start, end, infileName);
-
-        // Free the graph obtained for integrity checking.
+		
+		// Free the graph obtained for integrity checking.
         gp_Free(&origGraph);
 	}
 


### PR DESCRIPTION
Resolves #64 and #67 

## Updated
* `c/planaritySpecificGraph.c` - In `SpecificGraph()` we attach algorithm *after* reading the single graph in first so that we don't try to `EnsureArcCapacity()` (see issue descriptions for investigation and reasoning)
* `c/planarityTestGraphFunctionality.c` - In `testAllGraphs()`, if we are running with command `-(d34)`, we set the arc capacity to `(N * (N - 1))` up front so we will never try to increase the arc capacity after attaching those algorithm extensions.
* `TestSupport/` - updated `generate_graphs.bat` and `planarity_runner.bat` so that they generate files for `M = 0` and added error handling in `testTableGenerator.py` in case the `input_dir` isn't of the form `<root dir>\N\C` (i.e. we'll fail over to getting graph order and command run when we `_validateInfileName()`)