### PR TITLE
Fix for issue #105 plus pertinent code cleanup

### DIFF
--- a/c/graphLib/homeomorphSearch/graphK23Search.c
+++ b/c/graphLib/homeomorphSearch/graphK23Search.c
@@ -154,7 +154,7 @@ int _IsolateOuterplanarityObstructionE1orE2(graphP theGraph)
     isolatorContextP IC = &theGraph->IC;
     int XPrevLink = 1;
 
-    if (_MarkHighestXYPath(theGraph) != TRUE)
+    if (_MarkHighestXYPath(theGraph) != OK || theGraph->IC.py == NIL)
         return NOTOK;
 
     /* Isolate E1 */
@@ -212,7 +212,7 @@ int _IsolateOuterplanarityObstructionE3orE4(graphP theGraph)
     if (FUTUREPERTINENT(theGraph, theGraph->IC.x, theGraph->IC.v) ||
         FUTUREPERTINENT(theGraph, theGraph->IC.y, theGraph->IC.v))
     {
-        if (_MarkHighestXYPath(theGraph) != TRUE)
+        if (_MarkHighestXYPath(theGraph) != OK || theGraph->IC.py == NIL)
             return NOTOK;
 
         gp_UpdateVertexFuturePertinentChild(theGraph, theGraph->IC.x, theGraph->IC.v);

--- a/c/graphLib/planarityRelated/graphOuterplanarObstruction.c
+++ b/c/graphLib/planarityRelated/graphOuterplanarObstruction.c
@@ -120,7 +120,7 @@ int _IsolateOuterplanarObstruction(graphP theGraph, int v, int R)
 
     if (theGraph->IC.minorType & MINORTYPE_E)
     {
-        if (_MarkHighestXYPath(theGraph) != TRUE)
+        if (_MarkHighestXYPath(theGraph) != OK || theGraph->IC.py == NIL)
             return NOTOK;
     }
 


### PR DESCRIPTION
Closes #105 

The X-Y path being used for detection of minor E5 wasn't the lowest X-Y path, which is the same one needed to test for minor E4. Once the lowest X-Y path is identified for E4, if neither of its attachment points are below x and y, then the x-y path identified in that test is also the one needed for E5 because only the lowest x-y path could possibly have a Z-to-W path, since the containing bicomp is a planar embedding.

Also had to clean up code related to how the X-Y path marking functions were called, and what they return, to avoid writing the same undesirable pattern into the new method to be used in E4 and E5 testing.