### PR TITLE
Issue #102 - Add support for MinGW-w64 and deprecate MinGW 32 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Please refer to the [2. Dev Setup](https://github.com/graph-algorithms/edge-addi
 
 Once one has set up the development environment and is able to work with the code in the development environment, it is possible to make the distribution with the following additional steps:
 
-1. Ensure that the `autotools`, `configure`, and `make` are available on the command-line (e.g. add `C:\MinGW\msys\1.0\bin` to the system `PATH` before Windows Program Files to ensure that the `find` program is the one from `MSYS` rather than the one from Windows (e.g. adjust the `PATH` variable as needed)). 
-2. Navigate to the root of the `edge-addition-planarity-suite` repository (i.e. the directory containing `configure.ac` and the `c` subdirectory)
-3. Get into `bash` (e.g., type `bash` in the Windows command-line), then enter the following commands:
+1. Ensure that the `autotools`, `configure`, and `make` are available on the command-line (e.g. add `C:\msys64\usr\bin` to the system `PATH` before Windows Program Files to ensure that the `find` program is the one from `MSYS2` rather than the one from Windows (e.g. adjust the `PATH` variable as needed)). 
+2. Open the MSYS2 UCRT64 terminal app and navigate to the root of the `edge-addition-planarity-suite` repository (i.e. the directory containing `configure.ac` and the `c` subdirectory)
+3. Enter the following commands:
     1. `./autogen.sh`
     2. `./configure`
     3. `make dist`

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Please refer to the [2. Dev Setup](https://github.com/graph-algorithms/edge-addi
 Once one has set up the development environment and is able to work with the code in the development environment, it is possible to make the distribution with the following additional steps:
 
 1. Ensure that the `autotools`, `configure`, and `make` are available on the command-line (e.g. add `C:\msys64\usr\bin` to the system `PATH` before Windows Program Files to ensure that the `find` program is the one from `MSYS2` rather than the one from Windows (e.g. adjust the `PATH` variable as needed)). 
-2. Open the MSYS2 UCRT64 terminal app and navigate to the root of the `edge-addition-planarity-suite` repository (i.e. the directory containing `configure.ac` and the `c` subdirectory)
+2. Open the start menu and start typing "MSYS2 UCRT64" to open the correct terminal app, then navigate to the root of the `edge-addition-planarity-suite` repository (i.e. the directory containing `configure.ac` and the `c` subdirectory)
 3. Enter the following commands:
     1. `./autogen.sh`
     2. `./configure`

--- a/devEnvSetupAndDefaults/.vscode/launch.json
+++ b/devEnvSetupAndDefaults/.vscode/launch.json
@@ -38,7 +38,7 @@
             "environment": [],
             "externalConsole": true,
             "MIMode": "gdb",
-            "miDebuggerPath": "C:\\MinGW\\bin\\gdb.exe",
+            "miDebuggerPath": "C:\\msys64\\ucrt64\\bin\\gdb.exe",
             "setupCommands": [
                 {
                     "description": "Enable pretty-printing for gdb",
@@ -73,7 +73,7 @@
             "environment": [],
             "externalConsole": true,
             "MIMode": "gdb",
-            "miDebuggerPath": "C:\\MinGW\\bin\\gdb.exe",
+            "miDebuggerPath": "C:\\msys64\\ucrt64\\bin\\gdb.exe",
             "setupCommands": [],
             "preLaunchTask": "C/C++: (Windows) [Release] gcc.exe build planarity project"
         },

--- a/devEnvSetupAndDefaults/.vscode/tasks.json
+++ b/devEnvSetupAndDefaults/.vscode/tasks.json
@@ -3,7 +3,7 @@
         {
             "type": "cppbuild",
             "label": "C/C++: (Windows) [Debug] gcc.exe build planarity project",
-            "command": "C:\\MinGW\\bin\\gcc.exe",
+            "command": "C:\\msys64\\ucrt64\\bin\\gcc.exe",
             "args": [
                 "-fdiagnostics-color=always",
                 "-DDEBUG", // Added so that _DEBUG is defined; see appconst.h
@@ -32,7 +32,7 @@
         {
             "type": "cppbuild",
             "label": "C/C++: (Windows) [Release] gcc.exe build planarity project",
-            "command": "C:\\MinGW\\bin\\gcc.exe",
+            "command": "C:\\msys64\\ucrt64\\bin\\gcc.exe",
             "args": [
                 "-O3",
                 "-Wall",


### PR DESCRIPTION
Resolves #102 

_**N.B.**_ One must follow the updated [2. Dev Setup](https://github.com/graph-algorithms/edge-addition-planarity-suite/wiki/2.-Dev-Setup) steps to install MSYS2 and then install the MinGW-w64 toolchain.

## Updated
* `devEnvSetupAndDefaults/.vscode/tasks.json` - update `command` to use the `gcc.exe` installed as part of the MinGW-w64 toolchain
* `devEnvSetupAndDefaults/.vscode/launch.json` - update `miDebuggerPath` to use the `gdb.exe` installed as part of the MinGW-w64 toolchain 
* `README.md` - Instruct users to perform steps to build the distribution using the MSYS2 UCRT64 terminal app.

---

Confirmed that the distribution build process outlined in `README.md` successfully produces the expected `.tar.gz`.

Additionally, successfully hit breakpoints (e.g. within `planarityTestAllGraphs.c`) with the Debug executable and was able to run the Release executable from VSCode.