### PR TITLE
Added prerequisites for pkg-config compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ Makefile.in
 missing
 ltmain.sh
 configure
+configure~
 aclocal.m4
 compile
 test-driver

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ compile
 test-driver
 planarity-*
 planarity-*/*
+libplanarity.pc
 
 # Ignoring configuration for VSCode
 /.vscode/

--- a/Makefile.am
+++ b/Makefile.am
@@ -31,7 +31,15 @@ libplanarity_la_SOURCES = \
 
 libplanarity_la_LDFLAGS = -no-undefined $(AM_LDFLAGS) -version-info @LT_CURRENT@:@LT_REVISION@:@LT_AGE@
 
+# These pkgincludes are added without "nobase_" so that the files will be copied to the
+# root of the planarity project includedir (i.e. excluding the c subdirectory)
 pkginclude_HEADERS = \
+	c/graph.h \
+	c/graphLib.h
+
+# This is the full set of pkgincludes for which "nobase_" has been used to ensure that
+# the directory structure is retained.
+nobase_pkginclude_HEADERS = \
 	c/graphLib/graph.h \
 	c/graphLib/graphLib.h \
 	c/graphLib/graphStructures.h \

--- a/Makefile.am
+++ b/Makefile.am
@@ -79,3 +79,5 @@ TESTS = test-samples.sh
 # The @docdir@ variable will be replaced by the ./configure script.
 docdir = @docdir@
 dist_doc_DATA = README.md LICENSE.TXT
+
+pkgconfig_DATA = libplanarity.pc

--- a/Makefile.am
+++ b/Makefile.am
@@ -38,7 +38,7 @@ pkginclude_HEADERS = \
 	c/graphLib.h
 
 # This is the full set of pkgincludes for which "nobase_" has been used to ensure that
-# the directory structure is retained.
+# the directory structure is retained when installing the planarity headers.
 nobase_pkginclude_HEADERS = \
 	c/graphLib/graph.h \
 	c/graphLib/graphLib.h \

--- a/c/graph.h
+++ b/c/graph.h
@@ -8,10 +8,10 @@ See the LICENSE.TXT file for licensing information.
 */
 
 // NOTE: This helper stub has been added for backwards compatibility to
-// support current downstream consumers who expect graph.h to be at the
+// support downstream consumers who expect graph.h to be at the
 // root of the installed planarity headers directory. Future downstream
 // consumers are advised to include the graphLib.h helper stub instead
-// beause it offers access to to all features in the graph library of
+// because it offers access to all features in the graph library of
 // the planarity project.
 
 #ifdef __cplusplus

--- a/c/graph.h
+++ b/c/graph.h
@@ -1,0 +1,28 @@
+#ifndef HELPERSTUB_GRAPH_H
+#define HELPERSTUB_GRAPH_H
+
+/*
+Copyright (c) 1997-2024, John M. Boyer
+All rights reserved.
+See the LICENSE.TXT file for licensing information.
+*/
+
+// NOTE: This helper stub has been added for backwards compatibility to
+// support current downstream consumers who expect graph.h to be at the
+// root of the installed planarity headers directory. Future downstream
+// consumers are advised to include the graphLib.h helper stub instead
+// beause it offers access to to all features in the graph library of
+// the planarity project.
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "c/graphLib/graph.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/c/graphLib.h
+++ b/c/graphLib.h
@@ -1,0 +1,25 @@
+#ifndef HELPERSTUB_GRAPHLIB_H
+#define HELPERSTUB_GRAPHLIB_H
+
+/*
+Copyright (c) 1997-2024, John M. Boyer
+All rights reserved.
+See the LICENSE.TXT file for licensing information.
+*/
+
+// NOTE: This helper stub has been added to make it eaier for downstream
+// consumers to obtain access to to all features in the graph library of
+// the planarity project.
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "c/graphLib/graphLib.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/c/graphLib.h
+++ b/c/graphLib.h
@@ -7,8 +7,8 @@ All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */
 
-// NOTE: This helper stub has been added to make it eaier for downstream
-// consumers to obtain access to to all features in the graph library of
+// NOTE: This helper stub has been added to make it easier for downstream
+// consumers to obtain access to all features in the graph library of
 // the planarity project.
 
 #ifdef __cplusplus

--- a/c/graphLib/graph.h
+++ b/c/graphLib/graph.h
@@ -14,7 +14,7 @@ extern "C"
 
 #include "graphStructures.h"
 
-#include "./extensionSystem/graphExtensions.h"
+#include "extensionSystem/graphExtensions.h"
 
 	///////////////////////////////////////////////////////////////////////////////
 	// Definitions for higher-order operations at the vertex, edge and graph levels

