### PR TITLE
Adding `planarity_leaks_config.ini` default config file to source control

### DIFF
--- a/TestSupport/planaritytesting/leaksorchestrator/planarity_leaks_config.ini
+++ b/TestSupport/planaritytesting/leaksorchestrator/planarity_leaks_config.ini
@@ -1,0 +1,35 @@
+[RandomGraphs]
+enabled = False
+perform_full_analysis = True
+num_graphs = 500
+order = 1000
+commands_to_run = 
+
+[RandomMaxPlanarGraphGenerator]
+enabled = False
+perform_full_analysis = True
+order = 1000
+
+[SpecificGraph]
+enabled = False
+perform_full_analysis = True
+infile_path = >>CHANGEME<<
+commands_to_run = 
+
+[RandomNonplanarGraphGenerator]
+enabled = False
+perform_full_analysis = True
+order = 1000
+
+[TransformGraph]
+enabled = False
+perform_full_analysis = True
+infile_path = >>CHANGEME<<
+output_formats_to_test = 
+
+[TestAllGraphs]
+enabled = False
+perform_full_analysis = True
+infile_path = >>CHANGEME<<
+commands_to_run = 
+


### PR DESCRIPTION
Follow-up to #59

Adding `planarity_leaks_config.ini` default config file to source control so that users will not have to run `planarity_leaks_config_manager.py` locally to generate it before updating the default values with the parameters necessary for their run.