### PR TITLE
Issues 40 and 118 - function pointer param fix

### DIFF
--- a/c/graphLib/extensionSystem/graphFunctionTable.h
+++ b/c/graphLib/extensionSystem/graphFunctionTable.h
@@ -8,53 +8,56 @@ See the LICENSE.TXT file for licensing information.
 */
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-/*
- NOTE: If you add any FUNCTION POINTERS to this function table, then you must
-       also initialize them in _InitFunctionTable() in graphUtils.c.
-*/
+    /*
+     NOTE: If you add any FUNCTION POINTERS to this function table, then you must
+           also initialize them in _InitFunctionTable() in graphUtils.c.
+    */
+    typedef struct baseGraphStructure baseGraphStructure;
+    typedef baseGraphStructure *graphP;
 
-typedef struct
-{
+    typedef struct
+    {
         // These function pointers allow extension modules to overload some of
         // the behaviors of protected functions.  Only advanced applications
         // will overload these functions
-    	int  (*fpEmbeddingInitialize)();
-        void (*fpEmbedBackEdgeToDescendant)();
-        void (*fpWalkUp)();
-        int  (*fpWalkDown)();
-        int  (*fpMergeBicomps)();
-        void (*fpMergeVertex)();
-        int  (*fpHandleInactiveVertex)();
-        int  (*fpHandleBlockedBicomp)();
-        int  (*fpEmbedPostprocess)();
-        int  (*fpMarkDFSPath)();
+        int (*fpEmbeddingInitialize)(graphP);
+        void (*fpEmbedBackEdgeToDescendant)(graphP, int, int, int, int);
+        void (*fpWalkUp)(graphP, int, int);
+        int (*fpWalkDown)(graphP, int, int);
+        int (*fpMergeBicomps)(graphP, int, int, int, int);
+        void (*fpMergeVertex)(graphP, int, int, int);
+        int (*fpHandleInactiveVertex)(graphP, int, int *, int *);
+        int (*fpHandleBlockedBicomp)(graphP, int, int, int);
+        int (*fpEmbedPostprocess)(graphP, int, int);
+        int (*fpMarkDFSPath)(graphP, int, int);
 
-        int  (*fpCheckEmbeddingIntegrity)();
-        int  (*fpCheckObstructionIntegrity)();
+        int (*fpCheckEmbeddingIntegrity)(graphP, graphP);
+        int (*fpCheckObstructionIntegrity)(graphP, graphP);
 
         // These function pointers allow extension modules to overload some
         // of the behaviors of gp_* function in the public API
-        int  (*fpInitGraph)();
-        void (*fpReinitializeGraph)();
-        int  (*fpEnsureArcCapacity)();
-        int  (*fpSortVertices)();
+        int (*fpInitGraph)(graphP, int);
+        void (*fpReinitializeGraph)(graphP);
+        int (*fpEnsureArcCapacity)(graphP, int);
+        int (*fpSortVertices)(graphP);
 
-        int  (*fpReadPostprocess)();
-        int  (*fpWritePostprocess)();
+        int (*fpReadPostprocess)(graphP, void *, long);
+        int (*fpWritePostprocess)(graphP, void **, long *);
 
-        void (*fpHideEdge)();
-        void (*fpRestoreEdge)();
-        int  (*fpHideVertex)();
-        int  (*fpRestoreVertex)();
-        int  (*fpContractEdge)();
-        int  (*fpIdentifyVertices)();
+        void (*fpHideEdge)(graphP, int);
+        void (*fpRestoreEdge)(graphP, int);
+        int (*fpHideVertex)(graphP, int);
+        int (*fpRestoreVertex)(graphP);
+        int (*fpContractEdge)(graphP, int);
+        int (*fpIdentifyVertices)(graphP, int, int, int);
 
-} graphFunctionTable;
+    } graphFunctionTable;
 
-typedef graphFunctionTable * graphFunctionTableP;
+    typedef graphFunctionTable *graphFunctionTableP;
 
 #ifdef __cplusplus
 }

--- a/c/graphLib/graphStructures.h
+++ b/c/graphLib/graphStructures.h
@@ -552,7 +552,7 @@ extern "C"
 					   extension behaviors to the graph
 	*/
 
-	typedef struct
+	struct baseGraphStructure
 	{
 		vertexRecP V;
 		vertexInfoP VI;
@@ -571,9 +571,9 @@ extern "C"
 
 		graphExtensionP extensions;
 		graphFunctionTable functions;
+	};
 
-	} baseGraphStructure;
-
+	typedef struct baseGraphStructure baseGraphStructure;
 	typedef baseGraphStructure *graphP;
 
 	/* Flags for graph:


### PR DESCRIPTION
Resolves #40 and #118

Extrapolated fix recommended by @orlitzky and verified semantics with @john-boyer-phd

## Updated
* `c/graphLib/graphStructures.h` - now declare named struct `baseGraphStructure` and `typedef` that struct so that the `typedef` of `graphP` works (since `graphUtils.c` `#include`s `graphStructures.h`, there's no need to add the same`typedef` statements)
* `c/graphLib/extensionSystem/graphFunctionTable.h` - updated so that we can use `graphP` in parameter list (external linkage due to `typedef`)

Verified Debug and Release builds on all supported platforms, i.e. MacOS `clang`, Windows 10 (MinGW32 `gcc` and MSVC `cl`), and Debian 12.7 (`gcc` 12.2.0)

_**N.B.**_ I tried cloning the `gcc` [repository](https://gcc.gnu.org/git.html), but there's no branch yet for `gcc-15` (which is slated to be released in April 2025); however, I am going to try to compile the [`gcc-15` snapshot](https://gcc.gnu.org/pub/gcc/snapshots/LATEST-15/) on Debian linux using the provided [instructions](https://gcc.gnu.org/install/index.html) and test compilation of this branch of `planarity` again to ensure there's no warnings or errors