--- a/c/graphLib/graphDFSUtils.c
+++ b/c/graphLib/graphDFSUtils.c
@@ -24,7 +24,7 @@ extern void _ClearVertexVisitedFlags(graphP theGraph, int);
  up related data structures at the same time as the DFS tree is created.
  ********************************************************************/
 
-#include "./lowLevelUtils/platformTime.h"
+#include "lowLevelUtils/platformTime.h"
 
 int gp_CreateDFSTree(graphP theGraph)
 {

--- a/configure.ac
+++ b/configure.ac
@@ -20,6 +20,8 @@ AC_SUBST(LT_CURRENT)
 AC_SUBST(LT_REVISION)
 AC_SUBST(LT_AGE)
 
+PKG_INSTALLDIR
+
 AC_PROG_CC
 LT_INIT
 AC_PROG_INSTALL
@@ -31,5 +33,6 @@ AC_CONFIG_FILES([
   c/samples/Makefile
 ])
 AC_CONFIG_FILES([test-samples.sh], [chmod +x test-samples.sh])
+AC_CONFIG_FILES([libplanarity.pc])
 
 AC_OUTPUT

--- a/libplanarity.pc.in
+++ b/libplanarity.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: @PACKAGE_NAME@
+URL: https://github.com/graph-algorithms/edge-addition-planarity-suite
+Description: Planarity Library for Edge Addition Planarity Suite
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lplanarity
+Cflags: -I${includedir}

--- a/libplanarity.pc.in
+++ b/libplanarity.pc.in
@@ -5,7 +5,7 @@ includedir=@includedir@
 
 Name: @PACKAGE_NAME@
 URL: https://github.com/graph-algorithms/edge-addition-planarity-suite
-Description: Planarity Library for Edge Addition Planarity Suite
+Description: Edge Addition Planarity Suite Graph Library
 Version: @PACKAGE_VERSION@
 Libs: -L${libdir} -lplanarity
 Cflags: -I${includedir}


### PR DESCRIPTION
Resolves #122 

## Added
* `libplanarity.pc.in` - Based on [libbraiding.pc.in](https://github.com/miguelmarco/libbraiding/blob/master/libbraiding.pc.in)
* `c/graph.h` - convenience wrapper for backwards compatibility for users expecting `graph.h` to be at the root of the planarity `@includedir@`
* `c/graphLib.h` - convenience wrapper to expose planarity graph library functionality to downstream consumers

## Updated
* `c/graphLib/graph.h` and `c/graphLib/graphDFSUtils.c` - removed `./` for relative `#include`s to match pattern in all other headers
* `.gitignore` - ignore generated files `libplanarity.pc` and `configure~`
* `configure.ac` - Added `PKG_INSTALLDIR` macro to set the default install directory, and added `AC_CONFIG_FILES([libplanarity.pc])` to ask for the creation of the `libplanarity.pc` by replacing all `@...@` variables in `libplanarity.pc.in` with their computed values
* `Makefile.am` - set `pkgconfig_DATA` to indicate generated `libplanarity.pc` to be installed in the `$(datadir)/pkgconfig` directory during the `make install` process. Also changed `pkginclude_HEADERS` so that the helper stubs `c/graph.h` and `c/graphLib.h` will be installed at `@includedir@` (e.g. `/usr/local/include/planarity` on Debian 12.7), and all other installed headers are listed with `nobase_pkginclude_HEADERS` so that the directory structure of the project is maintained within the `@includedir@`.

---

After running the autotools build process to make the distrubution on Debian 12.7:

```
./autogen.sh
./configure
make dist
make distcheck
tar -xvf planarity-3.0.2.0.tar.gz
cd planarity-3.0.2.0
./configure
sudo make install
sudo sh -c "echo '/usr/local/lib' > /etc/ld.so.conf.d/planarity.conf"
sudo ldconfig
```

I checked the output of `pkg-config` and it seems to find `libplanarity`:

```
$ pkg-config -cflags libplanarity
-I/usr/local/include 
```

And verified that the header files copied into `/usr/local/include/planarity` conform to the expected project structure.

---

I created the [`wbkboyer/libplanarityIncludeTest`](https://github.com/wbkboyer/libplanarityIncludeTest) repository to demonstrate how downstream consumers may include the planarity headers and use the installed library in their own VSCode project:
* `.vscode/tasks.json` - updated the build commands to include the `-I` compiler flag with the include dir resulting from installing planarity via `sudo make install` 
* `.vscode/c_cpp_properties.json` - appending the include dir to the `includePath`

---

As per [this comment](https://github.com/graph-algorithms/edge-addition-planarity-suite/issues/102#issuecomment-2532827568) on #102, MinGW32 does not have support for `pkg-config`; however, MinGW64 does.