### PR TITLE
Issue #98 - Build format string to use with `scanf()` when prompting user for filenames in `TransformGraphMenu()` and `TestAllGraphsMenu()`

### DIFF
--- a/c/planarityApp/planarity.h
+++ b/c/planarityApp/planarity.h
@@ -68,6 +68,8 @@ extern "C"
     int ConstructTransformationExpectedResultFilename(char *infileName, char **outfileName, char command, int actualOrExpectedFlag);
     void WriteAlgorithmResults(graphP theGraph, int Result, char command, platform_time start, platform_time end, char *infileName);
 
+    int GetNumCharsToReprInt(int theNum);
+
 #ifdef __cplusplus
 }
 #endif

--- a/c/planarityApp/planarityMenu.c
+++ b/c/planarityApp/planarityMenu.c
@@ -109,11 +109,15 @@ void TransformGraphMenu(void)
     char commandStr[4];
     commandStr[0] = '\0';
 
+    char *fileNameFormatFormat = " %%%d[^\r\n]";
+    char *fileNameFormat = (char *)malloc((strlen(fileNameFormatFormat) + GetNumCharsToReprInt(MAXLINE) + 1) * sizeof(char));
+    sprintf(fileNameFormat, fileNameFormatFormat, MAXLINE);
+
     do
     {
         Prompt("Enter input filename:\n");
         fflush(stdin);
-        fgets(infileName, MAXLINE, stdin);
+        scanf(fileNameFormat, infileName);
 
         if (strncmp(infileName, "stdin", 5) == 0)
         {
@@ -122,12 +126,9 @@ void TransformGraphMenu(void)
         }
     } while (strlen(infileName) == 0);
 
-    infileName[strcspn(infileName, "\n\r")] = '\0';
-
     Prompt("Enter output filename, or press return to output to console:\n");
     fflush(stdin);
-    fgets(outfileName, MAXLINE, stdin);
-    outfileName[strcspn(outfileName, "\n\r")] = '\0';
+    scanf(fileNameFormat, outfileName);
 
     do
     {
@@ -179,11 +180,15 @@ void TestAllGraphsMenu(void)
     char commandStr[3];
     commandStr[0] = '\0';
 
+    char *fileNameFormatFormat = " %%%d[^\r\n]";
+    char *fileNameFormat = (char *)malloc((strlen(fileNameFormatFormat) + GetNumCharsToReprInt(MAXLINE) + 1) * sizeof(char));
+    sprintf(fileNameFormat, fileNameFormatFormat, MAXLINE);
+
     do
     {
         Prompt("Enter input filename:\n");
         fflush(stdin);
-        fgets(infileName, MAXLINE, stdin);
+        scanf(fileNameFormat, infileName);
 
         if (strncmp(infileName, "stdin", 5) == 0)
         {
@@ -192,12 +197,9 @@ void TestAllGraphsMenu(void)
         }
     } while (strlen(infileName) == 0);
 
-    infileName[strcspn(infileName, "\n\r")] = '\0';
-
     Prompt("Enter output filename, or press return to output to console:\n");
     fflush(stdin);
-    fgets(outfileName, MAXLINE, stdin);
-    outfileName[strcspn(outfileName, "\n\r")] = '\0';
+    scanf(fileNameFormat, outfileName);
 
     do
     {

--- a/c/planarityApp/planarityUtils.c
+++ b/c/planarityApp/planarityUtils.c
@@ -646,3 +646,13 @@ int ConstructTransformationExpectedResultFilename(char *infileName, char **outfi
 
 	return Result;
 }
+
+int GetNumCharsToReprInt(int theNum)
+{
+	int numCharsRequired = 1;
+
+	while (theNum /= 10)
+		numCharsRequired++;
+
+	return numCharsRequired;
+}


### PR DESCRIPTION
Resolves #98 

## Updated
* `c/planarityApp/planarityMenu.c` - When prompting users for filenames, I first construct a format string that limits the number of characters being read using `scanf()`, then pass this constructed format string to `scanf()` when trying to populate `infileName` and `outfileName` in both `TransformGraphMenu()` and `TestAllGraphsMenu()`

_**N.B.**_ The changes to `c/planarityApp/planarity.h` and `c/planarityApp/planarityUtils.c` are changes that will come from merging #131 

---

Verified both Transform Graph and Test All Graphs menu interactions on MacOS (`clang`), Windows (MinGW-w64 `gcc` and MSVC `cl`), and Debian Linux (`gcc`).