### PR TITLE
Issue #94 - Separate Transform Graph and Test All Graphs functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,7 +83,7 @@ planarity-*
 planarity-*/*
 
 # Ignoring configuration for VSCode
-**/.vscode/
+# **/.vscode/
 
 ## MacOS excludes
 .DS_Store

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,9 +24,9 @@
             "request": "launch",
             "program": "${workspaceFolder}\\Debug\\planarity.exe",
             "args": [
-                // Command: `planarity -t [-q] -ta I O`
-                // "-t",
-                // "-ta",
+                // Command: `planarity -x [-q] -a I O`
+                // "-x",
+                // "-a",
                 // "${workspaceFolder}\\c\\samples\\nauty_example.g6",
                 // "${workspaceFolder}\\c\\samples\\nauty_example.g6.AdjList.expected.out.txt"
                 // Command: `planarity -test <samplesDir>`
@@ -59,9 +59,9 @@
             "request": "launch",
             "program": "${workspaceFolder}\\Release\\planarity.exe",
             "args": [
-                // Command: `planarity -t [-q] -ta I O`
-                // "-t",
-                // "-ta",
+                // Command: `planarity -x [-q] -a I O`
+                // "-x",
+                // "-a",
                 // "${workspaceFolder}\\c\\samples\\nauty_example.g6",
                 // "${workspaceFolder}\\c\\samples\\nauty_example.g6.AdjList.expected.out.txt"
                 // Command: `planarity -test <samplesDir>`
@@ -83,9 +83,9 @@
             "request": "launch",
             "program": "${workspaceFolder}/Debug/planarity",
             "args": [
-                // Command: `planarity -t [-q] -ta I O`
-                // "-t",
-                // "-ta",
+                // Command: `planarity -x [-q] -a I O`
+                // "-x",
+                // "-a",
                 // "${workspaceFolder}/c/samples/nauty_example.g6",
                 // "${workspaceFolder}/c/samples/nauty_example.g6.AdjList.expected.out.txt"
                 // Command: `planarity -test <samplesDir>`
@@ -118,9 +118,9 @@
             "request": "launch",
             "program": "${workspaceFolder}/Release/planarity",
             "args": [
-                // Command: `planarity -t [-q] -ta I O`
-                // "-t",
-                // "-ta",
+                // Command: `planarity -x [-q] -a I O`
+                // "-x",
+                // "-a",
                 // "${workspaceFolder}/c/samples/nauty_example.g6",
                 // "${workspaceFolder}/c/samples/nauty_example.g6.AdjList.expected.out.txt"
                 // Command: `planarity -test <samplesDir>`
@@ -142,9 +142,9 @@
             "request": "launch",
             "program": "${workspaceFolder}\\Debug\\planarity.exe",
             "args": [
-                // Command: `planarity -t [-q] -ta I O`
-                // "-t",
-                // "-ta",
+                // Command: `planarity -x [-q] -a I O`
+                // "-x",
+                // "-a",
                 // "${workspaceFolder}\\c\\samples\\nauty_example.g6",
                 // "${workspaceFolder}\\c\\samples\\nauty_example.g6.AdjList.expected.out.txt"
                 // Command: `planarity -test <samplesDir>`
@@ -164,9 +164,9 @@
             "request": "launch",
             "program": "${workspaceFolder}\\Release\\planarity.exe",
             "args": [
-                // Command: `planarity -t [-q] -ta I O`
-                // "-t",
-                // "-ta",
+                // Command: `planarity -x [-q] -a I O`
+                // "-x",
+                // "-a",
                 // "${workspaceFolder}\\c\\samples\\nauty_example.g6",
                 // "${workspaceFolder}\\c\\samples\\nauty_example.g6.AdjList.expected.out.txt"
                 // Command: `planarity -test <samplesDir>`
@@ -186,9 +186,9 @@
             "request": "launch",
             "program": "${workspaceFolder}/Debug/planarity",
             "args": [
-                // Command: `planarity -t [-q] -ta I O`
-                // "-t",
-                // "-ta",
+                // Command: `planarity -x [-q] -a I O`
+                // "-x",
+                // "-a",
                 // "${workspaceFolder}/c/samples/nauty_example.g6",
                 // "${workspaceFolder}/c/samples/nauty_example.g6.AdjList.expected.out.txt"
                 // Command: `planarity -test <samplesDir>`
@@ -208,9 +208,9 @@
             "request": "launch",
             "program": "${workspaceFolder}/Release/planarity",
             "args": [
-                // Command: `planarity -t [-q] -ta I O`
-                // "-t",
-                // "-ta",
+                // Command: `planarity -x [-q] -a I O`
+                // "-x",
+                // "-a",
                 // "${workspaceFolder}/c/samples/nauty_example.g6",
                 // "${workspaceFolder}/c/samples/nauty_example.g6.AdjList.expected.out.txt"
                 // Command: `planarity -test <samplesDir>`

--- a/Makefile.am
+++ b/Makefile.am
@@ -67,7 +67,8 @@ planarity_SOURCES = \
 	c/planarityApp/planarityMenu.c \
 	c/planarityApp/planarityRandomGraphs.c \
 	c/planarityApp/planaritySpecificGraph.c \
-	c/planarityApp/planarityTestGraphFunctionality.c \
+	c/planarityApp/planarityTransformGraph.c \
+	c/planarityApp/planarityTestAllGraphs.c \
 	c/planarityApp/planarityUtils.c
 
 man1_MANS = c/planarityApp/planarity.1

--- a/c/planarityApp/planarity.1
+++ b/c/planarityApp/planarity.1
@@ -23,7 +23,9 @@ planarity - The Edge Addition Planarity Suite
 
 .B planarity -rn [-q] \fIN\fR \fIOUTPUT\fR [\fICOMPLEMENT\fR]
 
-.B planarity -t [-q] \fICOMMAND\fR|\fB-t(gam)\fR \fIINPUT\fR \fIOUTPUT\fR
+.B planarity -x [-q] \fB-(gam)\fR \fIINPUT\fR \fIOUTPUT\fR
+
+.B planarity -t [-q] \fICOMMAND\fR \fIINPUT\fR \fIOUTPUT\fR
 
 .SH DESCRIPTION
 Invokes the Edge Addition Planarity Suite command-line tool, either in
@@ -78,12 +80,15 @@ in the primary \fIOUTPUT\fR file and optionally the gnerated graph in
 the \fICOMPLEMENT\fR file.
 
 .TP
-.B [-q] \fICOMMAND\fR|\fB-t(gam)\fR \fIINPUT\fR \fIOUTPUT\fR
-Run the \fICOMMAND\fR (see below) on graphs in .g6 encoded \fIINPUT\fR,
-file then output summary statistics to \fIOUTPUT\fR file or transform
-single graph in \fIINPUT\fR file (any supported format) to .g6 (\fBg\fR),
+.B [-q] \fB-(gam)\fR \fIINPUT\fR \fIOUTPUT\fR
+Transform single graph in \fIINPUT\fR file (any supported format) to .g6 (\fBg\fR),
 adjacency list (\fBa\fR), or adjacency matrix (\fBm\fR) format and output
 to \fIOUTPUT\fR file.
+
+.TP
+.B [-q] \fICOMMAND\fR \fIINPUT\fR \fIOUTPUT\fR
+Run the \fICOMMAND\fR (see below) on graphs in .g6 encoded \fIINPUT\fR
+file, then output summary statistics to \fIOUTPUT\fR file.
 
 .SH COMMANDS
 Determine which algorithm implementation to run:

--- a/c/planarityApp/planarity.h
+++ b/c/planarityApp/planarity.h
@@ -30,7 +30,8 @@ extern "C"
         char *inputStr, char **pOutputStr, char **pOutput2Str);
     int RandomGraph(char command, int extraEdges, int numVertices, char *outfileName, char *outfile2Name);
     int RandomGraphs(char command, int NumGraphs, int SizeOfGraphs);
-    int TestGraphFunctionality(char *commandString, char *infileName, char *inputStr, int *outputBase, char *outfileName, char **outputStr);
+    int TransformGraph(char *commandString, char *infileName, char *inputStr, int *outputBase, char *outfileName, char **outputStr);
+    int TestAllGraphs(char *commandString, char *infileName, int *outputBase, char *outfileName, char **outputStr);
 
     /* Command line, Menu, and Configuration */
     int menu();

--- a/c/planarityApp/planarityCommandLine.c
+++ b/c/planarityApp/planarityCommandLine.c
@@ -17,7 +17,8 @@ int callRandomGraphs(int argc, char *argv[]);
 int callSpecificGraph(int argc, char *argv[]);
 int callRandomMaxPlanarGraph(int argc, char *argv[]);
 int callRandomNonplanarGraph(int argc, char *argv[]);
-int callTestGraphFunctionality(int argc, char *argv[]);
+int callTestAllGraphs(int argc, char *argv[]);
+int callTransformGraph(int argc, char *argv[]);
 
 /****************************************************************************
  Command Line Processor
@@ -55,8 +56,11 @@ int commandLine(int argc, char *argv[])
 	else if (strcmp(argv[1], "-rn") == 0)
 		Result = callRandomNonplanarGraph(argc, argv);
 
+	else if (strncmp(argv[1], "-x", 2) == 0)
+		Result = callTransformGraph(argc, argv);
+
 	else if (strncmp(argv[1], "-t", 2) == 0)
-		Result = callTestGraphFunctionality(argc, argv);
+		Result = callTestAllGraphs(argc, argv);
 
 	else
 	{
@@ -87,8 +91,8 @@ int commandLine(int argc, char *argv[])
 
 int legacyCommandLine(int argc, char *argv[])
 {
-graphP theGraph = gp_New();
-int Result;
+	graphP theGraph = gp_New();
+	int Result;
 
 	Result = gp_Read(theGraph, argv[1]);
 	if (Result != OK)
@@ -97,7 +101,7 @@ int Result;
 		{
 			char *messageFormat = "Failed to read graph \"%.*s\"";
 			char messageContents[MAXLINE + 1];
-			int charsAvailForFilename = (int) (MAXLINE - strlen(messageFormat));
+			int charsAvailForFilename = (int)(MAXLINE - strlen(messageFormat));
 			sprintf(messageContents, messageFormat, charsAvailForFilename, argv[1]);
 			ErrorMessage(messageContents);
 			return -2;
@@ -114,7 +118,7 @@ int Result;
 
 	else if (Result == NONEMBEDDABLE)
 	{
-		if (argc >= 5 && strcmp(argv[3], "-n")==0)
+		if (argc >= 5 && strcmp(argv[3], "-n") == 0)
 		{
 			gp_SortVertices(theGraph);
 			gp_Write(theGraph, argv[4], WRITE_ADJLIST);
@@ -126,7 +130,7 @@ int Result;
 	gp_Free(&theGraph);
 
 	// In the legacy 1.x versions, OK/NONEMBEDDABLE was 0 and NOTOK was -2
-	return Result==OK || Result==NONEMBEDDABLE ? 0 : -2;
+	return Result == OK || Result == NONEMBEDDABLE ? 0 : -2;
 }
 
 /****************************************************************************
@@ -190,42 +194,50 @@ int runSpecificGraphTests(char *samplesDir)
 #if NIL == 0
 	Message("Starting NIL == 0 Tests\n");
 
-	if (runSpecificGraphTest("-p", "maxPlanar5.txt", TRUE) < 0) {
+	if (runSpecificGraphTest("-p", "maxPlanar5.txt", TRUE) < 0)
+	{
 		retVal = -1;
 		Message("Planarity test on maxPlanar5.txt failed.\n");
 	}
 
-	if (runSpecificGraphTest("-d", "maxPlanar5.txt", FALSE) < 0) {
+	if (runSpecificGraphTest("-d", "maxPlanar5.txt", FALSE) < 0)
+	{
 		retVal = -1;
 		Message("Graph drawing test maxPlanar5.txt failed.\n");
 	}
 
-	if (runSpecificGraphTest("-d", "drawExample.txt", TRUE) < 0) {
+	if (runSpecificGraphTest("-d", "drawExample.txt", TRUE) < 0)
+	{
 		retVal = -1;
 		Message("Graph drawing on drawExample.txt failed.\n");
 	}
 
-	if (runSpecificGraphTest("-p", "Petersen.txt", FALSE) < 0) {
+	if (runSpecificGraphTest("-p", "Petersen.txt", FALSE) < 0)
+	{
 		retVal = -1;
 		Message("Planarity test on Petersen.txt failed.\n");
 	}
 
-	if (runSpecificGraphTest("-o", "Petersen.txt", TRUE) < 0) {
+	if (runSpecificGraphTest("-o", "Petersen.txt", TRUE) < 0)
+	{
 		retVal = -1;
 		Message("Outerplanarity test on Petersen.txt failed.\n");
 	}
 
-	if (runSpecificGraphTest("-2", "Petersen.txt", FALSE) < 0) {
+	if (runSpecificGraphTest("-2", "Petersen.txt", FALSE) < 0)
+	{
 		retVal = -1;
 		Message("K_{2,3} search on Petersen.txt failed.\n");
 	}
 
-	if (runSpecificGraphTest("-3", "Petersen.txt", TRUE) < 0) {
+	if (runSpecificGraphTest("-3", "Petersen.txt", TRUE) < 0)
+	{
 		retVal = -1;
 		Message("K_{3,3} search on Petersen.txt failed.\n");
 	}
 
-	if (runSpecificGraphTest("-4", "Petersen.txt", FALSE) < 0) {
+	if (runSpecificGraphTest("-4", "Petersen.txt", FALSE) < 0)
+	{
 		retVal = -1;
 		Message("K_4 search on Petersen.txt failed.\n");
 	}
@@ -233,134 +245,140 @@ int runSpecificGraphTests(char *samplesDir)
 	Message("Finished NIL == 0 Tests.\n\n");
 #endif
 
-	if (runSpecificGraphTest("-p", "maxPlanar5.0-based.txt", FALSE) < 0) {
+	if (runSpecificGraphTest("-p", "maxPlanar5.0-based.txt", FALSE) < 0)
+	{
 		retVal = -1;
 		Message("Planarity test on maxPlanar5.0-based.txt failed.\n");
 	}
 
-	if (runSpecificGraphTest("-d", "maxPlanar5.0-based.txt", TRUE) < 0) {
+	if (runSpecificGraphTest("-d", "maxPlanar5.0-based.txt", TRUE) < 0)
+	{
 		retVal = -1;
 		Message("Graph drawing test maxPlanar5.0-based.txt failed.\n");
 	}
 
-	if (runSpecificGraphTest("-d", "drawExample.0-based.txt", FALSE) < 0) {
+	if (runSpecificGraphTest("-d", "drawExample.0-based.txt", FALSE) < 0)
+	{
 		retVal = -1;
 		Message("Graph drawing on drawExample.0-based.txt failed.\n");
 	}
 
-	if (runSpecificGraphTest("-p", "Petersen.0-based.txt", TRUE) < 0) {
+	if (runSpecificGraphTest("-p", "Petersen.0-based.txt", TRUE) < 0)
+	{
 		retVal = -1;
 		Message("Planarity test on Petersen.0-based.txt failed.\n");
 	}
 
-	if (runSpecificGraphTest("-o", "Petersen.0-based.txt", FALSE) < 0) {
+	if (runSpecificGraphTest("-o", "Petersen.0-based.txt", FALSE) < 0)
+	{
 		retVal = -1;
 		Message("Outerplanarity test on Petersen.0-based.txt failed.\n");
 	}
 
-	if (runSpecificGraphTest("-2", "Petersen.0-based.txt", TRUE) < 0) {
+	if (runSpecificGraphTest("-2", "Petersen.0-based.txt", TRUE) < 0)
+	{
 		retVal = -1;
 		Message("K_{2,3} search on Petersen.0-based.txt failed.\n");
 	}
 
-	if (runSpecificGraphTest("-3", "Petersen.0-based.txt", FALSE) < 0) {
+	if (runSpecificGraphTest("-3", "Petersen.0-based.txt", FALSE) < 0)
+	{
 		retVal = -1;
 		Message("K_{3,3} search on Petersen.0-based.txt failed.\n");
 	}
 
-	if (runSpecificGraphTest("-4", "Petersen.0-based.txt", TRUE) < 0) {
+	if (runSpecificGraphTest("-4", "Petersen.0-based.txt", TRUE) < 0)
+	{
 		retVal = -1;
 		Message("K_4 search on Petersen.0-based.txt failed.\n");
 	}
 
-
-/*
-	GRAPH TRANSFORMATION TESTS
-*/
+	/*
+		GRAPH TRANSFORMATION TESTS
+	*/
 	//	TRANSFORM TO ADJACENCY LIST
 
 	// runGraphTransformationTest by reading file contents into string
-	if (runGraphTransformationTest("-ta", "nauty_example.g6", TRUE) < 0)
+	if (runGraphTransformationTest("-a", "nauty_example.g6", TRUE) < 0)
 	{
 		retVal = -1;
 		Message("Transforming nauty_example.g6 file contents as string to adjacency list failed.\n");
 	}
 
 	// runGraphTransformationTest by reading from file
-	if (runGraphTransformationTest("-ta", "nauty_example.g6", FALSE) < 0)
+	if (runGraphTransformationTest("-a", "nauty_example.g6", FALSE) < 0)
 	{
 		retVal = -1;
 		Message("Transforming nauty_example.g6 using file pointer to adjacency list failed.\n");
 	}
 
 	// runGraphTransformationTest by reading first graph from file into string
-	if (runGraphTransformationTest("-ta", "N5-all.g6", TRUE) < 0)
+	if (runGraphTransformationTest("-a", "N5-all.g6", TRUE) < 0)
 	{
 		retVal = -1;
 		Message("Transforming first graph in N5-all.g6 (read as string) to adjacency list failed.\n");
 	}
 
 	// runGraphTransformationTest by reading first graph from file pointer
-	if (runGraphTransformationTest("-ta", "N5-all.g6", FALSE) < 0)
+	if (runGraphTransformationTest("-a", "N5-all.g6", FALSE) < 0)
 	{
 		retVal = -1;
 		Message("Transforming first graph in N5-all.g6 (read from file pointer) to adjacency list failed.\n");
 	}
 
 	// runGraphTransformationTest by reading file contents corresponding to dense graph into string
-	if (runGraphTransformationTest("-ta", "K10.g6", TRUE) < 0)
+	if (runGraphTransformationTest("-a", "K10.g6", TRUE) < 0)
 	{
 		retVal = -1;
 		Message("Transforming K10.g6 file contents as string to adjacency list failed.\n");
 	}
 
 	// runGraphTransformationTest by reading dense graph from file
-	if (runGraphTransformationTest("-ta", "K10.g6", FALSE) < 0)
+	if (runGraphTransformationTest("-a", "K10.g6", FALSE) < 0)
 	{
 		retVal = -1;
 		Message("Transforming K10.g6 using file pointer to adjacency list failed.\n");
 	}
 
-
 	//	TRANSFORM TO ADJACENCY MATRIX
 
 	// runGraphTransformationTest by reading file contents into string
-	if (runGraphTransformationTest("-tm", "nauty_example.g6", TRUE) < 0)
+	if (runGraphTransformationTest("-m", "nauty_example.g6", TRUE) < 0)
 	{
 		retVal = -1;
 		Message("Transforming nauty_example.g6 file contents as string to adjacency matrix failed.\n");
 	}
 
 	// runGraphTransformationTest by reading from file
-	if (runGraphTransformationTest("-tm", "nauty_example.g6", FALSE) < 0)
+	if (runGraphTransformationTest("-m", "nauty_example.g6", FALSE) < 0)
 	{
 		retVal = -1;
 		Message("Transforming nauty_example.g6 using file pointer to adjacency matrix failed.\n");
 	}
 
 	// runGraphTransformationTest by reading first graph from file into string
-	if (runGraphTransformationTest("-tm", "N5-all.g6", TRUE) < 0)
+	if (runGraphTransformationTest("-m", "N5-all.g6", TRUE) < 0)
 	{
 		retVal = -1;
 		Message("Transforming first graph in N5-all.g6 (read as string) to adjacency matrix failed.\n");
 	}
 
 	// runGraphTransformationTest by reading first graph from file pointer
-	if (runGraphTransformationTest("-tm", "N5-all.g6", FALSE) < 0)
+	if (runGraphTransformationTest("-m", "N5-all.g6", FALSE) < 0)
 	{
 		retVal = -1;
 		Message("Transforming first graph in N5-all.g6 (read from file pointer) to adjacency matrix failed.\n");
 	}
 
 	// runGraphTransformationTest by reading file contents corresponding to dense graph into string
-	if (runGraphTransformationTest("-tm", "K10.g6", TRUE) < 0)
+	if (runGraphTransformationTest("-m", "K10.g6", TRUE) < 0)
 	{
 		retVal = -1;
 		Message("Transforming K10.g6 file contents as string to adjacency matrix failed.\n");
 	}
 
 	// runGraphTransformationTest by reading dense graph from file
-	if (runGraphTransformationTest("-tm", "K10.g6", FALSE) < 0)
+	if (runGraphTransformationTest("-m", "K10.g6", FALSE) < 0)
 	{
 		retVal = -1;
 		Message("Transforming K10.g6 using file pointer to adjacency matrix failed.\n");
@@ -369,19 +387,18 @@ int runSpecificGraphTests(char *samplesDir)
 	//	TRANSFORM TO .G6
 
 	// runGraphTransformationTest by reading from file
-	if (runGraphTransformationTest("-tg", "nauty_example.g6.0-based.AdjList.out.txt", TRUE) < 0)
+	if (runGraphTransformationTest("-g", "nauty_example.g6.0-based.AdjList.out.txt", TRUE) < 0)
 	{
 		retVal = -1;
 		Message("Transforming nauty_example.g6.0-based.AdjList.out.txt using file pointer to .g6 failed.\n");
 	}
 
 	// runGraphTransformationTest by reading from file
-	if (runGraphTransformationTest("-tg", "K10.g6.0-based.AdjList.out.txt", TRUE) < 0)
+	if (runGraphTransformationTest("-g", "K10.g6.0-based.AdjList.out.txt", TRUE) < 0)
 	{
 		retVal = -1;
 		Message("Transforming K10.g6.0-based.AdjList.out.txt using file pointer to .g6 failed.\n");
 	}
-
 
 	if (retVal == 0)
 		Message("Tests of all specific graphs succeeded.\n");
@@ -389,7 +406,7 @@ int runSpecificGraphTests(char *samplesDir)
 		Message("One or more specific graph tests FAILED.\n");
 
 	chdir(origDir);
-    FlushConsole(stdout);
+	FlushConsole(stdout);
 	return retVal;
 }
 
@@ -411,18 +428,19 @@ int runSpecificGraphTest(char *command, char *infileName, int inputInMemFlag)
 	if (inputInMemFlag)
 	{
 		inputString = ReadTextFileIntoString(infileName);
-		if (inputString == NULL) {
+		if (inputString == NULL)
+		{
 			ErrorMessage("Failed to read input file into string.\n");
 			Result = NOTOK;
 		}
 	}
 
-	if  (Result == OK)
+	if (Result == OK)
 	{
 		// Perform the indicated algorithm on the graph in the input file or string. gp_ReadFromString()
 		// will handle freeing inputString.
 		Result = SpecificGraph(algorithmCode,
-				               infileName, NULL, NULL,
+							   infileName, NULL, NULL,
 							   inputString, &actualOutput, &actualOutput2);
 	}
 
@@ -450,7 +468,7 @@ int runSpecificGraphTest(char *command, char *infileName, int inputInMemFlag)
 	// Test that the secondary actual output matches the secondary expected output
 	if (algorithmCode == 'd' && Result == 0)
 	{
-		char *expectedSecondaryResultFileName = (char *) malloc(strlen(expectedPrimaryResultFileName) + strlen(".render.txt") + 1);
+		char *expectedSecondaryResultFileName = (char *)malloc(strlen(expectedPrimaryResultFileName) + strlen(".render.txt") + 1);
 
 		if (expectedSecondaryResultFileName != NULL)
 		{
@@ -486,17 +504,17 @@ int runSpecificGraphTest(char *command, char *infileName, int inputInMemFlag)
 int runGraphTransformationTest(char *command, char *infileName, int inputInMemFlag)
 {
 	int Result = OK;
-	
+
 	char transformationCode = '\0';
 	// runGraphTransformationTest will not test performing an algorithm on a given
-	// input graph; it will only support "-t(gam)"
-	if (command == NULL || strlen(command) < 3)
+	// input graph; it will only support "-(gam)"
+	if (command == NULL || strlen(command) < 2)
 	{
-		ErrorMessage("runGraphTransformationTest only supports -t(gam).\n");
+		ErrorMessage("runGraphTransformationTest only supports -(gam).\n");
 		return NOTOK;
 	}
-	else if (strlen(command) == 3)
-		transformationCode = command[2];
+	else if (strlen(command) == 2)
+		transformationCode = command[1];
 
 	// SpecificGraph() can invoke gp_Read() if the graph is to be read from a file, or it can invoke
 	// gp_ReadFromString() if the inputInMemFlag is set.
@@ -504,7 +522,8 @@ int runGraphTransformationTest(char *command, char *infileName, int inputInMemFl
 	if (inputInMemFlag)
 	{
 		inputString = ReadTextFileIntoString(infileName);
-		if (inputString == NULL) {
+		if (inputString == NULL)
+		{
 			ErrorMessage("Failed to read input file into string.\n");
 			Result = NOTOK;
 		}
@@ -516,11 +535,11 @@ int runGraphTransformationTest(char *command, char *infileName, int inputInMemFl
 		int zeroBasedOutputFlag = 0;
 		char *actualOutput = NULL;
 		// We want to handle the test being run when we read from an input file or read from a string,
-		// so pass both infileName and inputString. Ownership of inputString is relinquished to TestGraphFunctionality,
+		// so pass both infileName and inputString. Ownership of inputString is relinquished to TestAllGraphs,
 		// and gp_ReadFromString() will handle freeing it.
 		// We want to output to string, so we pass in the address of the actualOutput string.
-		Result = TestGraphFunctionality(command, infileName, inputString, &zeroBasedOutputFlag, NULL, &actualOutput);
-		
+		Result = TransformGraph(command, infileName, inputString, &zeroBasedOutputFlag, NULL, &actualOutput);
+
 		if (Result != OK || actualOutput == NULL)
 		{
 			ErrorMessage("Failed to perform transformation.\n");
@@ -545,7 +564,7 @@ int runGraphTransformationTest(char *command, char *infileName, int inputInMemFl
 			if (Result == TRUE)
 			{
 				messageFormat = "For the transformation %s on file \"%.*s\", actual output file matched expected output file.\n";
-				charsAvailForFilename = (int) (MAXLINE - strlen(messageFormat));
+				charsAvailForFilename = (int)(MAXLINE - strlen(messageFormat));
 				sprintf(messageContents, messageFormat, command, charsAvailForFilename, infileName);
 				Message(messageContents);
 				Result = OK;
@@ -553,7 +572,7 @@ int runGraphTransformationTest(char *command, char *infileName, int inputInMemFl
 			else
 			{
 				messageFormat = "For the transformation %s on file \"%.*s\", actual output file did not match expected output file.\n";
-				charsAvailForFilename = (int) (MAXLINE - strlen(messageFormat));
+				charsAvailForFilename = (int)(MAXLINE - strlen(messageFormat));
 				sprintf(messageContents, messageFormat, command, charsAvailForFilename, infileName);
 				ErrorMessage(messageContents);
 				Result = NOTOK;
@@ -593,10 +612,10 @@ int callRandomGraphs(int argc, char *argv[])
 		offset = 1;
 	}
 
-	NumGraphs = atoi(argv[3+offset]);
-	SizeOfGraphs = atoi(argv[4+offset]);
+	NumGraphs = atoi(argv[3 + offset]);
+	SizeOfGraphs = atoi(argv[4 + offset]);
 
-    return RandomGraphs(Choice, NumGraphs, SizeOfGraphs);
+	return RandomGraphs(Choice, NumGraphs, SizeOfGraphs);
 }
 
 /****************************************************************************
@@ -606,7 +625,7 @@ int callRandomGraphs(int argc, char *argv[])
 // 'planarity -s [-q] C I O [O2]': Specific graph
 int callSpecificGraph(int argc, char *argv[])
 {
-	char Choice=0, *infileName=NULL, *outfileName=NULL, *outfile2Name=NULL;
+	char Choice = 0, *infileName = NULL, *outfileName = NULL, *outfile2Name = NULL;
 	int offset = 0;
 
 	if (argc < 5)
@@ -620,10 +639,10 @@ int callSpecificGraph(int argc, char *argv[])
 		offset = 1;
 	}
 
-	infileName = argv[3+offset];
-	outfileName = argv[4+offset];
-	if (argc == 6+offset)
-	    outfile2Name = argv[5+offset];
+	infileName = argv[3 + offset];
+	outfileName = argv[4 + offset];
+	if (argc == 6 + offset)
+		outfile2Name = argv[5 + offset];
 
 	return SpecificGraph(Choice, infileName, outfileName, outfile2Name, NULL, NULL, NULL);
 }
@@ -648,10 +667,10 @@ int callRandomMaxPlanarGraph(int argc, char *argv[])
 		offset = 1;
 	}
 
-	numVertices = atoi(argv[2+offset]);
-	outfileName = argv[3+offset];
-	if (argc == 5+offset)
-	    outfile2Name = argv[4+offset];
+	numVertices = atoi(argv[2 + offset]);
+	outfileName = argv[3 + offset];
+	if (argc == 5 + offset)
+		outfile2Name = argv[4 + offset];
 
 	return RandomGraph('p', 0, numVertices, outfileName, outfile2Name);
 }
@@ -676,28 +695,22 @@ int callRandomNonplanarGraph(int argc, char *argv[])
 		offset = 1;
 	}
 
-	numVertices = atoi(argv[2+offset]);
-	outfileName = argv[3+offset];
-	if (argc == 5+offset)
-	    outfile2Name = argv[4+offset];
+	numVertices = atoi(argv[2 + offset]);
+	outfileName = argv[3 + offset];
+	if (argc == 5 + offset)
+		outfile2Name = argv[4 + offset];
 
 	return RandomGraph('p', 1, numVertices, outfileName, outfile2Name);
 }
 
 /****************************************************************************
- callTestGraphFunctionality()
+ callTransformGraph()
  ****************************************************************************/
 
-// 'planarity -t [-q] C|-t(gam) I O':
-//     * If -t(gam) is given rather than an algorithm command C, then the input
-// file I is transformed from its given format to the format given by the g (g6),
-// a (adjacency list) or m (matrix), and written to output file O.
-//     * Otherwise, if the command line argument after -t [-q] is a recognized
-// algorithm command C, then the input file I must be in ".g6" format
-// (report an error otherwise), and the algorithm(s) indicated by C are executed
-// on the graph(s) in the input file, with the results of the execution stored
-// in output file O.
-int callTestGraphFunctionality(int argc, char *argv[])
+// 'planarity -x [-q] -(gam) I O': Input file I is transformed from its given
+// format to the format given by the g (g6), a (adjacency list) or m (matrix),
+// and written to output file O.
+int callTransformGraph(int argc, char *argv[])
 {
 	int offset = 0;
 	char *commandString = NULL;
@@ -713,12 +726,48 @@ int callTestGraphFunctionality(int argc, char *argv[])
 		offset = 1;
 	}
 
-	commandString = argv[2+offset];
+	commandString = argv[2 + offset];
 
-	infileName = argv[3+offset];
-	outfileName = argv[4+offset];
+	infileName = argv[3 + offset];
+	outfileName = argv[4 + offset];
 
-	// We don't want to read from string nor output to string, so inputStr and outputStr are NULL
+	// We don't want to read from string, so inputStr is NULL
+	// We don't want to write to string, so outputStr is NULL
 	// We don't need to capture whether output is 0- or 1-based, so zeroBasedOutputFlag arg is NULL
-	return TestGraphFunctionality(commandString, infileName, NULL, NULL, outfileName, NULL);
+	return TransformGraph(commandString, infileName, NULL, NULL, outfileName, NULL);
+}
+
+/****************************************************************************
+ callTestAllGraphs()
+ ****************************************************************************/
+
+// 'planarity -t [-q] C I O': If the command line argument after -t [-q] is a
+// recognized algorithm command C, then the input file I must be in ".g6" format
+// (report an error otherwise), and the algorithm(s) indicated by C are executed
+// on the graph(s) in the input file, with the results of the execution stored
+// in output file O.
+int callTestAllGraphs(int argc, char *argv[])
+{
+	int offset = 0;
+	char *commandString = NULL;
+	char *infileName = NULL, *outfileName = NULL;
+
+	if (argc < 5)
+		return -1;
+
+	if (argv[2][0] == '-' && argv[2][1] == 'q')
+	{
+		if (argc < 6)
+			return -1;
+		offset = 1;
+	}
+
+	commandString = argv[2 + offset];
+
+	infileName = argv[3 + offset];
+	outfileName = argv[4 + offset];
+
+	// We don't want to write to string, so outputStr is NULL
+	// We don't need to capture whether output is 0- or 1-based, so zeroBasedOutputFlag arg is NULL
+	return TestAllGraphs(commandString, infileName, NULL, outfileName, NULL);
 }

--- a/c/planarityApp/planarityCommandLine.c
+++ b/c/planarityApp/planarityCommandLine.c
@@ -535,7 +535,7 @@ int runGraphTransformationTest(char *command, char *infileName, int inputInMemFl
 		int zeroBasedOutputFlag = 0;
 		char *actualOutput = NULL;
 		// We want to handle the test being run when we read from an input file or read from a string,
-		// so pass both infileName and inputString. Ownership of inputString is relinquished to TestAllGraphs,
+		// so pass both infileName and inputString. Ownership of inputString is relinquished to TransformGraph(),
 		// and gp_ReadFromString() will handle freeing it.
 		// We want to output to string, so we pass in the address of the actualOutput string.
 		Result = TransformGraph(command, infileName, inputString, &zeroBasedOutputFlag, NULL, &actualOutput);

--- a/c/planarityApp/planarityHelp.c
+++ b/c/planarityApp/planarityHelp.c
@@ -92,7 +92,8 @@ int helpMessage(char *param)
             "'planarity -s [-q] C I O [O2]': Specific graph\n"
             "'planarity -rm [-q] N O [O2]': Random maximal planar graph\n"
             "'planarity -rn [-q] N O [O2]': Random nonplanar graph (maximal planar + edge)\n"
-            "'planarity -t [-q] C|-t(gam) I O': Test algorithm on graphs or transform graph\n"
+            "'planarity -t [-q] C I O': Test algorithm on graph(s) in .g6 file\n"
+            "'planarity -x [-q] -(gam) I O': Transform graph to .g6 (g), Adjacency List (a), or Adjacency Matrix (m)\n"
             "'planarity I O [-n O2]': Legacy command-line (default -s -p)\n"
             "\n");
 

--- a/c/planarityApp/planarityMenu.c
+++ b/c/planarityApp/planarityMenu.c
@@ -9,9 +9,8 @@ See the LICENSE.TXT file for licensing information.
 /****************************************************************************
  MENU-DRIVEN PROGRAM
  ****************************************************************************/
-void TransformOrTestMenu(void);
-void TransformMenu(void);
-void TestMenu(void);
+void TransformGraphMenu(void);
+void TestAllGraphsMenu(void);
 
 int menu()
 {
@@ -24,10 +23,11 @@ int menu()
         Message(GetAlgorithmSpecifiers());
 
         Message(
-            "T. Test graph functionality\n"
+            "X. Transform single graph in supported file to .g6, adjacency list, or adjacency matrix\n"
+            "T. Perform an algorithm test on all graphs in .g6 input file\n"
             "H. Help message for command line version\n"
             "R. Reconfigure options\n"
-            "X. Exit\n"
+            "Q. Quit\n"
             "\n");
 
         Prompt("Enter Choice: ");
@@ -41,10 +41,13 @@ int menu()
         else if (Choice == 'r')
             Reconfigure();
 
-        else if (Choice == 't')
-            TransformOrTestMenu();
+        else if (Choice == 'x')
+            TransformGraphMenu();
 
-        else if (Choice != 'x')
+        else if (Choice == 't')
+            TestAllGraphsMenu();
+
+        else if (Choice != 'q')
         {
             char *secondOutfile = NULL;
             if (Choice == 'p' || Choice == 'd' || Choice == 'o')
@@ -74,7 +77,7 @@ int menu()
             }
         }
 
-        if (Choice != 'r' && Choice != 'x')
+        if (Choice != 'r' && Choice != 'q')
         {
             Prompt("\nPress a key then hit ENTER to continue...");
             fflush(stdin);
@@ -84,7 +87,7 @@ int menu()
             FlushConsole(stdout);
         }
 
-    } while (Choice != 'x');
+    } while (Choice != 'q');
 
     // Certain debuggers don't terminate correctly with pending output content
     FlushConsole(stdout);
@@ -93,35 +96,7 @@ int menu()
     return 0;
 }
 
-void TransformOrTestMenu()
-{
-    char Choice;
-    char *messageFormat;
-    char messageContents[MAXLINE + 1];
-
-    Message("\n");
-    Message("T. Transform single graph in supported file to .g6, adjacency list, or adjacency matrix\n");
-    Message("A. Perform an algorithm test on all graphs in .g6 input file\n");
-    Message("\nPress any other key to return to the main menu.\n");
-    Message("\n");
-
-    Prompt("Enter Choice: ");
-    fflush(stdin);
-    scanf(" %c", &Choice);
-    Choice = tolower(Choice);
-
-    switch (Choice)
-    {
-    case 't':
-        TransformMenu();
-        return;
-    case 'a':
-        TestMenu();
-        return;
-    }
-}
-
-void TransformMenu()
+void TransformGraphMenu()
 {
     int Result = OK;
 
@@ -162,12 +137,12 @@ void TransformMenu()
         scanf(" %c", &outputFormat);
         outputFormat = tolower(outputFormat);
         if (strchr(GetSupportedOutputFormats(), outputFormat))
-            sprintf(commandStr, "-t%c", outputFormat);
+            sprintf(commandStr, "-%c", outputFormat);
     } while (strlen(commandStr) == 0);
 
     if (strlen(outfileName) == 0)
     {
-        Result = TestGraphFunctionality(commandStr, infileName, NULL, NULL, NULL, &outputStr);
+        Result = TransformGraph(commandStr, infileName, NULL, NULL, NULL, &outputStr);
         if (Result != OK || outputStr == NULL)
             ErrorMessage("Failed to perform transformation.\n");
         else
@@ -179,7 +154,7 @@ void TransformMenu()
     }
     else
     {
-        Result = TestGraphFunctionality(commandStr, infileName, NULL, NULL, outfileName, NULL);
+        Result = TransformGraph(commandStr, infileName, NULL, NULL, outfileName, NULL);
         if (Result != OK)
             ErrorMessage("Failed to perform transformation.\n");
     }
@@ -191,7 +166,7 @@ void TransformMenu()
     }
 }
 
-void TestMenu()
+void TestAllGraphsMenu()
 {
     int Result = OK;
 
@@ -238,7 +213,7 @@ void TestMenu()
 
     if (strlen(outfileName) == 0)
     {
-        Result = TestGraphFunctionality(commandStr, infileName, NULL, NULL, NULL, &outputStr);
+        Result = TestAllGraphs(commandStr, infileName, NULL, NULL, &outputStr);
         if (Result != OK || outputStr == NULL)
             ErrorMessage("Algorithm test on all graphs in .g6 input file failed.\n");
         else
@@ -250,7 +225,7 @@ void TestMenu()
     }
     else
     {
-        Result = TestGraphFunctionality(commandStr, infileName, NULL, NULL, outfileName, NULL);
+        Result = TestAllGraphs(commandStr, infileName, NULL, outfileName, NULL);
         if (Result != OK)
             ErrorMessage("Algorithm test on all graphs in .g6 input file failed.\n");
     }

--- a/c/planarityApp/planarityTransformGraph.c
+++ b/c/planarityApp/planarityTransformGraph.c
@@ -33,7 +33,6 @@ int TransformGraph(char *commandString, char *infileName, char *inputStr, int *o
 
 	graphP theGraph;
 
-	// Create the graph and, if needed, attach the correct algorithm to it
 	theGraph = gp_New();
 
 	int outputFormat = -1;

--- a/c/planarityApp/planarityTransformGraph.c
+++ b/c/planarityApp/planarityTransformGraph.c
@@ -1,0 +1,110 @@
+/*
+Copyright (c) 1997-2024, John M. Boyer
+All rights reserved.
+See the LICENSE.TXT file for licensing information.
+*/
+
+#include "planarity.h"
+#include "../graphLib/graph.h"
+
+int transformFile(graphP theGraph, char *infileName);
+int transformString(graphP theGraph, char *inputStr);
+
+/****************************************************************************
+ TransformGraph()
+ commandString - command to run; i.e. `-(gam)` to transform graph to .g6, adjacency list, or
+ adjacency matrix format
+ infileName - name of file to read, or NULL to cause the program to prompt the user for a filename
+ inputStr - string containing input graph, or NULL to cause the program to fall back on reading from file
+ outputBase - pointer to the flag set for whether output is 0- or 1-based
+ outputFormat - output format
+ outfileName - name of primary output file, or NULL to construct an output filename based on the input
+ outputStr - pointer to string which we wish to use to store the transformation output
+ ****************************************************************************/
+int TransformGraph(char *commandString, char *infileName, char *inputStr, int *outputBase, char *outfileName, char **outputStr)
+{
+	int Result = OK;
+	platform_time start, end;
+
+	int charsAvailForFilename = 0;
+	char *messageFormat = NULL;
+	char messageContents[MAXLINE + 1];
+	messageContents[MAXLINE] = '\0';
+
+	graphP theGraph;
+
+	// Create the graph and, if needed, attach the correct algorithm to it
+	theGraph = gp_New();
+
+	int outputFormat = -1;
+
+	if (commandString[0] == '-')
+	{
+		if (commandString[1] == 'g')
+			outputFormat = WRITE_G6;
+		else if (commandString[1] == 'a')
+			outputFormat = WRITE_ADJLIST;
+		else if (commandString[1] == 'm')
+			outputFormat = WRITE_ADJMATRIX;
+		else
+		{
+			ErrorMessage("Invalid argument; only -(gam) is allowed.\n");
+			return NOTOK;
+		}
+
+		if (inputStr)
+			Result = transformString(theGraph, inputStr);
+		else
+			Result = transformFile(theGraph, infileName);
+
+		if (Result != OK)
+		{
+			ErrorMessage("Unable to transform input graph.\n");
+		}
+		else
+		{
+			// Want to know whether the output is 0- or 1-based; will always be
+			// 0-based for transformations of .g6 input
+			if (outputBase != NULL)
+				(*outputBase) = (theGraph->internalFlags & FLAGS_ZEROBASEDIO) ? 1 : 0;
+
+			if (outputStr != NULL)
+				Result = gp_WriteToString(theGraph, outputStr, outputFormat);
+			else
+				Result = gp_Write(theGraph, outfileName, outputFormat);
+
+			if (Result != OK)
+				ErrorMessage("Unable to write graph.\n");
+		}
+	}
+	else
+	{
+		ErrorMessage("Invalid argument; must start with '-'.\n");
+		Result = NOTOK;
+	}
+
+	gp_Free(&theGraph);
+	return Result;
+}
+
+int transformFile(graphP theGraph, char *infileName)
+{
+	if (infileName == NULL)
+	{
+		if ((infileName = ConstructInputFilename(infileName)) == NULL)
+			return NOTOK;
+	}
+
+	return gp_Read(theGraph, infileName);
+}
+
+int transformString(graphP theGraph, char *inputStr)
+{
+	if (inputStr == NULL || strlen(inputStr) == 0)
+	{
+		ErrorMessage("Input string is null or empty.\n");
+		return NOTOK;
+	}
+
+	return gp_ReadFromString(theGraph, inputStr);
+}


### PR DESCRIPTION
Resolves #94 

## Removed
- `c/planarityApp/planarityTestGraphFunctionality.c` - split out into `planarityTransformGraph.c` and `planarityTestAllGraphs.c`

## Added
- `c/planarityApp/`
  - `planarityTransformGraph.c` - Contains `TransformGraph()`, which is comprised of the first branch of the old `TestGraphFunctionality()` function
  - `planarityTestAllGraphs.c` - Contains `TestAllGraphs()`, which is comprised of the second branch of the old `TestGraphFunctionality()` function. (note change in function signature, since Test All Graphs branch in old `TestGraphFunctionality()` function disallowed `inputStr`)

## Updated
- `.vscode/launch.json` - Corrected Transform Graph example launch configuration command-line parameterization (i.e. `planarity -x -(gam) infileName outfileName` rather than `planarity -t -t(gam) infileName outfileName`)
- `Makefile.am` - Updated `planarity_SOURCES` to include `c/planarityApp/planarityTransformGraph.c` and `c/planarityApp/planarityTestAllGraphs.c`
- `c/planarityApp/`
  - `planarity.1` - Updated manpage to split up old `-t` flag into transform graph (`-x`) versus test all graphs (`-t`)
  - `planarityHelp.c` - Updated `helpMessage()` to split up old `-t` flag into transform graph (`-x`) versus test all graphs (`-t`)
  - `planarity.h` - Added declarations for `TransformGraph()` and `TestAllGraphs()` (note change in function signature, since Test All Graphs branch in old `TestGraphFunctionality()` function disallowed `inputStr`)
  - `planarityCommandLine.c` - replaced `callTestGraphFunctionality()` with two new functions, `callTransformGraph()` (note that we now expect `-(gam)` rather than `-t(gam)`, so expected length of `command` is reduced within both `callTransformGraph()` and `runGraphTransformationTest()`) and `callTestAllGraphs()`. Also updated the arguments of the calls to `runGraphTransformationTest()` within `runSpecificGraphTests()` so that they are of the form `-(gam)` rather than `-t(gam)`.
  - `planarityMenu.c` - Removed `TransformOrTestMenu()` layer so that `menu()` directly leads to the transform graph and test all graphs menus; renamed `TransformMenu()` to `TransformGraphMenu()` and `TestMenu()` to `TestAllGraphsMenu()`
