### PR TITLE
Issue #120 -  Fixing how we determine whether the OS is Windows so that `FILE_DELIMETER` is correctly defined for MSVC `cl`

### DIFF
--- a/c/graphLib/lowLevelUtils/appconst.h
+++ b/c/graphLib/lowLevelUtils/appconst.h
@@ -11,7 +11,7 @@ See the LICENSE.TXT file for licensing information.
 
 // NOTE: This is defined on 32- and 64-bit Windows systems; see
 // https://sourceforge.net/p/predef/wiki/OperatingSystems
-#ifdef _WIN32
+#if defined(WIN32) || defined(_WIN32)
 #define WINDOWS
 #endif
 

--- a/c/graphLib/lowLevelUtils/appconst.h
+++ b/c/graphLib/lowLevelUtils/appconst.h
@@ -9,7 +9,9 @@ See the LICENSE.TXT file for licensing information.
 
 #include "apiutils.h"
 
-#ifdef WIN32
+// NOTE: This is defined on 32- and 64-bit Windows systems; see
+// https://sourceforge.net/p/predef/wiki/OperatingSystems
+#ifdef _WIN32
 #define WINDOWS
 #endif
 

--- a/c/graphLib/lowLevelUtils/platformTime.h
+++ b/c/graphLib/lowLevelUtils/platformTime.h
@@ -7,20 +7,23 @@ All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */
 
-#ifdef WIN32
+// NOTE: Since platformTime.h is only #include'd by appconst.h, and since appconst.h
+// #define's WINDOWS before including platformTime.h, we condition on WINDOWS being defined.
+#ifdef WINDOWS
 
 #include <windows.h>
 #include <winbase.h>
 
 #define platform_time DWORD
 #define platform_GetTime(timeVar) (timeVar = GetTickCount())
-#define platform_GetDuration(startTime, endTime) ((double) (endTime-startTime) / 1000.0)
+#define platform_GetDuration(startTime, endTime) ((double)(endTime - startTime) / 1000.0)
 
 #else
 
 #include <time.h>
 
-typedef struct {
+typedef struct
+{
 	clock_t hiresTime;
 	time_t lowresTime;
 } platform_time;
@@ -32,9 +35,7 @@ typedef struct {
 // If we're getting a duration longer than that, then we fall back to the coarser time() measure
 
 #define platform_GetDuration(startTime, endTime) ( \
-		( (double) (endTime.lowresTime - startTime.lowresTime) ) > 2000 ? \
-		( (double) (endTime.lowresTime - startTime.lowresTime) ) : \
-		( (double) (endTime.hiresTime - startTime.hiresTime)) / CLOCKS_PER_SEC)
+	((double)(endTime.lowresTime - startTime.lowresTime)) > 2000 ? ((double)(endTime.lowresTime - startTime.lowresTime)) : ((double)(endTime.hiresTime - startTime.hiresTime)) / CLOCKS_PER_SEC)
 
 /*
 #define platform_time clock_t

--- a/devEnvSetupAndDefaults/.vscode/tasks.json
+++ b/devEnvSetupAndDefaults/.vscode/tasks.json
@@ -131,6 +131,8 @@
                 "/wd4774", // Ignore warnings about format string not being a string literal; requires developer caution!
                 "/wd4996", // Ignore safety warnings about sprintf, scanf, strcpy, strcat, fopen, etc.
                 "/wd5045", // Ignore Spectre mitigation warning
+                "/external:anglebrackets",
+                "/external:W0", // Ignore warnings thrown by external headers
                 "/Fe${workspaceFolder}\\Debug\\planarity.exe",
                 "${workspaceFolder}\\c\\planarityApp\\**.c",
                 "${workspaceFolder}\\c\\graphLib\\**.c",
@@ -165,6 +167,8 @@
                 "/wd4774", // Ignore warnings about format string not being a string literal; requires developer caution!
                 "/wd4996", // Ignore safety warnings about sprintf, scanf, strcpy, strcat, fopen, etc.
                 "/wd5045", // Ignore Spectre mitigation warning
+                "/external:anglebrackets",
+                "/external:W0", // Ignore warnings thrown by external headers
                 "/Fe${workspaceFolder}\\Release\\planarity.exe",
                 "${workspaceFolder}\\c\\planarityApp\\**.c",
                 "${workspaceFolder}\\c\\graphLib\\**.c",


### PR DESCRIPTION
Resolves #120 

## Summary

`FILE_DELIMETER` was being defined incorrectly due to incorrect OS check, which caused `outputTestAllGraphsResults()` in `planarityTestAllGraphs.c` to fail in finding the `finalSlash` within `infileName`.

## Updated
* `c/graphLib/lowLevelUtils/appconst.h` - Should check if `_WIN32` is defined to determine if the OS is Windows according to the Pre-defined Compiler Macros Wiki page on [Operating Systems](https://sourceforge.net/p/predef/wiki/OperatingSystems/), which itself links to [64-Bit Compiler - Predefined macros](https://learn.microsoft.com/en-us/windows-hardware/drivers/kernel/64-bit-compiler?redirectedfrom=MSDN#predefined-macros).
* `c/graphLib/lowLevelUtils/platformTime.h` - should check against `WINDOWS` rather than `WIN32` for the above reason, as well as the fact that `platformTime.h` is only `#include`'d by `appconst.h`, which `#define`'s `WINDOWS` before including `platformTime.h`
* `devEnvSetupAndDefaults/.vscode/tasks.json` - added warning switches to ignore warnings thrown by external headers