### PR TITLE
Issue #27 and #104 - Formatted C source files and headers, plus batch scripts

### DIFF
--- a/TestSupport/generate_graphs.bat
+++ b/TestSupport/generate_graphs.bat
@@ -7,7 +7,7 @@ SET graphOutputDir="E:\graphs"
 
 SET /A N=11
 IF NOT "%1"=="" (
-	SET N=%1
+    SET N=%1
 )
 
 SET /A MAXM = (%N% * (%N% - 1^)) / 2
@@ -16,5 +16,5 @@ IF NOT EXIST "%graphOutputDir%\%N%" mkdir "%graphOutputDir%\%N%"
 
 REM Make sure to update the path to the geng executable and the directory to which you wish to write the generated graphs
 FOR /L %%M IN (0,1,%MAXM%) DO (
-	START /B "geng%%M" %gengPath% %N% %%M:%%M > "%graphOutputDir%\%N%\n%N%.m%%M.g6"
+    START /B "geng%%M" %gengPath% %N% %%M:%%M > "%graphOutputDir%\%N%\n%N%.m%%M.g6"
 )

--- a/TestSupport/planarity_runner.bat
+++ b/TestSupport/planarity_runner.bat
@@ -12,9 +12,9 @@ SET outputDir="C:\Users\wbkbo\git\edge-addition-planarity-suite-fork\TestSupport
 SET /A N=11
 SET C=p
 IF NOT "%1"=="" (
-	SET N=%1
-	IF NOT "%2"=="" (
-		SET C=%2
+    SET N=%1
+    IF NOT "%2"=="" (
+        SET C=%2
     )
 )
 
@@ -23,5 +23,5 @@ IF NOT EXIST "%outputDir%\%N%\%C%" mkdir "%outputDir%\%N%\%C%"
 SET /A MAXM = (%N% * (%N% - 1^)) / 2
 
 FOR /L %%M IN (0,1,%MAXM%) DO (
-	CALL %planarityPath% -t -%C% "%graphFilesDir%\%N%\test.n%N%.m%%M.g6" "%outputDir%\%N%\%C%\n%N%.m%%M.%C%.out.txt"
+    CALL %planarityPath% -t -%C% "%graphFilesDir%\%N%\test.n%N%.m%%M.g6" "%outputDir%\%N%\%C%\n%N%.m%%M.%C%.out.txt"
 )

--- a/c/graphLib/extensionSystem/graphExtensions.private.h
+++ b/c/graphLib/extensionSystem/graphExtensions.private.h
@@ -10,22 +10,23 @@ See the LICENSE.TXT file for licensing information.
 #include "graphFunctionTable.h"
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-typedef struct
-{
-    int  moduleID;
-    void *context;
-    void *(*dupContext)(void *, void *);
-    void (*freeContext)(void *);
+    typedef struct
+    {
+        int moduleID;
+        void *context;
+        void *(*dupContext)(void *, void *);
+        void (*freeContext)(void *);
 
-    graphFunctionTableP functions;
+        graphFunctionTableP functions;
 
-    struct graphExtension *next;
-} graphExtension;
+        struct graphExtension *next;
+    } graphExtension;
 
-typedef graphExtension * graphExtensionP;
+    typedef graphExtension *graphExtensionP;
 
 #ifdef __cplusplus
 }

--- a/c/graphLib/graph.h
+++ b/c/graphLib/graph.h
@@ -21,67 +21,67 @@ extern "C"
 
 #include "extensionSystem/graphExtensions.h"
 
-	///////////////////////////////////////////////////////////////////////////////
-	// Definitions for higher-order operations at the vertex, edge and graph levels
-	///////////////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////////
+    // Definitions for higher-order operations at the vertex, edge and graph levels
+    ///////////////////////////////////////////////////////////////////////////////
 
-	graphP gp_New(void);
+    graphP gp_New(void);
 
-	int gp_InitGraph(graphP theGraph, int N);
-	void gp_ReinitializeGraph(graphP theGraph);
-	int gp_CopyAdjacencyLists(graphP dstGraph, graphP srcGraph);
-	int gp_CopyGraph(graphP dstGraph, graphP srcGraph);
-	graphP gp_DupGraph(graphP theGraph);
+    int gp_InitGraph(graphP theGraph, int N);
+    void gp_ReinitializeGraph(graphP theGraph);
+    int gp_CopyAdjacencyLists(graphP dstGraph, graphP srcGraph);
+    int gp_CopyGraph(graphP dstGraph, graphP srcGraph);
+    graphP gp_DupGraph(graphP theGraph);
 
-	int gp_CreateRandomGraph(graphP theGraph);
-	int gp_CreateRandomGraphEx(graphP theGraph, int numEdges);
+    int gp_CreateRandomGraph(graphP theGraph);
+    int gp_CreateRandomGraphEx(graphP theGraph, int numEdges);
 
-	void gp_Free(graphP *pGraph);
+    void gp_Free(graphP *pGraph);
 
-	int gp_Read(graphP theGraph, char *FileName);
-	int gp_ReadFromString(graphP theGraph, char *inputStr);
+    int gp_Read(graphP theGraph, char *FileName);
+    int gp_ReadFromString(graphP theGraph, char *inputStr);
 
 #define WRITE_ADJLIST 1
 #define WRITE_ADJMATRIX 2
 #define WRITE_DEBUGINFO 3
 #define WRITE_G6 4
 
-	int gp_Write(graphP theGraph, char *FileName, int Mode);
-	int gp_WriteToString(graphP theGraph, char **pOutputStr, int Mode);
+    int gp_Write(graphP theGraph, char *FileName, int Mode);
+    int gp_WriteToString(graphP theGraph, char **pOutputStr, int Mode);
 
-	int gp_IsNeighbor(graphP theGraph, int u, int v);
-	int gp_GetNeighborEdgeRecord(graphP theGraph, int u, int v);
-	int gp_GetVertexDegree(graphP theGraph, int v);
-	int gp_GetVertexInDegree(graphP theGraph, int v);
-	int gp_GetVertexOutDegree(graphP theGraph, int v);
+    int gp_IsNeighbor(graphP theGraph, int u, int v);
+    int gp_GetNeighborEdgeRecord(graphP theGraph, int u, int v);
+    int gp_GetVertexDegree(graphP theGraph, int v);
+    int gp_GetVertexInDegree(graphP theGraph, int v);
+    int gp_GetVertexOutDegree(graphP theGraph, int v);
 
-	int gp_GetArcCapacity(graphP theGraph);
-	int gp_EnsureArcCapacity(graphP theGraph, int requiredArcCapacity);
+    int gp_GetArcCapacity(graphP theGraph);
+    int gp_EnsureArcCapacity(graphP theGraph, int requiredArcCapacity);
 
-	int gp_AddEdge(graphP theGraph, int u, int ulink, int v, int vlink);
-	int gp_DynamicAddEdge(graphP theGraph, int u, int ulink, int v, int vlink);
-	int gp_InsertEdge(graphP theGraph, int u, int e_u, int e_ulink,
-					  int v, int e_v, int e_vlink);
+    int gp_AddEdge(graphP theGraph, int u, int ulink, int v, int vlink);
+    int gp_DynamicAddEdge(graphP theGraph, int u, int ulink, int v, int vlink);
+    int gp_InsertEdge(graphP theGraph, int u, int e_u, int e_ulink,
+                      int v, int e_v, int e_vlink);
 
-	void gp_HideEdge(graphP theGraph, int e);
-	void gp_RestoreEdge(graphP theGraph, int e);
-	int gp_HideVertex(graphP theGraph, int vertex);
-	int gp_DeleteEdge(graphP theGraph, int e, int nextLink);
+    void gp_HideEdge(graphP theGraph, int e);
+    void gp_RestoreEdge(graphP theGraph, int e);
+    int gp_HideVertex(graphP theGraph, int vertex);
+    int gp_DeleteEdge(graphP theGraph, int e, int nextLink);
 
-	int gp_ContractEdge(graphP theGraph, int e);
-	int gp_IdentifyVertices(graphP theGraph, int u, int v, int eBefore);
-	int gp_RestoreVertices(graphP theGraph);
+    int gp_ContractEdge(graphP theGraph, int e);
+    int gp_IdentifyVertices(graphP theGraph, int u, int v, int eBefore);
+    int gp_RestoreVertices(graphP theGraph);
 
-	int gp_CreateDFSTree(graphP theGraph);
-	int gp_SortVertices(graphP theGraph);
-	int gp_LowpointAndLeastAncestor(graphP theGraph);
-	int gp_PreprocessForEmbedding(graphP theGraph);
+    int gp_CreateDFSTree(graphP theGraph);
+    int gp_SortVertices(graphP theGraph);
+    int gp_LowpointAndLeastAncestor(graphP theGraph);
+    int gp_PreprocessForEmbedding(graphP theGraph);
 
-	int gp_Embed(graphP theGraph, int embedFlags);
-	int gp_TestEmbedResultIntegrity(graphP theGraph, graphP origGraph, int embedResult);
+    int gp_Embed(graphP theGraph, int embedFlags);
+    int gp_TestEmbedResultIntegrity(graphP theGraph, graphP origGraph, int embedResult);
 
-	/* Possible Flags for gp_Embed.  The planar and outerplanar settings are supported
-		natively.  The rest require extension modules. */
+    /* Possible Flags for gp_Embed.  The planar and outerplanar settings are supported
+        natively.  The rest require extension modules. */
 
 #define EMBEDFLAGS_PLANAR 1
 #define EMBEDFLAGS_OUTERPLANAR 2
@@ -99,9 +99,9 @@ extern "C"
 #define EMBEDFLAGS_TOROIDAL 1024
 
 /* If LOGGING is defined, then write to the log, otherwise no-op
-	By default, neither release nor DEBUG builds including LOGGING.
-	Logging is useful for seeing details of how various algorithms
-	handle a particular graph. */
+    By default, neither release nor DEBUG builds including LOGGING.
+    Logging is useful for seeing details of how various algorithms
+    handle a particular graph. */
 
 // #define LOGGING
 #ifdef LOGGING
@@ -109,8 +109,8 @@ extern "C"
 #define gp_LogLine _LogLine
 #define gp_Log _Log
 
-	void _LogLine(char *Line);
-	void _Log(char *Line);
+    void _LogLine(char *Line);
+    void _Log(char *Line);
 
 #define gp_MakeLogStr1 _MakeLogStr1
 #define gp_MakeLogStr2 _MakeLogStr2
@@ -118,11 +118,11 @@ extern "C"
 #define gp_MakeLogStr4 _MakeLogStr4
 #define gp_MakeLogStr5 _MakeLogStr5
 
-	char *_MakeLogStr1(char *format, int);
-	char *_MakeLogStr2(char *format, int, int);
-	char *_MakeLogStr3(char *format, int, int, int);
-	char *_MakeLogStr4(char *format, int, int, int, int);
-	char *_MakeLogStr5(char *format, int, int, int, int, int);
+    char *_MakeLogStr1(char *format, int);
+    char *_MakeLogStr2(char *format, int, int);
+    char *_MakeLogStr3(char *format, int, int, int);
+    char *_MakeLogStr4(char *format, int, int, int, int);
+    char *_MakeLogStr5(char *format, int, int, int, int, int);
 
 #else
 #define gp_LogLine(Line)

--- a/c/graphLib/graphStructures.h
+++ b/c/graphLib/graphStructures.h
@@ -32,37 +32,37 @@ extern "C"
 // before calling gp_InitGraph() or gp_Read().
 #define DEFAULT_EDGE_LIMIT 3
 
-	/********************************************************************
-	 Edge Record Definition
+    /********************************************************************
+     Edge Record Definition
 
-	 An edge is defined by a pair of edge records, or arcs, allocated in
-	 array E of a graph.  An edge record represents the edge in the
-	 adjacency list of each vertex to which the edge is incident.
+     An edge is defined by a pair of edge records, or arcs, allocated in
+     array E of a graph.  An edge record represents the edge in the
+     adjacency list of each vertex to which the edge is incident.
 
-	 link[2]: the next and previous edge records (arcs) in the adjacency
-			  list that contains this edge record.
+     link[2]: the next and previous edge records (arcs) in the adjacency
+              list that contains this edge record.
 
-	 v: The vertex neighbor of the vertex whose adjacency list contains
-		this edge record (an index into array V).
+     v: The vertex neighbor of the vertex whose adjacency list contains
+        this edge record (an index into array V).
 
-	 flags: Bits 0-15 reserved for library; bits 16 and higher for apps
-			Bit 0: Visited
-			Bit 1: DFS type has been set, versus not set
-			Bit 2: DFS tree edge, versus cycle edge (co-tree edge, etc.)
-			Bit 3: DFS arc to descendant, versus arc to ancestor
-			Bit 4: Inverted (same as marking an edge with a "sign" of -1)
-			Bit 5: Arc is directed into the containing vertex only
-			Bit 6: Arc is directed from the containing vertex only
-	 ********************************************************************/
+     flags: Bits 0-15 reserved for library; bits 16 and higher for apps
+            Bit 0: Visited
+            Bit 1: DFS type has been set, versus not set
+            Bit 2: DFS tree edge, versus cycle edge (co-tree edge, etc.)
+            Bit 3: DFS arc to descendant, versus arc to ancestor
+            Bit 4: Inverted (same as marking an edge with a "sign" of -1)
+            Bit 5: Arc is directed into the containing vertex only
+            Bit 6: Arc is directed from the containing vertex only
+     ********************************************************************/
 
-	typedef struct
-	{
-		int link[2];
-		int neighbor;
-		unsigned flags;
-	} edgeRec;
+    typedef struct
+    {
+        int link[2];
+        int neighbor;
+        unsigned flags;
+    } edgeRec;
 
-	typedef edgeRec *edgeRecP;
+    typedef edgeRec *edgeRecP;
 
 #if NIL == 0
 #define gp_IsArc(e) (e)
@@ -129,7 +129,7 @@ extern "C"
 #define gp_ClearEdgeType(theGraph, e) (theGraph->E[e].flags &= ~EDGE_TYPE_MASK)
 #define gp_SetEdgeType(theGraph, e, type) (theGraph->E[e].flags |= type)
 #define gp_ResetEdgeType(theGraph, e, type) \
-	(theGraph->E[e].flags = (theGraph->E[e].flags & ~EDGE_TYPE_MASK) | type)
+    (theGraph->E[e].flags = (theGraph->E[e].flags & ~EDGE_TYPE_MASK) | type)
 
 #define EDGEFLAG_INVERTED_MASK 16
 #define gp_GetEdgeFlagInverted(theGraph, e) (theGraph->E[e].flags & EDGEFLAG_INVERTED_MASK)
@@ -147,68 +147,68 @@ extern "C"
 // A direction of 0 clears directedness. Otherwise, edge record e is set
 // to edgeFlag_Direction and e's twin arc is set to the opposing setting.
 #define gp_SetDirection(theGraph, e, edgeFlag_Direction)                                       \
-	{                                                                                          \
-		if (edgeFlag_Direction == EDGEFLAG_DIRECTION_INONLY)                                   \
-		{                                                                                      \
-			theGraph->E[e].flags |= EDGEFLAG_DIRECTION_INONLY;                                 \
-			theGraph->E[gp_GetTwinArc(theGraph, e)].flags |= EDGEFLAG_DIRECTION_OUTONLY;       \
-		}                                                                                      \
-		else if (edgeFlag_Direction == EDGEFLAG_DIRECTION_OUTONLY)                             \
-		{                                                                                      \
-			theGraph->E[e].flags |= EDGEFLAG_DIRECTION_OUTONLY;                                \
-			theGraph->E[gp_GetTwinArc(theGraph, e)].flags |= EDGEFLAG_DIRECTION_INONLY;        \
-		}                                                                                      \
-		else                                                                                   \
-		{                                                                                      \
-			theGraph->E[e].flags &= ~(EDGEFLAG_DIRECTION_INONLY | EDGEFLAG_DIRECTION_OUTONLY); \
-			theGraph->E[gp_GetTwinArc(theGraph, e)].flags &= ~EDGEFLAG_DIRECTION_MASK;         \
-		}                                                                                      \
-	}
+    {                                                                                          \
+        if (edgeFlag_Direction == EDGEFLAG_DIRECTION_INONLY)                                   \
+        {                                                                                      \
+            theGraph->E[e].flags |= EDGEFLAG_DIRECTION_INONLY;                                 \
+            theGraph->E[gp_GetTwinArc(theGraph, e)].flags |= EDGEFLAG_DIRECTION_OUTONLY;       \
+        }                                                                                      \
+        else if (edgeFlag_Direction == EDGEFLAG_DIRECTION_OUTONLY)                             \
+        {                                                                                      \
+            theGraph->E[e].flags |= EDGEFLAG_DIRECTION_OUTONLY;                                \
+            theGraph->E[gp_GetTwinArc(theGraph, e)].flags |= EDGEFLAG_DIRECTION_INONLY;        \
+        }                                                                                      \
+        else                                                                                   \
+        {                                                                                      \
+            theGraph->E[e].flags &= ~(EDGEFLAG_DIRECTION_INONLY | EDGEFLAG_DIRECTION_OUTONLY); \
+            theGraph->E[gp_GetTwinArc(theGraph, e)].flags &= ~EDGEFLAG_DIRECTION_MASK;         \
+        }                                                                                      \
+    }
 
 #define gp_CopyEdgeRec(dstGraph, edst, srcGraph, esrc) (dstGraph->E[edst] = srcGraph->E[esrc])
 
-	/********************************************************************
-	 Vertex Record Definition
+    /********************************************************************
+     Vertex Record Definition
 
-	 This record definition provides the data members needed for the
-	 core structural information for both vertices and virtual vertices.
-	 Vertices are also equipped with additional information provided by
-	 the vertexInfo structure.
+     This record definition provides the data members needed for the
+     core structural information for both vertices and virtual vertices.
+     Vertices are also equipped with additional information provided by
+     the vertexInfo structure.
 
-	 The vertices of a graph are stored in the first N locations of array V.
-	 Virtual vertices are secondary vertices used to help represent the
-	 main vertices in substructural components of a graph (e.g. biconnected
-	 components).
+     The vertices of a graph are stored in the first N locations of array V.
+     Virtual vertices are secondary vertices used to help represent the
+     main vertices in substructural components of a graph (e.g. biconnected
+     components).
 
-	 link[2]: the first and last edge records (arcs) in the adjacency list
-			  of the vertex.
+     link[2]: the first and last edge records (arcs) in the adjacency list
+              of the vertex.
 
-	 index: In vertices, stores either the depth first index of a vertex or
-			the original array index of the vertex if the vertices of the
-			graph are sorted by DFI.
-			In virtual vertices, the index may be used to indicate the vertex
-			that the virtual vertex represents, unless an algorithm has some
-			other way of making the association (for example, the planarity
-			algorithms rely on biconnected components and therefore place
-			virtual vertices of a vertex at positions corresponding to the
-			DFS children of the vertex).
+     index: In vertices, stores either the depth first index of a vertex or
+            the original array index of the vertex if the vertices of the
+            graph are sorted by DFI.
+            In virtual vertices, the index may be used to indicate the vertex
+            that the virtual vertex represents, unless an algorithm has some
+            other way of making the association (for example, the planarity
+            algorithms rely on biconnected components and therefore place
+            virtual vertices of a vertex at positions corresponding to the
+            DFS children of the vertex).
 
-	 flags: Bits 0-15 reserved for library; bits 16 and higher for apps
-			Bit 0: visited, for vertices and virtual vertices
-					Use in lieu of TYPE_VERTEX_VISITED in K4 algorithm
-			Bit 1: Obstruction type VERTEX_TYPE_SET (versus not set, i.e. VERTEX_TYPE_UNKNOWN)
-			Bit 2: Obstruction type qualifier RYW (set) versus RXW (clear)
-			Bit 3: Obstruction type qualifier high (set) versus low (clear)
-	 ********************************************************************/
+     flags: Bits 0-15 reserved for library; bits 16 and higher for apps
+            Bit 0: visited, for vertices and virtual vertices
+                    Use in lieu of TYPE_VERTEX_VISITED in K4 algorithm
+            Bit 1: Obstruction type VERTEX_TYPE_SET (versus not set, i.e. VERTEX_TYPE_UNKNOWN)
+            Bit 2: Obstruction type qualifier RYW (set) versus RXW (clear)
+            Bit 3: Obstruction type qualifier high (set) versus low (clear)
+     ********************************************************************/
 
-	typedef struct
-	{
-		int link[2];
-		int index;
-		unsigned flags;
-	} vertexRec;
+    typedef struct
+    {
+        int link[2];
+        int index;
+        unsigned flags;
+    } vertexRec;
 
-	typedef vertexRec *vertexRecP;
+    typedef vertexRec *vertexRecP;
 
 // Accessors for vertex adjacency list links
 #define gp_GetFirstArc(theGraph, v) (theGraph->V[v].link[0])
@@ -312,101 +312,101 @@ extern "C"
 #define gp_ClearVertexObstructionType(theGraph, v) (theGraph->V[v].flags &= ~VERTEX_OBSTRUCTIONTYPE_MASK)
 #define gp_SetVertexObstructionType(theGraph, v, type) (theGraph->V[v].flags |= type)
 #define gp_ResetVertexObstructionType(theGraph, v, type) \
-	(theGraph->V[v].flags = (theGraph->V[v].flags & ~VERTEX_OBSTRUCTIONTYPE_MASK) | type)
+    (theGraph->V[v].flags = (theGraph->V[v].flags & ~VERTEX_OBSTRUCTIONTYPE_MASK) | type)
 
 #define gp_CopyVertexRec(dstGraph, vdst, srcGraph, vsrc) (dstGraph->V[vdst] = srcGraph->V[vsrc])
 
 #define gp_SwapVertexRec(dstGraph, vdst, srcGraph, vsrc) \
-	{                                                    \
-		vertexRec tempV = dstGraph->V[vdst];             \
-		dstGraph->V[vdst] = srcGraph->V[vsrc];           \
-		srcGraph->V[vsrc] = tempV;                       \
-	}
+    {                                                    \
+        vertexRec tempV = dstGraph->V[vdst];             \
+        dstGraph->V[vdst] = srcGraph->V[vsrc];           \
+        srcGraph->V[vsrc] = tempV;                       \
+    }
 
-	/********************************************************************
-	 This structure defines a pair of links used by each vertex and virtual vertex
-	 to create "short circuit" paths that eliminate unimportant vertices from
-	 the external face, enabling more efficient traversal of the external face.
+    /********************************************************************
+     This structure defines a pair of links used by each vertex and virtual vertex
+     to create "short circuit" paths that eliminate unimportant vertices from
+     the external face, enabling more efficient traversal of the external face.
 
-	 It is also possible to embed the "short circuit" edges, but this approach
-	 creates a better separation of concerns, imparts greater clarity, and
-	 removes exceptionalities for handling additional fake "short circuit" edges.
+     It is also possible to embed the "short circuit" edges, but this approach
+     creates a better separation of concerns, imparts greater clarity, and
+     removes exceptionalities for handling additional fake "short circuit" edges.
 
-	 vertex[2]: The two adjacent vertices along the external face, possibly
-				short-circuiting paths of inactive vertices.
-	*/
+     vertex[2]: The two adjacent vertices along the external face, possibly
+                short-circuiting paths of inactive vertices.
+    */
 
-	typedef struct
-	{
-		int vertex[2];
-	} extFaceLinkRec;
+    typedef struct
+    {
+        int vertex[2];
+    } extFaceLinkRec;
 
-	typedef extFaceLinkRec *extFaceLinkRecP;
+    typedef extFaceLinkRec *extFaceLinkRecP;
 
 #define gp_GetExtFaceVertex(theGraph, v, link) (theGraph->extFace[v].vertex[link])
 #define gp_SetExtFaceVertex(theGraph, v, link, theVertex) (theGraph->extFace[v].vertex[link] = theVertex)
 
-	/********************************************************************
-	 Vertex Info Structure Definition.
+    /********************************************************************
+     Vertex Info Structure Definition.
 
-	 This structure equips the primary (non-virtual) vertices with additional
-	 information needed for lowpoint and planarity-related algorithms.
+     This structure equips the primary (non-virtual) vertices with additional
+     information needed for lowpoint and planarity-related algorithms.
 
-		parent: The DFI of the DFS tree parent of this vertex
-		leastAncestor: min(DFI of neighbors connected by backedge)
-		lowpoint: min(leastAncestor, min(lowpoint of DFS Children))
+        parent: The DFI of the DFS tree parent of this vertex
+        leastAncestor: min(DFI of neighbors connected by backedge)
+        lowpoint: min(leastAncestor, min(lowpoint of DFS Children))
 
-		visitedInfo: enables algorithms to manage vertex visitation with more than
-					 just a flag.  For example, the planarity test flags visitation
-					 as a step number that implicitly resets on each step, whereas
-					 part of the planar drawing method signifies a first visitation
-					 by storing the index of the first edge used to reach a vertex
-		pertinentEdge: Used by the planarity method; during Walkup, each vertex
-					that is directly adjacent via a back edge to the vertex v
-					currently being embedded will have the forward edge's index
-					stored in this field.  During Walkdown, each vertex for which
-					this field is set will cause a back edge to be embedded.
-					Implicitly resets at each vertex step of the planarity method
-		pertinentRootsList: used by Walkup to store a list of child bicomp roots of
-					a vertex descendant of the current vertex that are pertinent
-					and must be merged by the Walkdown in order to embed the cycle
-					edges of the current vertex.  Future pertinent child bicomp roots
-					are placed at the end of the list to ensure bicomps that are
-					only pertinent are processed first.
-		futurePertinentChild: indicates a DFS child with a lowpoint less than the
-					current vertex v.  This member is initialized to the start of
-					the sortedDFSChildList and is advanced in a relaxed manner as
-					needed until one with a lowpoint less than v is found or until
-					there are no more children.
-		sortedDFSChildList: at the start of embedding, the list of DFS children of
-					this vertex is calculated in ascending order by DFI (sorted in
-					linear time). The list is used during Walkdown processing of
-					a vertex to process all of its children.  It is also used in
-					future pertinence management when processing the ancestors of
-					the vertex. When a child C is merged into the same bicomp as
-					the vertex, it is removed from the list.
-		fwdArcList: at the start of embedding, the "back" edges from a vertex to
-					its DFS *descendants* (i.e. the forward arcs of the back edges)
-					are separated from the main adjacency list and placed in a
-					circular list until they are embedded. The list is sorted in
-					ascending DFI order of the descendants (in linear time).
-					This member indicates a node in that list.
-	*/
+        visitedInfo: enables algorithms to manage vertex visitation with more than
+                     just a flag.  For example, the planarity test flags visitation
+                     as a step number that implicitly resets on each step, whereas
+                     part of the planar drawing method signifies a first visitation
+                     by storing the index of the first edge used to reach a vertex
+        pertinentEdge: Used by the planarity method; during Walkup, each vertex
+                    that is directly adjacent via a back edge to the vertex v
+                    currently being embedded will have the forward edge's index
+                    stored in this field.  During Walkdown, each vertex for which
+                    this field is set will cause a back edge to be embedded.
+                    Implicitly resets at each vertex step of the planarity method
+        pertinentRootsList: used by Walkup to store a list of child bicomp roots of
+                    a vertex descendant of the current vertex that are pertinent
+                    and must be merged by the Walkdown in order to embed the cycle
+                    edges of the current vertex.  Future pertinent child bicomp roots
+                    are placed at the end of the list to ensure bicomps that are
+                    only pertinent are processed first.
+        futurePertinentChild: indicates a DFS child with a lowpoint less than the
+                    current vertex v.  This member is initialized to the start of
+                    the sortedDFSChildList and is advanced in a relaxed manner as
+                    needed until one with a lowpoint less than v is found or until
+                    there are no more children.
+        sortedDFSChildList: at the start of embedding, the list of DFS children of
+                    this vertex is calculated in ascending order by DFI (sorted in
+                    linear time). The list is used during Walkdown processing of
+                    a vertex to process all of its children.  It is also used in
+                    future pertinence management when processing the ancestors of
+                    the vertex. When a child C is merged into the same bicomp as
+                    the vertex, it is removed from the list.
+        fwdArcList: at the start of embedding, the "back" edges from a vertex to
+                    its DFS *descendants* (i.e. the forward arcs of the back edges)
+                    are separated from the main adjacency list and placed in a
+                    circular list until they are embedded. The list is sorted in
+                    ascending DFI order of the descendants (in linear time).
+                    This member indicates a node in that list.
+    */
 
-	typedef struct
-	{
-		int parent, leastAncestor, lowpoint;
+    typedef struct
+    {
+        int parent, leastAncestor, lowpoint;
 
-		int visitedInfo;
+        int visitedInfo;
 
-		int pertinentEdge,
-			pertinentRoots,
-			futurePertinentChild,
-			sortedDFSChildList,
-			fwdArcList;
-	} vertexInfo;
+        int pertinentEdge,
+            pertinentRoots,
+            futurePertinentChild,
+            sortedDFSChildList,
+            fwdArcList;
+    } vertexInfo;
 
-	typedef vertexInfo *vertexInfoP;
+    typedef vertexInfo *vertexInfoP;
 
 #define gp_GetVertexVisitedInfo(theGraph, v) (theGraph->VI[v].visitedInfo)
 #define gp_SetVertexVisitedInfo(theGraph, v, theVisitedInfo) (theGraph->VI[v].visitedInfo = theVisitedInfo)
@@ -432,16 +432,16 @@ extern "C"
 #define gp_GetVertexLastPertinentRootChild(theGraph, v) LCGetPrev(theGraph->BicompRootLists, theGraph->VI[v].pertinentRoots, NIL)
 
 #define gp_DeleteVertexPertinentRoot(theGraph, v, R) \
-	gp_SetVertexPertinentRootsList(theGraph, v,      \
-								   LCDelete(theGraph->BicompRootLists, gp_GetVertexPertinentRootsList(theGraph, v), gp_GetDFSChildFromRoot(theGraph, R)))
+    gp_SetVertexPertinentRootsList(theGraph, v,      \
+                                   LCDelete(theGraph->BicompRootLists, gp_GetVertexPertinentRootsList(theGraph, v), gp_GetDFSChildFromRoot(theGraph, R)))
 
 #define gp_PrependVertexPertinentRoot(theGraph, v, R) \
-	gp_SetVertexPertinentRootsList(theGraph, v,       \
-								   LCPrepend(theGraph->BicompRootLists, gp_GetVertexPertinentRootsList(theGraph, v), gp_GetDFSChildFromRoot(theGraph, R)))
+    gp_SetVertexPertinentRootsList(theGraph, v,       \
+                                   LCPrepend(theGraph->BicompRootLists, gp_GetVertexPertinentRootsList(theGraph, v), gp_GetDFSChildFromRoot(theGraph, R)))
 
 #define gp_AppendVertexPertinentRoot(theGraph, v, R) \
-	gp_SetVertexPertinentRootsList(theGraph, v,      \
-								   LCAppend(theGraph->BicompRootLists, gp_GetVertexPertinentRootsList(theGraph, v), gp_GetDFSChildFromRoot(theGraph, R)))
+    gp_SetVertexPertinentRootsList(theGraph, v,      \
+                                   LCAppend(theGraph->BicompRootLists, gp_GetVertexPertinentRootsList(theGraph, v), gp_GetDFSChildFromRoot(theGraph, R)))
 
 #define gp_GetVertexFuturePertinentChild(theGraph, v) (theGraph->VI[v].futurePertinentChild)
 #define gp_SetVertexFuturePertinentChild(theGraph, v, theFuturePertinentChild) (theGraph->VI[v].futurePertinentChild = theFuturePertinentChild)
@@ -450,18 +450,18 @@ extern "C"
 // Once futurePertinentChild advances past a child, no future planarity operation could make that child
 // relevant to future pertinence
 #define gp_UpdateVertexFuturePertinentChild(theGraph, w, v)                                             \
-	while (gp_IsVertex(theGraph->VI[w].futurePertinentChild))                                           \
-	{                                                                                                   \
-		/* Skip children that 1) aren't future pertinent, 2) have been merged into the bicomp with w */ \
-		if (gp_GetVertexLowpoint(theGraph, theGraph->VI[w].futurePertinentChild) >= v ||                \
-			gp_IsNotSeparatedDFSChild(theGraph, theGraph->VI[w].futurePertinentChild))                  \
-		{                                                                                               \
-			theGraph->VI[w].futurePertinentChild =                                                      \
-				gp_GetVertexNextDFSChild(theGraph, w, gp_GetVertexFuturePertinentChild(theGraph, w));   \
-		}                                                                                               \
-		else                                                                                            \
-			break;                                                                                      \
-	}
+    while (gp_IsVertex(theGraph->VI[w].futurePertinentChild))                                           \
+    {                                                                                                   \
+        /* Skip children that 1) aren't future pertinent, 2) have been merged into the bicomp with w */ \
+        if (gp_GetVertexLowpoint(theGraph, theGraph->VI[w].futurePertinentChild) >= v ||                \
+            gp_IsNotSeparatedDFSChild(theGraph, theGraph->VI[w].futurePertinentChild))                  \
+        {                                                                                               \
+            theGraph->VI[w].futurePertinentChild =                                                      \
+                gp_GetVertexNextDFSChild(theGraph, w, gp_GetVertexFuturePertinentChild(theGraph, w));   \
+        }                                                                                               \
+        else                                                                                            \
+            break;                                                                                      \
+    }
 
 #define gp_GetVertexSortedDFSChildList(theGraph, v) (theGraph->VI[v].sortedDFSChildList)
 #define gp_SetVertexSortedDFSChildList(theGraph, v, theSortedDFSChildList) (theGraph->VI[v].sortedDFSChildList = theSortedDFSChildList)
@@ -469,7 +469,7 @@ extern "C"
 #define gp_GetVertexNextDFSChild(theGraph, v, c) LCGetNext(theGraph->sortedDFSChildLists, gp_GetVertexSortedDFSChildList(theGraph, v), c)
 
 #define gp_AppendDFSChild(theGraph, v, c) \
-	LCAppend(theGraph->sortedDFSChildLists, gp_GetVertexSortedDFSChildList(theGraph, v), c)
+    LCAppend(theGraph->sortedDFSChildLists, gp_GetVertexSortedDFSChildList(theGraph, v), c)
 
 #define gp_GetVertexFwdArcList(theGraph, v) (theGraph->VI[v].fwdArcList)
 #define gp_SetVertexFwdArcList(theGraph, v, theFwdArcList) (theGraph->VI[v].fwdArcList = theFwdArcList)
@@ -477,39 +477,39 @@ extern "C"
 #define gp_CopyVertexInfo(dstGraph, dstI, srcGraph, srcI) (dstGraph->VI[dstI] = srcGraph->VI[srcI])
 
 #define gp_SwapVertexInfo(dstGraph, dstPos, srcGraph, srcPos) \
-	{                                                         \
-		vertexInfo tempVI = dstGraph->VI[dstPos];             \
-		dstGraph->VI[dstPos] = srcGraph->VI[srcPos];          \
-		srcGraph->VI[srcPos] = tempVI;                        \
-	}
+    {                                                         \
+        vertexInfo tempVI = dstGraph->VI[dstPos];             \
+        dstGraph->VI[dstPos] = srcGraph->VI[srcPos];          \
+        srcGraph->VI[srcPos] = tempVI;                        \
+    }
 
-	/********************************************************************
-	 Variables needed in embedding by Kuratowski subgraph isolator:
-			minorType: the type of planarity obstruction found.
-			v: the current vertex being processed
-			r: the root of the bicomp on which the Walkdown failed
-			x,y: stopping vertices on bicomp rooted by r
-			w: pertinent vertex on ext. face path below x and y
-			px, py: attachment points of x-y path,
-			z: Unused except in minors D and E (not needed in A, B, C).
+    /********************************************************************
+     Variables needed in embedding by Kuratowski subgraph isolator:
+            minorType: the type of planarity obstruction found.
+            v: the current vertex being processed
+            r: the root of the bicomp on which the Walkdown failed
+            x,y: stopping vertices on bicomp rooted by r
+            w: pertinent vertex on ext. face path below x and y
+            px, py: attachment points of x-y path,
+            z: Unused except in minors D and E (not needed in A, B, C).
 
-			ux,dx: endpoints of unembedded edge that helps connext x with
-					ancestor of v
-			uy,dy: endpoints of unembedded edge that helps connext y with
-					ancestor of v
-			dw: descendant endpoint in unembedded edge to v
-			uz,dz: endpoints of unembedded edge that helps connext z with
-					ancestor of v (for minors B and E, not A, C, D).
-	*/
+            ux,dx: endpoints of unembedded edge that helps connext x with
+                    ancestor of v
+            uy,dy: endpoints of unembedded edge that helps connext y with
+                    ancestor of v
+            dw: descendant endpoint in unembedded edge to v
+            uz,dz: endpoints of unembedded edge that helps connext z with
+                    ancestor of v (for minors B and E, not A, C, D).
+    */
 
-	typedef struct
-	{
-		int minorType;
-		int v, r, x, y, w, px, py, z;
-		int ux, dx, uy, dy, dw, uz, dz;
-	} isolatorContext;
+    typedef struct
+    {
+        int minorType;
+        int v, r, x, y, w, px, py, z;
+        int ux, dx, uy, dy, dw, uz, dz;
+    } isolatorContext;
 
-	typedef isolatorContext *isolatorContextP;
+    typedef isolatorContext *isolatorContextP;
 
 #define MINORTYPE_A 1
 #define MINORTYPE_B 2
@@ -525,69 +525,69 @@ extern "C"
 #define MINORTYPE_E6 1024
 #define MINORTYPE_E7 2048
 
-	/********************************************************************
-	 Graph structure definition
-			V : Array of vertex records (allocated size N + NV)
-			VI: Array of additional vertexInfo structures (allocated size N)
-			N : Number of primary vertices (the "order" of the graph)
-			NV: Number of virtual vertices (currently always equal to N)
+    /********************************************************************
+     Graph structure definition
+            V : Array of vertex records (allocated size N + NV)
+            VI: Array of additional vertexInfo structures (allocated size N)
+            N : Number of primary vertices (the "order" of the graph)
+            NV: Number of virtual vertices (currently always equal to N)
 
-			E : Array of edge records (edge records come in pairs and represent half edges, or arcs)
-			M: Number of edges (the "size" of the graph)
-			arcCapacity: the maximum number of edge records allowed in E (the size of E)
-			edgeHoles: free locations in E where edges have been deleted
+            E : Array of edge records (edge records come in pairs and represent half edges, or arcs)
+            M: Number of edges (the "size" of the graph)
+            arcCapacity: the maximum number of edge records allowed in E (the size of E)
+            edgeHoles: free locations in E where edges have been deleted
 
-			theStack: Used by various graph routines needing a stack
-			internalFlags: Additional state information about the graph
-			embedFlags: controls type of embedding (e.g. planar)
+            theStack: Used by various graph routines needing a stack
+            internalFlags: Additional state information about the graph
+            embedFlags: controls type of embedding (e.g. planar)
 
-			IC: contains additional useful variables for Kuratowski subgraph isolation.
-			BicompRootLists: storage space for pertinent bicomp root lists that develop
-							during embedding
-			sortedDFSChildLists: storage for the sorted DFS child lists of each vertex
-			extFace: Array of (N + NV) external face short circuit records
+            IC: contains additional useful variables for Kuratowski subgraph isolation.
+            BicompRootLists: storage space for pertinent bicomp root lists that develop
+                            during embedding
+            sortedDFSChildLists: storage for the sorted DFS child lists of each vertex
+            extFace: Array of (N + NV) external face short circuit records
 
-			extensions: a list of extension data structures
-			functions: a table of function pointers that can be overloaded to provide
-					   extension behaviors to the graph
-	*/
+            extensions: a list of extension data structures
+            functions: a table of function pointers that can be overloaded to provide
+                       extension behaviors to the graph
+    */
 
-	struct baseGraphStructure
-	{
-		vertexRecP V;
-		vertexInfoP VI;
-		int N, NV;
+    struct baseGraphStructure
+    {
+        vertexRecP V;
+        vertexInfoP VI;
+        int N, NV;
 
-		edgeRecP E;
-		int M, arcCapacity;
-		stackP edgeHoles;
+        edgeRecP E;
+        int M, arcCapacity;
+        stackP edgeHoles;
 
-		stackP theStack;
-		int internalFlags, embedFlags;
+        stackP theStack;
+        int internalFlags, embedFlags;
 
-		isolatorContext IC;
-		listCollectionP BicompRootLists, sortedDFSChildLists;
-		extFaceLinkRecP extFace;
+        isolatorContext IC;
+        listCollectionP BicompRootLists, sortedDFSChildLists;
+        extFaceLinkRecP extFace;
 
-		graphExtensionP extensions;
-		graphFunctionTable functions;
-	};
+        graphExtensionP extensions;
+        graphFunctionTable functions;
+    };
 
-	typedef struct baseGraphStructure baseGraphStructure;
-	typedef baseGraphStructure *graphP;
+    typedef struct baseGraphStructure baseGraphStructure;
+    typedef baseGraphStructure *graphP;
 
-	/* Flags for graph:
-			FLAGS_DFSNUMBERED is set if DFSNumber() has succeeded for the graph
-			FLAGS_SORTEDBYDFI records whether the graph is in original vertex
-					order or sorted by depth first index.  Successive calls to
-					SortVertices() toggle this bit.
-			FLAGS_OBSTRUCTIONFOUND is set by gp_Embed() if an embedding obstruction
-					was isolated in the graph returned.  It is cleared by gp_Embed()
-					if an obstruction was not found.  The flag is used by
-					gp_TestEmbedResultIntegrity() to decide what integrity tests to run.
-			FLAGS_ZEROBASEDIO is typically set by gp_Read() to indicate that the
-					adjacency list representation began with index 0.
-	*/
+    /* Flags for graph:
+            FLAGS_DFSNUMBERED is set if DFSNumber() has succeeded for the graph
+            FLAGS_SORTEDBYDFI records whether the graph is in original vertex
+                    order or sorted by depth first index.  Successive calls to
+                    SortVertices() toggle this bit.
+            FLAGS_OBSTRUCTIONFOUND is set by gp_Embed() if an embedding obstruction
+                    was isolated in the graph returned.  It is cleared by gp_Embed()
+                    if an obstruction was not found.  The flag is used by
+                    gp_TestEmbedResultIntegrity() to decide what integrity tests to run.
+            FLAGS_ZEROBASEDIO is typically set by gp_Read() to indicate that the
+                    adjacency list representation began with index 0.
+    */
 
 #define FLAGS_DFSNUMBERED 1
 #define FLAGS_SORTEDBYDFI 2
@@ -602,190 +602,190 @@ extern "C"
 // as if the adjacency list were circular, i.e. that the
 // first arc and last arc were linked
 #define gp_GetNextArcCircular(theGraph, e) \
-	(gp_IsArc(gp_GetNextArc(theGraph, e)) ? gp_GetNextArc(theGraph, e) : gp_GetFirstArc(theGraph, theGraph->E[gp_GetTwinArc(theGraph, e)].neighbor))
+    (gp_IsArc(gp_GetNextArc(theGraph, e)) ? gp_GetNextArc(theGraph, e) : gp_GetFirstArc(theGraph, theGraph->E[gp_GetTwinArc(theGraph, e)].neighbor))
 
 #define gp_GetPrevArcCircular(theGraph, e) \
-	(gp_IsArc(gp_GetPrevArc(theGraph, e)) ? gp_GetPrevArc(theGraph, e) : gp_GetLastArc(theGraph, theGraph->E[gp_GetTwinArc(theGraph, e)].neighbor))
+    (gp_IsArc(gp_GetPrevArc(theGraph, e)) ? gp_GetPrevArc(theGraph, e) : gp_GetLastArc(theGraph, theGraph->E[gp_GetTwinArc(theGraph, e)].neighbor))
 
 // Definitions that make the cross-link binding between a vertex and an arc
 // The old first or last arc should be bound to this arc by separate calls,
 // e.g. see gp_AttachFirstArc() and gp_AttachLastArc()
 #define gp_BindFirstArc(theGraph, v, arc)  \
-	{                                      \
-		gp_SetPrevArc(theGraph, arc, NIL); \
-		gp_SetFirstArc(theGraph, v, arc);  \
-	}
+    {                                      \
+        gp_SetPrevArc(theGraph, arc, NIL); \
+        gp_SetFirstArc(theGraph, v, arc);  \
+    }
 
 #define gp_BindLastArc(theGraph, v, arc)   \
-	{                                      \
-		gp_SetNextArc(theGraph, arc, NIL); \
-		gp_SetLastArc(theGraph, v, arc);   \
-	}
+    {                                      \
+        gp_SetNextArc(theGraph, arc, NIL); \
+        gp_SetLastArc(theGraph, v, arc);   \
+    }
 
 // Attaches an arc between the current binding between a vertex and its first arc
 #define gp_AttachFirstArc(theGraph, v, arc)                            \
-	{                                                                  \
-		if (gp_IsArc(gp_GetFirstArc(theGraph, v)))                     \
-		{                                                              \
-			gp_SetNextArc(theGraph, arc, gp_GetFirstArc(theGraph, v)); \
-			gp_SetPrevArc(theGraph, gp_GetFirstArc(theGraph, v), arc); \
-		}                                                              \
-		else                                                           \
-			gp_BindLastArc(theGraph, v, arc);                          \
-		gp_BindFirstArc(theGraph, v, arc);                             \
-	}
+    {                                                                  \
+        if (gp_IsArc(gp_GetFirstArc(theGraph, v)))                     \
+        {                                                              \
+            gp_SetNextArc(theGraph, arc, gp_GetFirstArc(theGraph, v)); \
+            gp_SetPrevArc(theGraph, gp_GetFirstArc(theGraph, v), arc); \
+        }                                                              \
+        else                                                           \
+            gp_BindLastArc(theGraph, v, arc);                          \
+        gp_BindFirstArc(theGraph, v, arc);                             \
+    }
 
 // Attaches an arc between the current binding betwen a vertex and its last arc
 #define gp_AttachLastArc(theGraph, v, arc)                            \
-	{                                                                 \
-		if (gp_IsArc(gp_GetLastArc(theGraph, v)))                     \
-		{                                                             \
-			gp_SetPrevArc(theGraph, arc, gp_GetLastArc(theGraph, v)); \
-			gp_SetNextArc(theGraph, gp_GetLastArc(theGraph, v), arc); \
-		}                                                             \
-		else                                                          \
-			gp_BindFirstArc(theGraph, v, arc);                        \
-		gp_BindLastArc(theGraph, v, arc);                             \
-	}
+    {                                                                 \
+        if (gp_IsArc(gp_GetLastArc(theGraph, v)))                     \
+        {                                                             \
+            gp_SetPrevArc(theGraph, arc, gp_GetLastArc(theGraph, v)); \
+            gp_SetNextArc(theGraph, gp_GetLastArc(theGraph, v), arc); \
+        }                                                             \
+        else                                                          \
+            gp_BindFirstArc(theGraph, v, arc);                        \
+        gp_BindLastArc(theGraph, v, arc);                             \
+    }
 
 // Moves an arc that is in the adjacency list of v to the start of the adjacency list
 #define gp_MoveArcToFirst(theGraph, v, arc)                                                      \
-	if (arc != gp_GetFirstArc(theGraph, v))                                                      \
-	{                                                                                            \
-		/* If the arc is last in the adjacency list of uparent,                                  \
-		   then we delete it by adjacency list end management */                                 \
-		if (arc == gp_GetLastArc(theGraph, v))                                                   \
-		{                                                                                        \
-			gp_SetNextArc(theGraph, gp_GetPrevArc(theGraph, arc), NIL);                          \
-			gp_SetLastArc(theGraph, v, gp_GetPrevArc(theGraph, arc));                            \
-		}                                                                                        \
-		/* Otherwise, we delete the arc from the middle of the list */                           \
-		else                                                                                     \
-		{                                                                                        \
-			gp_SetNextArc(theGraph, gp_GetPrevArc(theGraph, arc), gp_GetNextArc(theGraph, arc)); \
-			gp_SetPrevArc(theGraph, gp_GetNextArc(theGraph, arc), gp_GetPrevArc(theGraph, arc)); \
-		}                                                                                        \
+    if (arc != gp_GetFirstArc(theGraph, v))                                                      \
+    {                                                                                            \
+        /* If the arc is last in the adjacency list of uparent,                                  \
+           then we delete it by adjacency list end management */                                 \
+        if (arc == gp_GetLastArc(theGraph, v))                                                   \
+        {                                                                                        \
+            gp_SetNextArc(theGraph, gp_GetPrevArc(theGraph, arc), NIL);                          \
+            gp_SetLastArc(theGraph, v, gp_GetPrevArc(theGraph, arc));                            \
+        }                                                                                        \
+        /* Otherwise, we delete the arc from the middle of the list */                           \
+        else                                                                                     \
+        {                                                                                        \
+            gp_SetNextArc(theGraph, gp_GetPrevArc(theGraph, arc), gp_GetNextArc(theGraph, arc)); \
+            gp_SetPrevArc(theGraph, gp_GetNextArc(theGraph, arc), gp_GetPrevArc(theGraph, arc)); \
+        }                                                                                        \
                                                                                                  \
-		/* Now add arc e as the new first arc of uparent.                                        \
-		   Note that the adjacency list is non-empty at this time */                             \
-		gp_SetNextArc(theGraph, arc, gp_GetFirstArc(theGraph, v));                               \
-		gp_SetPrevArc(theGraph, gp_GetFirstArc(theGraph, v), arc);                               \
-		gp_BindFirstArc(theGraph, v, arc);                                                       \
-	}
+        /* Now add arc e as the new first arc of uparent.                                        \
+           Note that the adjacency list is non-empty at this time */                             \
+        gp_SetNextArc(theGraph, arc, gp_GetFirstArc(theGraph, v));                               \
+        gp_SetPrevArc(theGraph, gp_GetFirstArc(theGraph, v), arc);                               \
+        gp_BindFirstArc(theGraph, v, arc);                                                       \
+    }
 
 // Moves an arc that is in the adjacency list of v to the end of the adjacency list
 #define gp_MoveArcToLast(theGraph, v, arc)                                                       \
-	if (arc != gp_GetLastArc(theGraph, v))                                                       \
-	{                                                                                            \
-		/* If the arc is first in the adjacency list of vertex v,                                \
-		   then we delete it by adjacency list end management */                                 \
-		if (arc == gp_GetFirstArc(theGraph, v))                                                  \
-		{                                                                                        \
-			gp_SetPrevArc(theGraph, gp_GetNextArc(theGraph, arc), NIL);                          \
-			gp_SetFirstArc(theGraph, v, gp_GetNextArc(theGraph, arc));                           \
-		}                                                                                        \
-		/* Otherwise, we delete the arc from the middle of the list */                           \
-		else                                                                                     \
-		{                                                                                        \
-			gp_SetNextArc(theGraph, gp_GetPrevArc(theGraph, arc), gp_GetNextArc(theGraph, arc)); \
-			gp_SetPrevArc(theGraph, gp_GetNextArc(theGraph, arc), gp_GetPrevArc(theGraph, arc)); \
-		}                                                                                        \
+    if (arc != gp_GetLastArc(theGraph, v))                                                       \
+    {                                                                                            \
+        /* If the arc is first in the adjacency list of vertex v,                                \
+           then we delete it by adjacency list end management */                                 \
+        if (arc == gp_GetFirstArc(theGraph, v))                                                  \
+        {                                                                                        \
+            gp_SetPrevArc(theGraph, gp_GetNextArc(theGraph, arc), NIL);                          \
+            gp_SetFirstArc(theGraph, v, gp_GetNextArc(theGraph, arc));                           \
+        }                                                                                        \
+        /* Otherwise, we delete the arc from the middle of the list */                           \
+        else                                                                                     \
+        {                                                                                        \
+            gp_SetNextArc(theGraph, gp_GetPrevArc(theGraph, arc), gp_GetNextArc(theGraph, arc)); \
+            gp_SetPrevArc(theGraph, gp_GetNextArc(theGraph, arc), gp_GetPrevArc(theGraph, arc)); \
+        }                                                                                        \
                                                                                                  \
-		/* Now add the arc as the new last arc of v.                                             \
-		   Note that the adjacency list is non-empty at this time */                             \
-		gp_SetPrevArc(theGraph, arc, gp_GetLastArc(theGraph, v));                                \
-		gp_SetNextArc(theGraph, gp_GetLastArc(theGraph, v), arc);                                \
-		gp_BindLastArc(theGraph, v, arc);                                                        \
-	}
+        /* Now add the arc as the new last arc of v.                                             \
+           Note that the adjacency list is non-empty at this time */                             \
+        gp_SetPrevArc(theGraph, arc, gp_GetLastArc(theGraph, v));                                \
+        gp_SetNextArc(theGraph, gp_GetLastArc(theGraph, v), arc);                                \
+        gp_BindLastArc(theGraph, v, arc);                                                        \
+    }
 
-	// Methods for attaching an arc into the adjacency list or detaching an arc from it.
-	// The terms AddArc, InsertArc and DeleteArc are not used because the arcs are not
-	// inserted or added to or deleted from storage (only whole edges are inserted or deleted)
-	void gp_AttachArc(graphP theGraph, int v, int e, int link, int newArc);
-	void gp_DetachArc(graphP theGraph, int arc);
+    // Methods for attaching an arc into the adjacency list or detaching an arc from it.
+    // The terms AddArc, InsertArc and DeleteArc are not used because the arcs are not
+    // inserted or added to or deleted from storage (only whole edges are inserted or deleted)
+    void gp_AttachArc(graphP theGraph, int v, int e, int link, int newArc);
+    void gp_DetachArc(graphP theGraph, int arc);
 
-	/********************************************************************
-	 PERTINENT()
-	 A vertex is pertinent in a partially processed graph if there is an
-	 unprocessed back edge between the vertex v whose edges are currently
-	 being processed and either the vertex or a DFS descendant D of the
-	 vertex not in the same bicomp as the vertex.
+    /********************************************************************
+     PERTINENT()
+     A vertex is pertinent in a partially processed graph if there is an
+     unprocessed back edge between the vertex v whose edges are currently
+     being processed and either the vertex or a DFS descendant D of the
+     vertex not in the same bicomp as the vertex.
 
-	 The vertex is either directly adjacent to v by an unembedded back edge
-	 or there is an unembedded back edge (v, D) and the vertex is a cut
-	 vertex in the partially processed graph along the DFS tree path from
-	 D to v.
+     The vertex is either directly adjacent to v by an unembedded back edge
+     or there is an unembedded back edge (v, D) and the vertex is a cut
+     vertex in the partially processed graph along the DFS tree path from
+     D to v.
 
-	 Pertinence is a dynamic property that can change for a vertex after
-	 each edge addition.  In other words, a vertex can become non-pertinent
-	 during step v as more back edges to v are embedded.
-	 ********************************************************************/
+     Pertinence is a dynamic property that can change for a vertex after
+     each edge addition.  In other words, a vertex can become non-pertinent
+     during step v as more back edges to v are embedded.
+     ********************************************************************/
 
 #define PERTINENT(theGraph, theVertex)                           \
-	(gp_IsArc(gp_GetVertexPertinentEdge(theGraph, theVertex)) || \
-	 gp_IsVertex(gp_GetVertexPertinentRootsList(theGraph, theVertex)))
+    (gp_IsArc(gp_GetVertexPertinentEdge(theGraph, theVertex)) || \
+     gp_IsVertex(gp_GetVertexPertinentRootsList(theGraph, theVertex)))
 
 #define NOTPERTINENT(theGraph, theVertex)                           \
-	(gp_IsNotArc(gp_GetVertexPertinentEdge(theGraph, theVertex)) && \
-	 gp_IsNotVertex(gp_GetVertexPertinentRootsList(theGraph, theVertex)))
+    (gp_IsNotArc(gp_GetVertexPertinentEdge(theGraph, theVertex)) && \
+     gp_IsNotVertex(gp_GetVertexPertinentRootsList(theGraph, theVertex)))
 
-	/********************************************************************
-	 FUTUREPERTINENT()
-	 A vertex is future-pertinent in a partially processed graph if
-	 there is an unprocessed back edge between a DFS ancestor A of the
-	 vertex v whose edges are currently being processed and either
-	 theVertex or a DFS descendant D of theVertex not in the same bicomp
-	 as theVertex.
+    /********************************************************************
+     FUTUREPERTINENT()
+     A vertex is future-pertinent in a partially processed graph if
+     there is an unprocessed back edge between a DFS ancestor A of the
+     vertex v whose edges are currently being processed and either
+     theVertex or a DFS descendant D of theVertex not in the same bicomp
+     as theVertex.
 
-	 Either theVertex is directly adjacent to A by an unembedded back edge
-	 or there is an unembedded back edge (A, D) and theVertex is a cut
-	 vertex in the partially processed graph along the DFS tree path from
-	 D to A.
+     Either theVertex is directly adjacent to A by an unembedded back edge
+     or there is an unembedded back edge (A, D) and theVertex is a cut
+     vertex in the partially processed graph along the DFS tree path from
+     D to A.
 
-	 If no more edges are added to the partially processed graph prior to
-	 processing the edges of A, then the vertex would be pertinent.
-	 The addition of edges to the partially processed graph can alter
-	 both the pertinence and future pertinence of a vertex.  For example,
-	 if the vertex is pertinent due to an unprocessed back edge (v, D1) and
-	 future pertinent due to an unprocessed back edge (A, D2), then the
-	 vertex may lose both its pertinence and future pertinence when edge
-	 (v, D1) is added if D2 is in the same subtree as D1.
+     If no more edges are added to the partially processed graph prior to
+     processing the edges of A, then the vertex would be pertinent.
+     The addition of edges to the partially processed graph can alter
+     both the pertinence and future pertinence of a vertex.  For example,
+     if the vertex is pertinent due to an unprocessed back edge (v, D1) and
+     future pertinent due to an unprocessed back edge (A, D2), then the
+     vertex may lose both its pertinence and future pertinence when edge
+     (v, D1) is added if D2 is in the same subtree as D1.
 
-	 Generally, pertinence and future pertinence are dynamic properties
-	 that can change for a vertex after each edge addition.
+     Generally, pertinence and future pertinence are dynamic properties
+     that can change for a vertex after each edge addition.
 
-	 Note that gp_UpdateVertexFuturePertinentChild() must be called before
-	 this macro. Since it is a statement and not a void expression, the
-	 desired commented out version does not compile (except with special
-	 compiler extensions not assumed by this code).
-	 ********************************************************************/
+     Note that gp_UpdateVertexFuturePertinentChild() must be called before
+     this macro. Since it is a statement and not a void expression, the
+     desired commented out version does not compile (except with special
+     compiler extensions not assumed by this code).
+     ********************************************************************/
 
 #define FUTUREPERTINENT(theGraph, theVertex, v)                    \
-	(theGraph->VI[theVertex].leastAncestor < v ||                  \
-	 (gp_IsVertex(theGraph->VI[theVertex].futurePertinentChild) && \
-	  theGraph->VI[theGraph->VI[theVertex].futurePertinentChild].lowpoint < v))
+    (theGraph->VI[theVertex].leastAncestor < v ||                  \
+     (gp_IsVertex(theGraph->VI[theVertex].futurePertinentChild) && \
+      theGraph->VI[theGraph->VI[theVertex].futurePertinentChild].lowpoint < v))
 
 #define NOTFUTUREPERTINENT(theGraph, theVertex, v)                    \
-	(theGraph->VI[theVertex].leastAncestor >= v &&                    \
-	 (gp_IsNotVertex(theGraph->VI[theVertex].futurePertinentChild) || \
-	  theGraph->VI[theGraph->VI[theVertex].futurePertinentChild].lowpoint >= v))
+    (theGraph->VI[theVertex].leastAncestor >= v &&                    \
+     (gp_IsNotVertex(theGraph->VI[theVertex].futurePertinentChild) || \
+      theGraph->VI[theGraph->VI[theVertex].futurePertinentChild].lowpoint >= v))
 
-	// This is the definition that would be preferrable if a while loop could be a void expression
-	// #define FUTUREPERTINENT(theGraph, theVertex, v)
-	//        (  theGraph->VI[theVertex].leastAncestor < v ||
-	//           ((gp_UpdateVertexFuturePertinentChild(theGraph, theVertex, v),
-	//        	   gp_IsArc(theGraph->VI[theVertex].futurePertinentChild)) &&
-	//             theGraph->VI[theGraph->VI[theVertex].futurePertinentChild].lowpoint < v) )
+    // This is the definition that would be preferrable if a while loop could be a void expression
+    // #define FUTUREPERTINENT(theGraph, theVertex, v)
+    //        (  theGraph->VI[theVertex].leastAncestor < v ||
+    //           ((gp_UpdateVertexFuturePertinentChild(theGraph, theVertex, v),
+    //             gp_IsArc(theGraph->VI[theVertex].futurePertinentChild)) &&
+    //             theGraph->VI[theGraph->VI[theVertex].futurePertinentChild].lowpoint < v) )
 
-	/********************************************************************
-	 INACTIVE()
-	 For planarity algorithms, a vertex is inactive if it is neither pertinent
-	 nor future pertinent.
-	 ********************************************************************/
+    /********************************************************************
+     INACTIVE()
+     For planarity algorithms, a vertex is inactive if it is neither pertinent
+     nor future pertinent.
+     ********************************************************************/
 
 #define INACTIVE(theGraph, theVertex, v)  \
-	(NOTPERTINENT(theGraph, theVertex) && \
-	 NOTFUTUREPERTINENT(theGraph, theVertex, v))
+    (NOTPERTINENT(theGraph, theVertex) && \
+     NOTFUTUREPERTINENT(theGraph, theVertex, v))
 
 #ifdef __cplusplus
 }

--- a/c/graphLib/homeomorphSearch/graphK23Search_Extensions.c
+++ b/c/graphLib/homeomorphSearch/graphK23Search_Extensions.c
@@ -9,19 +9,19 @@ See the LICENSE.TXT file for licensing information.
 #include "graphK23Search.private.h"
 #include "graphK23Search.h"
 
-extern int  _SearchForK23InBicomp(graphP theGraph, int v, int R);
+extern int _SearchForK23InBicomp(graphP theGraph, int v, int R);
 
-extern int  _TestForK23GraphObstruction(graphP theGraph, int *degrees, int *imageVerts);
-extern int  _getImageVertices(graphP theGraph, int *degrees, int maxDegree,
-                              int *imageVerts, int maxNumImageVerts);
-extern int  _TestSubgraph(graphP theSubgraph, graphP theGraph);
+extern int _TestForK23GraphObstruction(graphP theGraph, int *degrees, int *imageVerts);
+extern int _getImageVertices(graphP theGraph, int *degrees, int maxDegree,
+                             int *imageVerts, int maxNumImageVerts);
+extern int _TestSubgraph(graphP theSubgraph, graphP theGraph);
 
 /* Forward declarations of overloading functions */
 
-int  _K23Search_HandleBlockedBicomp(graphP theGraph, int v, int RootVertex, int R);
-int  _K23Search_EmbedPostprocess(graphP theGraph, int v, int edgeEmbeddingResult);
-int  _K23Search_CheckEmbeddingIntegrity(graphP theGraph, graphP origGraph);
-int  _K23Search_CheckObstructionIntegrity(graphP theGraph, graphP origGraph);
+int _K23Search_HandleBlockedBicomp(graphP theGraph, int v, int RootVertex, int R);
+int _K23Search_EmbedPostprocess(graphP theGraph, int v, int edgeEmbeddingResult);
+int _K23Search_CheckEmbeddingIntegrity(graphP theGraph, graphP origGraph);
+int _K23Search_CheckObstructionIntegrity(graphP theGraph, graphP origGraph);
 
 /* Forward declarations of functions used by the extension system */
 
@@ -43,46 +43,46 @@ int K23SEARCH_ID = 0;
  feature.
  ****************************************************************************/
 
-int  gp_AttachK23Search(graphP theGraph)
+int gp_AttachK23Search(graphP theGraph)
 {
-     K23SearchContext *context = NULL;
+    K23SearchContext *context = NULL;
 
-     // If the K2,3 search feature has already been attached to the graph
-     // then there is no need to attach it again
-     gp_FindExtension(theGraph, K23SEARCH_ID, (void *)&context);
-     if (context != NULL)
-     {
-         return OK;
-     }
+    // If the K2,3 search feature has already been attached to the graph
+    // then there is no need to attach it again
+    gp_FindExtension(theGraph, K23SEARCH_ID, (void *)&context);
+    if (context != NULL)
+    {
+        return OK;
+    }
 
-     // Allocate a new extension context
-     context = (K23SearchContext *) malloc(sizeof(K23SearchContext));
-     if (context == NULL)
-     {
-         return NOTOK;
-     }
+    // Allocate a new extension context
+    context = (K23SearchContext *)malloc(sizeof(K23SearchContext));
+    if (context == NULL)
+    {
+        return NOTOK;
+    }
 
-     // Put the overload functions into the context function table.
-     // gp_AddExtension will overload the graph's functions with these, and
-     // return the base function pointers in the context function table
-     memset(&context->functions, 0, sizeof(graphFunctionTable));
+    // Put the overload functions into the context function table.
+    // gp_AddExtension will overload the graph's functions with these, and
+    // return the base function pointers in the context function table
+    memset(&context->functions, 0, sizeof(graphFunctionTable));
 
-     context->functions.fpHandleBlockedBicomp = _K23Search_HandleBlockedBicomp;
-     context->functions.fpEmbedPostprocess = _K23Search_EmbedPostprocess;
-     context->functions.fpCheckEmbeddingIntegrity = _K23Search_CheckEmbeddingIntegrity;
-     context->functions.fpCheckObstructionIntegrity = _K23Search_CheckObstructionIntegrity;
+    context->functions.fpHandleBlockedBicomp = _K23Search_HandleBlockedBicomp;
+    context->functions.fpEmbedPostprocess = _K23Search_EmbedPostprocess;
+    context->functions.fpCheckEmbeddingIntegrity = _K23Search_CheckEmbeddingIntegrity;
+    context->functions.fpCheckObstructionIntegrity = _K23Search_CheckObstructionIntegrity;
 
-     // Store the K23 search context, including the data structure and the
-     // function pointers, as an extension of the graph
-     if (gp_AddExtension(theGraph, &K23SEARCH_ID, (void *) context,
-                         _K23Search_DupContext, _K23Search_FreeContext,
-                         &context->functions) != OK)
-     {
-         _K23Search_FreeContext(context);
-         return NOTOK;
-     }
+    // Store the K23 search context, including the data structure and the
+    // function pointers, as an extension of the graph
+    if (gp_AddExtension(theGraph, &K23SEARCH_ID, (void *)context,
+                        _K23Search_DupContext, _K23Search_FreeContext,
+                        &context->functions) != OK)
+    {
+        _K23Search_FreeContext(context);
+        return NOTOK;
+    }
 
-     return OK;
+    return OK;
 }
 
 /********************************************************************
@@ -100,15 +100,15 @@ int gp_DetachK23Search(graphP theGraph)
 
 void *_K23Search_DupContext(void *pContext, void *theGraph)
 {
-     K23SearchContext *context = (K23SearchContext *) pContext;
-     K23SearchContext *newContext = (K23SearchContext *) malloc(sizeof(K23SearchContext));
+    K23SearchContext *context = (K23SearchContext *)pContext;
+    K23SearchContext *newContext = (K23SearchContext *)malloc(sizeof(K23SearchContext));
 
-     if (newContext != NULL)
-     {
-         *newContext = *context;
-     }
+    if (newContext != NULL)
+    {
+        *newContext = *context;
+    }
 
-     return newContext;
+    return newContext;
 }
 
 /********************************************************************
@@ -117,28 +117,28 @@ void *_K23Search_DupContext(void *pContext, void *theGraph)
 
 void _K23Search_FreeContext(void *pContext)
 {
-     free(pContext);
+    free(pContext);
 }
 
 /********************************************************************
  ********************************************************************/
 
-int  _K23Search_HandleBlockedBicomp(graphP theGraph, int v, int RootVertex, int R)
+int _K23Search_HandleBlockedBicomp(graphP theGraph, int v, int RootVertex, int R)
 {
     if (theGraph->embedFlags == EMBEDFLAGS_SEARCHFORK23)
     {
-		// If R is the root of a descendant bicomp of v, we push it, but then we know the search for K2,3
-    	// will be successful and return NONEMBEDDABLE because this condition corresponds to minor A, which
-    	// is a K2,3.  Thus, an "OK to proceed with Walkdown searching elsewhere" result cannot happen,
-    	// so we don't have to test for it to detect if we have to pop these two back off the stack.
-    	if (R != RootVertex)
-    	    sp_Push2(theGraph->theStack, R, 0);
+        // If R is the root of a descendant bicomp of v, we push it, but then we know the search for K2,3
+        // will be successful and return NONEMBEDDABLE because this condition corresponds to minor A, which
+        // is a K2,3.  Thus, an "OK to proceed with Walkdown searching elsewhere" result cannot happen,
+        // so we don't have to test for it to detect if we have to pop these two back off the stack.
+        if (R != RootVertex)
+            sp_Push2(theGraph->theStack, R, 0);
 
-    	// The possible results here are NONEMBEDDABLE if a K2,3 homeomorph is found, or OK if only
-    	// a K4 was found and unblocked such that it is OK for the Walkdown to continue searching
-    	// elsewhere.  Note that the OK result can only happen if RootVertex==R since minor E can only
-    	// happen on a child bicomp of vertex v, not a descendant bicomp.
-    	return _SearchForK23InBicomp(theGraph, v, R);
+        // The possible results here are NONEMBEDDABLE if a K2,3 homeomorph is found, or OK if only
+        // a K4 was found and unblocked such that it is OK for the Walkdown to continue searching
+        // elsewhere.  Note that the OK result can only happen if RootVertex==R since minor E can only
+        // happen on a child bicomp of vertex v, not a descendant bicomp.
+        return _SearchForK23InBicomp(theGraph, v, R);
     }
 
     else
@@ -158,18 +158,18 @@ int  _K23Search_HandleBlockedBicomp(graphP theGraph, int v, int RootVertex, int 
 /********************************************************************
  ********************************************************************/
 
-int  _K23Search_EmbedPostprocess(graphP theGraph, int v, int edgeEmbeddingResult)
+int _K23Search_EmbedPostprocess(graphP theGraph, int v, int edgeEmbeddingResult)
 {
-     // For K2,3 search, we just return the edge embedding result because the
-     // search result has been obtained already.
-     if (theGraph->embedFlags == EMBEDFLAGS_SEARCHFORK23)
-     {
-         return edgeEmbeddingResult;
-     }
+    // For K2,3 search, we just return the edge embedding result because the
+    // search result has been obtained already.
+    if (theGraph->embedFlags == EMBEDFLAGS_SEARCHFORK23)
+    {
+        return edgeEmbeddingResult;
+    }
 
-     // When not searching for K2,3, we let the superclass do the work
-     else
-     {
+    // When not searching for K2,3, we let the superclass do the work
+    else
+    {
         K23SearchContext *context = NULL;
         gp_FindExtension(theGraph, K23SEARCH_ID, (void *)&context);
 
@@ -177,24 +177,24 @@ int  _K23Search_EmbedPostprocess(graphP theGraph, int v, int edgeEmbeddingResult
         {
             return context->functions.fpEmbedPostprocess(theGraph, v, edgeEmbeddingResult);
         }
-     }
+    }
 
-     return NOTOK;
+    return NOTOK;
 }
 
 /********************************************************************
  ********************************************************************/
 
-int  _K23Search_CheckEmbeddingIntegrity(graphP theGraph, graphP origGraph)
+int _K23Search_CheckEmbeddingIntegrity(graphP theGraph, graphP origGraph)
 {
-     if (theGraph->embedFlags == EMBEDFLAGS_SEARCHFORK23)
-     {
-         return OK;
-     }
+    if (theGraph->embedFlags == EMBEDFLAGS_SEARCHFORK23)
+    {
+        return OK;
+    }
 
-     // When not searching for K2,3, we let the superclass do the work
-     else
-     {
+    // When not searching for K2,3, we let the superclass do the work
+    else
+    {
         K23SearchContext *context = NULL;
         gp_FindExtension(theGraph, K23SEARCH_ID, (void *)&context);
 
@@ -202,39 +202,39 @@ int  _K23Search_CheckEmbeddingIntegrity(graphP theGraph, graphP origGraph)
         {
             return context->functions.fpCheckEmbeddingIntegrity(theGraph, origGraph);
         }
-     }
+    }
 
-     return NOTOK;
+    return NOTOK;
 }
 
 /********************************************************************
  ********************************************************************/
 
-int  _K23Search_CheckObstructionIntegrity(graphP theGraph, graphP origGraph)
+int _K23Search_CheckObstructionIntegrity(graphP theGraph, graphP origGraph)
 {
-     // When searching for K2,3, we ensure that theGraph is a subgraph of
-     // the original graph and that it contains a K2,3 homeomorph
-     if (theGraph->embedFlags == EMBEDFLAGS_SEARCHFORK23)
-     {
-         int  degrees[4], imageVerts[5];
+    // When searching for K2,3, we ensure that theGraph is a subgraph of
+    // the original graph and that it contains a K2,3 homeomorph
+    if (theGraph->embedFlags == EMBEDFLAGS_SEARCHFORK23)
+    {
+        int degrees[4], imageVerts[5];
 
-         if (_TestSubgraph(theGraph, origGraph) != TRUE)
-             return NOTOK;
+        if (_TestSubgraph(theGraph, origGraph) != TRUE)
+            return NOTOK;
 
-         if (_getImageVertices(theGraph, degrees, 3, imageVerts, 5) != OK)
-             return NOTOK;
+        if (_getImageVertices(theGraph, degrees, 3, imageVerts, 5) != OK)
+            return NOTOK;
 
-         if (_TestForK23GraphObstruction(theGraph, degrees, imageVerts) == TRUE)
-         {
-             return OK;
-         }
+        if (_TestForK23GraphObstruction(theGraph, degrees, imageVerts) == TRUE)
+        {
+            return OK;
+        }
 
-         return NOTOK;
-     }
+        return NOTOK;
+    }
 
-     // When not searching for K2,3, we let the superclass do the work
-     else
-     {
+    // When not searching for K2,3, we let the superclass do the work
+    else
+    {
         K23SearchContext *context = NULL;
         gp_FindExtension(theGraph, K23SEARCH_ID, (void *)&context);
 
@@ -242,7 +242,7 @@ int  _K23Search_CheckObstructionIntegrity(graphP theGraph, graphP origGraph)
         {
             return context->functions.fpCheckObstructionIntegrity(theGraph, origGraph);
         }
-     }
+    }
 
-     return NOTOK;
+    return NOTOK;
 }

--- a/c/graphLib/homeomorphSearch/graphK33Search.c
+++ b/c/graphLib/homeomorphSearch/graphK33Search.c
@@ -353,7 +353,7 @@ int _RunExtraK33Tests(graphP theGraph, K33SearchContext *context)
                 with Minor E4.  */
 
     // Prior tests to choose the type of non-planarity minor selected the highest
-    // x-y path, so we need to clear the visited flags of that path before marking 
+    // x-y path, so we need to clear the visited flags of that path before marking
     // instead the x-y path with the lowest attachment points (those closest to W
     // along the external face).
     if (_ClearVisitedFlagsInBicomp(theGraph, IC->r) != OK)
@@ -385,8 +385,8 @@ int _RunExtraK33Tests(graphP theGraph, K33SearchContext *context)
     // Since the E4 test above has already marked the lowest X-Y path, and only
     // the lowest one could possibly have a Z-to-W path attached to it, we
     // simply reuse the x-y path from E4 here in the E5 test.
-    // (NOTE: Only the lowest X-Y path could have a Z-to-W path because all 
-    //        bicomps are planar embeddings, and so a Z-to-W path emanating 
+    // (NOTE: Only the lowest X-Y path could have a Z-to-W path because all
+    //        bicomps are planar embeddings, and so a Z-to-W path emanating
     //        from a higher X-Y path would cross the lowest one, violating the
     //        planarity of the bicomp).
     if (_TestForZtoWPath(theGraph) != OK)

--- a/c/graphLib/homeomorphSearch/graphK33Search_Extensions.c
+++ b/c/graphLib/homeomorphSearch/graphK33Search_Extensions.c
@@ -9,40 +9,40 @@ See the LICENSE.TXT file for licensing information.
 #include "graphK33Search.private.h"
 #include "graphK33Search.h"
 
-extern int  _SearchForMergeBlocker(graphP theGraph, K33SearchContext *context, int v, int *pMergeBlocker);
-extern int  _FindK33WithMergeBlocker(graphP theGraph, K33SearchContext *context, int v, int mergeBlocker);
-extern int  _SearchForK33InBicomp(graphP theGraph, K33SearchContext *context, int v, int R);
+extern int _SearchForMergeBlocker(graphP theGraph, K33SearchContext *context, int v, int *pMergeBlocker);
+extern int _FindK33WithMergeBlocker(graphP theGraph, K33SearchContext *context, int v, int mergeBlocker);
+extern int _SearchForK33InBicomp(graphP theGraph, K33SearchContext *context, int v, int R);
 
-extern int  _TestForK33GraphObstruction(graphP theGraph, int *degrees, int *imageVerts);
-extern int  _getImageVertices(graphP theGraph, int *degrees, int maxDegree,
-                              int *imageVerts, int maxNumImageVerts);
-extern int  _TestSubgraph(graphP theSubgraph, graphP theGraph);
+extern int _TestForK33GraphObstruction(graphP theGraph, int *degrees, int *imageVerts);
+extern int _getImageVertices(graphP theGraph, int *degrees, int maxDegree,
+                             int *imageVerts, int maxNumImageVerts);
+extern int _TestSubgraph(graphP theSubgraph, graphP theGraph);
 
 /* Forward declarations of local functions */
 
 void _K33Search_ClearStructures(K33SearchContext *context);
-int  _K33Search_CreateStructures(K33SearchContext *context);
-int  _K33Search_InitStructures(K33SearchContext *context);
+int _K33Search_CreateStructures(K33SearchContext *context);
+int _K33Search_InitStructures(K33SearchContext *context);
 
 void _K33Search_InitEdgeRec(K33SearchContext *context, int e);
 void _K33Search_InitVertexInfo(K33SearchContext *context, int v);
 
 /* Forward declarations of overloading functions */
 
-int  _K33Search_EmbeddingInitialize(graphP theGraph);
+int _K33Search_EmbeddingInitialize(graphP theGraph);
 void _CreateBackArcLists(graphP theGraph, K33SearchContext *context);
 void _CreateSeparatedDFSChildLists(graphP theGraph, K33SearchContext *context);
 void _K33Search_EmbedBackEdgeToDescendant(graphP theGraph, int RootSide, int RootVertex, int W, int WPrevLink);
-int  _K33Search_MergeBicomps(graphP theGraph, int v, int RootVertex, int W, int WPrevLink);
+int _K33Search_MergeBicomps(graphP theGraph, int v, int RootVertex, int W, int WPrevLink);
 void _K33Search_MergeVertex(graphP theGraph, int W, int WPrevLink, int R);
-int  _K33Search_HandleBlockedBicomp(graphP theGraph, int v, int RootVertex, int R);
-int  _K33Search_EmbedPostprocess(graphP theGraph, int v, int edgeEmbeddingResult);
-int  _K33Search_CheckEmbeddingIntegrity(graphP theGraph, graphP origGraph);
-int  _K33Search_CheckObstructionIntegrity(graphP theGraph, graphP origGraph);
+int _K33Search_HandleBlockedBicomp(graphP theGraph, int v, int RootVertex, int R);
+int _K33Search_EmbedPostprocess(graphP theGraph, int v, int edgeEmbeddingResult);
+int _K33Search_CheckEmbeddingIntegrity(graphP theGraph, graphP origGraph);
+int _K33Search_CheckObstructionIntegrity(graphP theGraph, graphP origGraph);
 
-int  _K33Search_InitGraph(graphP theGraph, int N);
+int _K33Search_InitGraph(graphP theGraph, int N);
 void _K33Search_ReinitializeGraph(graphP theGraph);
-int  _K33Search_EnsureArcCapacity(graphP theGraph, int requiredArcCapacity);
+int _K33Search_EnsureArcCapacity(graphP theGraph, int requiredArcCapacity);
 
 /* Forward declarations of functions used by the extension system */
 
@@ -64,78 +64,78 @@ int K33SEARCH_ID = 0;
  feature.
  ****************************************************************************/
 
-int  gp_AttachK33Search(graphP theGraph)
+int gp_AttachK33Search(graphP theGraph)
 {
-     K33SearchContext *context = NULL;
+    K33SearchContext *context = NULL;
 
-     // If the K3,3 search feature has already been attached to the graph,
-     // then there is no need to attach it again
-     gp_FindExtension(theGraph, K33SEARCH_ID, (void *)&context);
-     if (context != NULL)
-     {
-         return OK;
-     }
+    // If the K3,3 search feature has already been attached to the graph,
+    // then there is no need to attach it again
+    gp_FindExtension(theGraph, K33SEARCH_ID, (void *)&context);
+    if (context != NULL)
+    {
+        return OK;
+    }
 
-     // Allocate a new extension context
-     context = (K33SearchContext *) malloc(sizeof(K33SearchContext));
-     if (context == NULL)
-     {
-         return NOTOK;
-     }
+    // Allocate a new extension context
+    context = (K33SearchContext *)malloc(sizeof(K33SearchContext));
+    if (context == NULL)
+    {
+        return NOTOK;
+    }
 
-     // First, tell the context that it is not initialized
-     context->initialized = 0;
+    // First, tell the context that it is not initialized
+    context->initialized = 0;
 
-     // Save a pointer to theGraph in the context
-     context->theGraph = theGraph;
+    // Save a pointer to theGraph in the context
+    context->theGraph = theGraph;
 
-     // Put the overload functions into the context function table.
-     // gp_AddExtension will overload the graph's functions with these, and
-     // return the base function pointers in the context function table
-     memset(&context->functions, 0, sizeof(graphFunctionTable));
+    // Put the overload functions into the context function table.
+    // gp_AddExtension will overload the graph's functions with these, and
+    // return the base function pointers in the context function table
+    memset(&context->functions, 0, sizeof(graphFunctionTable));
 
-     context->functions.fpEmbeddingInitialize = _K33Search_EmbeddingInitialize;
-     context->functions.fpEmbedBackEdgeToDescendant = _K33Search_EmbedBackEdgeToDescendant;
-     context->functions.fpMergeBicomps = _K33Search_MergeBicomps;
-     context->functions.fpMergeVertex = _K33Search_MergeVertex;
-     context->functions.fpHandleBlockedBicomp = _K33Search_HandleBlockedBicomp;
-     context->functions.fpEmbedPostprocess = _K33Search_EmbedPostprocess;
-     context->functions.fpCheckEmbeddingIntegrity = _K33Search_CheckEmbeddingIntegrity;
-     context->functions.fpCheckObstructionIntegrity = _K33Search_CheckObstructionIntegrity;
+    context->functions.fpEmbeddingInitialize = _K33Search_EmbeddingInitialize;
+    context->functions.fpEmbedBackEdgeToDescendant = _K33Search_EmbedBackEdgeToDescendant;
+    context->functions.fpMergeBicomps = _K33Search_MergeBicomps;
+    context->functions.fpMergeVertex = _K33Search_MergeVertex;
+    context->functions.fpHandleBlockedBicomp = _K33Search_HandleBlockedBicomp;
+    context->functions.fpEmbedPostprocess = _K33Search_EmbedPostprocess;
+    context->functions.fpCheckEmbeddingIntegrity = _K33Search_CheckEmbeddingIntegrity;
+    context->functions.fpCheckObstructionIntegrity = _K33Search_CheckObstructionIntegrity;
 
-     context->functions.fpInitGraph = _K33Search_InitGraph;
-     context->functions.fpReinitializeGraph = _K33Search_ReinitializeGraph;
-     context->functions.fpEnsureArcCapacity = _K33Search_EnsureArcCapacity;
+    context->functions.fpInitGraph = _K33Search_InitGraph;
+    context->functions.fpReinitializeGraph = _K33Search_ReinitializeGraph;
+    context->functions.fpEnsureArcCapacity = _K33Search_EnsureArcCapacity;
 
-     _K33Search_ClearStructures(context);
+    _K33Search_ClearStructures(context);
 
-     // Store the K33 search context, including the data structure and the
-     // function pointers, as an extension of the graph
-     if (gp_AddExtension(theGraph, &K33SEARCH_ID, (void *) context,
-                         _K33Search_DupContext, _K33Search_FreeContext,
-                         &context->functions) != OK)
-     {
-         _K33Search_FreeContext(context);
-         return NOTOK;
-     }
+    // Store the K33 search context, including the data structure and the
+    // function pointers, as an extension of the graph
+    if (gp_AddExtension(theGraph, &K33SEARCH_ID, (void *)context,
+                        _K33Search_DupContext, _K33Search_FreeContext,
+                        &context->functions) != OK)
+    {
+        _K33Search_FreeContext(context);
+        return NOTOK;
+    }
 
-     // Create the K33-specific structures if the size of the graph is known
-     // Attach functions are always invoked after gp_New(), but if a graph
-     // extension must be attached before gp_Read(), then the attachment
-     // also happens before gp_InitGraph(), which means N==0.
-     // However, sometimes a feature is attached after gp_InitGraph(), in
-     // which case N > 0
-     if (theGraph->N > 0)
-     {
-         if (_K33Search_CreateStructures(context) != OK ||
-             _K33Search_InitStructures(context) != OK)
-         {
-             _K33Search_FreeContext(context);
-             return NOTOK;
-         }
-     }
+    // Create the K33-specific structures if the size of the graph is known
+    // Attach functions are always invoked after gp_New(), but if a graph
+    // extension must be attached before gp_Read(), then the attachment
+    // also happens before gp_InitGraph(), which means N==0.
+    // However, sometimes a feature is attached after gp_InitGraph(), in
+    // which case N > 0
+    if (theGraph->N > 0)
+    {
+        if (_K33Search_CreateStructures(context) != OK ||
+            _K33Search_InitStructures(context) != OK)
+        {
+            _K33Search_FreeContext(context);
+            return NOTOK;
+        }
+    }
 
-     return OK;
+    return OK;
 }
 
 /********************************************************************
@@ -180,12 +180,12 @@ void _K33Search_ClearStructures(K33SearchContext *context)
         }
 
         LCFree(&context->separatedDFSChildLists);
-		if (context->buckets != NULL)
-		{
-			free(context->buckets);
-			context->buckets = NULL;
-		}
-		LCFree(&context->bin);
+        if (context->buckets != NULL)
+        {
+            free(context->buckets);
+            context->buckets = NULL;
+        }
+        LCFree(&context->bin);
     }
 }
 
@@ -194,75 +194,75 @@ void _K33Search_ClearStructures(K33SearchContext *context)
  Create uninitialized structures for the vertex and edge
  levels, and initialized structures for the graph level
  ********************************************************************/
-int  _K33Search_CreateStructures(K33SearchContext *context)
+int _K33Search_CreateStructures(K33SearchContext *context)
 {
-     int VIsize = gp_PrimaryVertexIndexBound(context->theGraph);
-     int Esize = gp_EdgeIndexBound(context->theGraph);
+    int VIsize = gp_PrimaryVertexIndexBound(context->theGraph);
+    int Esize = gp_EdgeIndexBound(context->theGraph);
 
-     if (context->theGraph->N <= 0)
-         return NOTOK;
+    if (context->theGraph->N <= 0)
+        return NOTOK;
 
-     if ((context->E = (K33Search_EdgeRecP) malloc(Esize*sizeof(K33Search_EdgeRec))) == NULL ||
-         (context->VI = (K33Search_VertexInfoP) malloc(VIsize*sizeof(K33Search_VertexInfo))) == NULL ||
-		 (context->separatedDFSChildLists = LCNew(VIsize)) == NULL ||
-		 (context->buckets = (int *) malloc(VIsize * sizeof(int))) == NULL ||
-		 (context->bin = LCNew(VIsize)) == NULL
-        )
-     {
-         return NOTOK;
-     }
+    if ((context->E = (K33Search_EdgeRecP)malloc(Esize * sizeof(K33Search_EdgeRec))) == NULL ||
+        (context->VI = (K33Search_VertexInfoP)malloc(VIsize * sizeof(K33Search_VertexInfo))) == NULL ||
+        (context->separatedDFSChildLists = LCNew(VIsize)) == NULL ||
+        (context->buckets = (int *)malloc(VIsize * sizeof(int))) == NULL ||
+        (context->bin = LCNew(VIsize)) == NULL)
+    {
+        return NOTOK;
+    }
 
-     return OK;
+    return OK;
 }
 
 /********************************************************************
  _K33Search_InitStructures()
  ********************************************************************/
-int  _K33Search_InitStructures(K33SearchContext *context)
+int _K33Search_InitStructures(K33SearchContext *context)
 {
 #if NIL == 0 || NIL == -1
-	memset(context->VI, NIL_CHAR, gp_PrimaryVertexIndexBound(context->theGraph) * sizeof(K33Search_VertexInfo));
-	memset(context->E, NIL_CHAR, gp_EdgeIndexBound(context->theGraph) * sizeof(K33Search_EdgeRec));
+    memset(context->VI, NIL_CHAR, gp_PrimaryVertexIndexBound(context->theGraph) * sizeof(K33Search_VertexInfo));
+    memset(context->E, NIL_CHAR, gp_EdgeIndexBound(context->theGraph) * sizeof(K33Search_EdgeRec));
 #else
-	 graphP theGraph = context->theGraph;
-     int v, e, Esize;
+    graphP theGraph = context->theGraph;
+    int v, e, Esize;
 
-     if (theGraph->N <= 0)
-         return OK;
+    if (theGraph->N <= 0)
+        return OK;
 
-     for (v = gp_GetFirstVertex(theGraph); gp_VertexInRange(theGraph, v); v++)
-          _K33Search_InitVertexInfo(context, v);
+    for (v = gp_GetFirstVertex(theGraph); gp_VertexInRange(theGraph, v); v++)
+        _K33Search_InitVertexInfo(context, v);
 
-     Esize = gp_EdgeIndexBound(theGraph);
-     for (e = gp_GetFirstEdge(theGraph); e < Esize; e++)
-          _K33Search_InitEdgeRec(context, e);
+    Esize = gp_EdgeIndexBound(theGraph);
+    for (e = gp_GetFirstEdge(theGraph); e < Esize; e++)
+        _K33Search_InitEdgeRec(context, e);
 #endif
 
-     return OK;
+    return OK;
 }
 
 /********************************************************************
  ********************************************************************/
 
-int  _K33Search_InitGraph(graphP theGraph, int N)
+int _K33Search_InitGraph(graphP theGraph, int N)
 {
     K33SearchContext *context = NULL;
     gp_FindExtension(theGraph, K33SEARCH_ID, (void *)&context);
 
-    if (context == NULL) {
-    	return NOTOK;
+    if (context == NULL)
+    {
+        return NOTOK;
     }
 
-	theGraph->N = N;
-	theGraph->NV = N;
-	if (theGraph->arcCapacity == 0)
-		theGraph->arcCapacity = 2*DEFAULT_EDGE_LIMIT*N;
+    theGraph->N = N;
+    theGraph->NV = N;
+    if (theGraph->arcCapacity == 0)
+        theGraph->arcCapacity = 2 * DEFAULT_EDGE_LIMIT * N;
 
-	if (_K33Search_CreateStructures(context) != OK ||
-		_K33Search_InitStructures(context) != OK)
-		return NOTOK;
+    if (_K33Search_CreateStructures(context) != OK ||
+        _K33Search_InitStructures(context) != OK)
+        return NOTOK;
 
-	context->functions.fpInitGraph(theGraph, N);
+    context->functions.fpInitGraph(theGraph, N);
 
     return OK;
 }
@@ -277,13 +277,13 @@ void _K33Search_ReinitializeGraph(graphP theGraph)
 
     if (context != NULL)
     {
-		// Reinitialize the graph
-		context->functions.fpReinitializeGraph(theGraph);
+        // Reinitialize the graph
+        context->functions.fpReinitializeGraph(theGraph);
 
-		// Do the reinitialization that is specific to this module
-		_K33Search_InitStructures(context);
-		LCReset(context->separatedDFSChildLists);
-		LCReset(context->bin);
+        // Do the reinitialization that is specific to this module
+        _K33Search_InitStructures(context);
+        LCReset(context->separatedDFSChildLists);
+        LCReset(context->bin);
     }
 }
 
@@ -296,9 +296,9 @@ void _K33Search_ReinitializeGraph(graphP theGraph)
  reason to do so.
  ********************************************************************/
 
-int  _K33Search_EnsureArcCapacity(graphP theGraph, int requiredArcCapacity)
+int _K33Search_EnsureArcCapacity(graphP theGraph, int requiredArcCapacity)
 {
-	return NOTOK;
+    return NOTOK;
 }
 
 /********************************************************************
@@ -307,35 +307,35 @@ int  _K33Search_EnsureArcCapacity(graphP theGraph, int requiredArcCapacity)
 
 void *_K33Search_DupContext(void *pContext, void *theGraph)
 {
-     K33SearchContext *context = (K33SearchContext *) pContext;
-     K33SearchContext *newContext = (K33SearchContext *) malloc(sizeof(K33SearchContext));
+    K33SearchContext *context = (K33SearchContext *)pContext;
+    K33SearchContext *newContext = (K33SearchContext *)malloc(sizeof(K33SearchContext));
 
-     if (newContext != NULL)
-     {
-         int VIsize = gp_PrimaryVertexIndexBound((graphP) theGraph);
-         int Esize = gp_EdgeIndexBound((graphP) theGraph);
+    if (newContext != NULL)
+    {
+        int VIsize = gp_PrimaryVertexIndexBound((graphP)theGraph);
+        int Esize = gp_EdgeIndexBound((graphP)theGraph);
 
-         *newContext = *context;
+        *newContext = *context;
 
-         newContext->theGraph = (graphP) theGraph;
+        newContext->theGraph = (graphP)theGraph;
 
-         newContext->initialized = 0;
-         _K33Search_ClearStructures(newContext);
-         if (((graphP) theGraph)->N > 0)
-         {
-             if (_K33Search_CreateStructures(newContext) != OK)
-             {
-                 _K33Search_FreeContext(newContext);
-                 return NULL;
-             }
+        newContext->initialized = 0;
+        _K33Search_ClearStructures(newContext);
+        if (((graphP)theGraph)->N > 0)
+        {
+            if (_K33Search_CreateStructures(newContext) != OK)
+            {
+                _K33Search_FreeContext(newContext);
+                return NULL;
+            }
 
-             memcpy(newContext->E, context->E, Esize*sizeof(K33Search_EdgeRec));
-             memcpy(newContext->VI, context->VI, VIsize*sizeof(K33Search_VertexInfo));
-             LCCopy(newContext->separatedDFSChildLists, context->separatedDFSChildLists);
-         }
-     }
+            memcpy(newContext->E, context->E, Esize * sizeof(K33Search_EdgeRec));
+            memcpy(newContext->VI, context->VI, VIsize * sizeof(K33Search_VertexInfo));
+            LCCopy(newContext->separatedDFSChildLists, context->separatedDFSChildLists);
+        }
+    }
 
-     return newContext;
+    return newContext;
 }
 
 /********************************************************************
@@ -344,10 +344,10 @@ void *_K33Search_DupContext(void *pContext, void *theGraph)
 
 void _K33Search_FreeContext(void *pContext)
 {
-     K33SearchContext *context = (K33SearchContext *) pContext;
+    K33SearchContext *context = (K33SearchContext *)pContext;
 
-     _K33Search_ClearStructures(context);
-     free(pContext);
+    _K33Search_ClearStructures(context);
+    free(pContext);
 }
 
 /********************************************************************
@@ -359,20 +359,20 @@ void _K33Search_FreeContext(void *pContext)
  lowpoint) for each vertex.
  ********************************************************************/
 
-int  _K33Search_EmbeddingInitialize(graphP theGraph)
+int _K33Search_EmbeddingInitialize(graphP theGraph)
 {
     K33SearchContext *context = NULL;
     gp_FindExtension(theGraph, K33SEARCH_ID, (void *)&context);
 
     if (context != NULL)
     {
-    	if (context->functions.fpEmbeddingInitialize(theGraph) != OK)
-    		return NOTOK;
+        if (context->functions.fpEmbeddingInitialize(theGraph) != OK)
+            return NOTOK;
 
         if (theGraph->embedFlags == EMBEDFLAGS_SEARCHFORK33)
         {
-        	_CreateBackArcLists(theGraph, context);
-        	_CreateSeparatedDFSChildLists(theGraph, context);
+            _CreateBackArcLists(theGraph, context);
+            _CreateSeparatedDFSChildLists(theGraph, context);
         }
 
         return OK;
@@ -386,18 +386,18 @@ int  _K33Search_EmbeddingInitialize(graphP theGraph)
  ********************************************************************/
 void _CreateBackArcLists(graphP theGraph, K33SearchContext *context)
 {
-	int v, e, eTwin, ancestor;
+    int v, e, eTwin, ancestor;
 
-	for (v = gp_GetFirstVertex(theGraph); gp_VertexInRange(theGraph, v); v++)
+    for (v = gp_GetFirstVertex(theGraph); gp_VertexInRange(theGraph, v); v++)
     {
-    	e = gp_GetVertexFwdArcList(theGraph, v);
+        e = gp_GetVertexFwdArcList(theGraph, v);
         while (gp_IsArc(e))
         {
-        	// Get the ancestor endpoint and the associated back arc
-        	ancestor = gp_GetNeighbor(theGraph, e);
-        	eTwin = gp_GetTwinArc(theGraph, e);
+            // Get the ancestor endpoint and the associated back arc
+            ancestor = gp_GetNeighbor(theGraph, e);
+            eTwin = gp_GetTwinArc(theGraph, e);
 
-        	// Put it into the back arc list of the ancestor
+            // Put it into the back arc list of the ancestor
             if (gp_IsNotArc(context->VI[ancestor].backArcList))
             {
                 context->VI[ancestor].backArcList = eTwin;
@@ -406,18 +406,18 @@ void _CreateBackArcLists(graphP theGraph, K33SearchContext *context)
             }
             else
             {
-            	int eHead = context->VI[ancestor].backArcList;
-            	int eTail = gp_GetPrevArc(theGraph, eHead);
-        		gp_SetPrevArc(theGraph, eTwin, eTail);
-        		gp_SetNextArc(theGraph, eTwin, eHead);
-        		gp_SetPrevArc(theGraph, eHead, eTwin);
-        		gp_SetNextArc(theGraph, eTail, eTwin);
+                int eHead = context->VI[ancestor].backArcList;
+                int eTail = gp_GetPrevArc(theGraph, eHead);
+                gp_SetPrevArc(theGraph, eTwin, eTail);
+                gp_SetNextArc(theGraph, eTwin, eHead);
+                gp_SetPrevArc(theGraph, eHead, eTwin);
+                gp_SetNextArc(theGraph, eTail, eTwin);
             }
 
-        	// Advance to the next forward edge
-			e = gp_GetNextArc(theGraph, e);
-			if (e == gp_GetVertexFwdArcList(theGraph, v))
-				e = NIL;
+            // Advance to the next forward edge
+            e = gp_GetNextArc(theGraph, e);
+            if (e == gp_GetVertexFwdArcList(theGraph, v))
+                e = NIL;
         }
     }
 }
@@ -430,49 +430,49 @@ void _CreateBackArcLists(graphP theGraph, K33SearchContext *context)
 
 void _CreateSeparatedDFSChildLists(graphP theGraph, K33SearchContext *context)
 {
-int *buckets;
-listCollectionP bin;
-int v, L, DFSParent, theList;
+    int *buckets;
+    listCollectionP bin;
+    int v, L, DFSParent, theList;
 
-     buckets = context->buckets;
-     bin = context->bin;
+    buckets = context->buckets;
+    bin = context->bin;
 
-     // Initialize the bin and all the buckets to be empty
-     LCReset(bin);
-     for (L = gp_GetFirstVertex(theGraph); gp_VertexInRange(theGraph, L); L++)
-          buckets[L] = NIL;
+    // Initialize the bin and all the buckets to be empty
+    LCReset(bin);
+    for (L = gp_GetFirstVertex(theGraph); gp_VertexInRange(theGraph, L); L++)
+        buckets[L] = NIL;
 
-     // For each vertex, add it to the bucket whose index is equal to the lowpoint of the vertex.
+    // For each vertex, add it to the bucket whose index is equal to the lowpoint of the vertex.
 
-     for (v = gp_GetFirstVertex(theGraph); gp_VertexInRange(theGraph, v); v++)
-     {
-          L = gp_GetVertexLowpoint(theGraph, v);
-          buckets[L] = LCAppend(bin, buckets[L], v);
-     }
+    for (v = gp_GetFirstVertex(theGraph); gp_VertexInRange(theGraph, v); v++)
+    {
+        L = gp_GetVertexLowpoint(theGraph, v);
+        buckets[L] = LCAppend(bin, buckets[L], v);
+    }
 
-     // For each bucket, add each vertex in the bucket to the separatedDFSChildList of its DFSParent.
-     // Since lower numbered buckets are processed before higher numbered buckets, vertices with lower
-     // lowpoint values are added before those with higher lowpoint values, so the separatedDFSChildList
-     // of each vertex is sorted by lowpoint
-     for (L = gp_GetFirstVertex(theGraph); gp_VertexInRange(theGraph, L); L++)
-     {
-    	  v = buckets[L];
+    // For each bucket, add each vertex in the bucket to the separatedDFSChildList of its DFSParent.
+    // Since lower numbered buckets are processed before higher numbered buckets, vertices with lower
+    // lowpoint values are added before those with higher lowpoint values, so the separatedDFSChildList
+    // of each vertex is sorted by lowpoint
+    for (L = gp_GetFirstVertex(theGraph); gp_VertexInRange(theGraph, L); L++)
+    {
+        v = buckets[L];
 
-    	  // Loop through all the vertices with lowpoint L, putting each in the list of its parent
-		  while (gp_IsVertex(v))
-		  {
-			  DFSParent = gp_GetVertexParent(theGraph, v);
+        // Loop through all the vertices with lowpoint L, putting each in the list of its parent
+        while (gp_IsVertex(v))
+        {
+            DFSParent = gp_GetVertexParent(theGraph, v);
 
-			  if (gp_IsVertex(DFSParent) && DFSParent != v)
-			  {
-				  theList = context->VI[DFSParent].separatedDFSChildList;
-				  theList = LCAppend(context->separatedDFSChildLists, theList, v);
-				  context->VI[DFSParent].separatedDFSChildList = theList;
-			  }
+            if (gp_IsVertex(DFSParent) && DFSParent != v)
+            {
+                theList = context->VI[DFSParent].separatedDFSChildList;
+                theList = LCAppend(context->separatedDFSChildLists, theList, v);
+                context->VI[DFSParent].separatedDFSChildList = theList;
+            }
 
-			  v = LCGetNext(bin, buckets[L], v);
-		  }
-     }
+            v = LCGetNext(bin, buckets[L], v);
+        }
+    }
 }
 
 /********************************************************************
@@ -495,15 +495,16 @@ void _K33Search_EmbedBackEdgeToDescendant(graphP theGraph, int RootSide, int Roo
         // K33 search may have been attached, but not enabled
         if (theGraph->embedFlags == EMBEDFLAGS_SEARCHFORK33)
         {
-        	// Get the fwdArc from the adjacentTo field, and use it to get the backArc
+            // Get the fwdArc from the adjacentTo field, and use it to get the backArc
             int backArc = gp_GetTwinArc(theGraph, gp_GetVertexPertinentEdge(theGraph, W));
 
             // Remove the backArc from the backArcList
             if (context->VI[W].backArcList == backArc)
             {
                 if (gp_GetNextArc(theGraph, backArc) == backArc)
-                     context->VI[W].backArcList = NIL;
-                else context->VI[W].backArcList = gp_GetNextArc(theGraph, backArc);
+                    context->VI[W].backArcList = NIL;
+                else
+                    context->VI[W].backArcList = gp_GetNextArc(theGraph, backArc);
             }
 
             gp_SetNextArc(theGraph, gp_GetPrevArc(theGraph, backArc), gp_GetNextArc(theGraph, backArc));
@@ -528,7 +529,7 @@ void _K33Search_EmbedBackEdgeToDescendant(graphP theGraph, int RootSide, int Roo
           a K_{3,3} homeomorph was isolated.
  ********************************************************************/
 
-int  _K33Search_MergeBicomps(graphP theGraph, int v, int RootVertex, int W, int WPrevLink)
+int _K33Search_MergeBicomps(graphP theGraph, int v, int RootVertex, int W, int WPrevLink)
 {
     K33SearchContext *context = NULL;
     gp_FindExtension(theGraph, K33SEARCH_ID, (void *)&context);
@@ -540,7 +541,7 @@ int  _K33Search_MergeBicomps(graphP theGraph, int v, int RootVertex, int W, int 
 
         if (theGraph->embedFlags == EMBEDFLAGS_SEARCHFORK33)
         {
-        int mergeBlocker;
+            int mergeBlocker;
 
             // We want to test all merge points on the stack
             // as well as W, since the connection will go
@@ -548,16 +549,16 @@ int  _K33Search_MergeBicomps(graphP theGraph, int v, int RootVertex, int W, int 
             sp_Push2(theGraph->theStack, W, WPrevLink);
             sp_Push2(theGraph->theStack, NIL, NIL);
 
-			if (_SearchForMergeBlocker(theGraph, context, v, &mergeBlocker) != OK)
-				return NOTOK;
+            if (_SearchForMergeBlocker(theGraph, context, v, &mergeBlocker) != OK)
+                return NOTOK;
 
-			if (gp_IsVertex(mergeBlocker))
-			{
-				if (_FindK33WithMergeBlocker(theGraph, context, v, mergeBlocker) != OK)
-					return NOTOK;
+            if (gp_IsVertex(mergeBlocker))
+            {
+                if (_FindK33WithMergeBlocker(theGraph, context, v, mergeBlocker) != OK)
+                    return NOTOK;
 
-				return NONEMBEDDABLE;
-			}
+                return NONEMBEDDABLE;
+            }
 
             // If no merge blocker was found, then remove W from the stack.
             sp_Pop2(theGraph->theStack, W, WPrevLink);
@@ -623,32 +624,32 @@ void _K33Search_InitVertexInfo(K33SearchContext *context, int v)
 /********************************************************************
  ********************************************************************/
 
-int  _K33Search_HandleBlockedBicomp(graphP theGraph, int v, int RootVertex, int R)
+int _K33Search_HandleBlockedBicomp(graphP theGraph, int v, int RootVertex, int R)
 {
-	K33SearchContext *context = NULL;
+    K33SearchContext *context = NULL;
 
-	gp_FindExtension(theGraph, K33SEARCH_ID, (void *)&context);
-	if (context == NULL)
-		return NOTOK;
+    gp_FindExtension(theGraph, K33SEARCH_ID, (void *)&context);
+    if (context == NULL)
+        return NOTOK;
 
     if (theGraph->embedFlags == EMBEDFLAGS_SEARCHFORK33)
     {
-		// If R is the root of a descendant bicomp of v, we push it, but then we know the search for K3,3
-    	// will be successful and return NONEMBEDDABLE because this condition corresponds to minor A, which
-    	// is a K3,3.  Thus, an "OK to proceed with Walkdown searching elsewhere" result cannot happen,
-    	// so we don't have to test for it to detect if we have to pop these two back off the stack.
-    	if (R != RootVertex)
-    	    sp_Push2(theGraph->theStack, R, 0);
+        // If R is the root of a descendant bicomp of v, we push it, but then we know the search for K3,3
+        // will be successful and return NONEMBEDDABLE because this condition corresponds to minor A, which
+        // is a K3,3.  Thus, an "OK to proceed with Walkdown searching elsewhere" result cannot happen,
+        // so we don't have to test for it to detect if we have to pop these two back off the stack.
+        if (R != RootVertex)
+            sp_Push2(theGraph->theStack, R, 0);
 
-    	// The possible results here are NONEMBEDDABLE if a K3,3 homeomorph is found, or OK if only
-    	// a K5 was found and unblocked such that it is OK for the Walkdown to continue searching
-    	// elsewhere.  Note that the OK result can only happen if RootVertex==R since minor E can only
-    	// happen on a child bicomp of vertex v, not a descendant bicomp.
-    	return _SearchForK33InBicomp(theGraph, context, v, RootVertex);
+        // The possible results here are NONEMBEDDABLE if a K3,3 homeomorph is found, or OK if only
+        // a K5 was found and unblocked such that it is OK for the Walkdown to continue searching
+        // elsewhere.  Note that the OK result can only happen if RootVertex==R since minor E can only
+        // happen on a child bicomp of vertex v, not a descendant bicomp.
+        return _SearchForK33InBicomp(theGraph, context, v, RootVertex);
     }
     else
     {
-    	return context->functions.fpHandleBlockedBicomp(theGraph, v, RootVertex, R);
+        return context->functions.fpHandleBlockedBicomp(theGraph, v, RootVertex, R);
     }
 
     return NOTOK;
@@ -657,18 +658,18 @@ int  _K33Search_HandleBlockedBicomp(graphP theGraph, int v, int RootVertex, int 
 /********************************************************************
  ********************************************************************/
 
-int  _K33Search_EmbedPostprocess(graphP theGraph, int v, int edgeEmbeddingResult)
+int _K33Search_EmbedPostprocess(graphP theGraph, int v, int edgeEmbeddingResult)
 {
-     // For K3,3 search, we just return the edge embedding result because the
-     // search result has been obtained already.
-     if (theGraph->embedFlags == EMBEDFLAGS_SEARCHFORK33)
-     {
-         return edgeEmbeddingResult;
-     }
+    // For K3,3 search, we just return the edge embedding result because the
+    // search result has been obtained already.
+    if (theGraph->embedFlags == EMBEDFLAGS_SEARCHFORK33)
+    {
+        return edgeEmbeddingResult;
+    }
 
-     // When not searching for K3,3, we let the superclass do the work
-     else
-     {
+    // When not searching for K3,3, we let the superclass do the work
+    else
+    {
         K33SearchContext *context = NULL;
         gp_FindExtension(theGraph, K33SEARCH_ID, (void *)&context);
 
@@ -676,24 +677,24 @@ int  _K33Search_EmbedPostprocess(graphP theGraph, int v, int edgeEmbeddingResult
         {
             return context->functions.fpEmbedPostprocess(theGraph, v, edgeEmbeddingResult);
         }
-     }
+    }
 
-     return NOTOK;
+    return NOTOK;
 }
 
 /********************************************************************
  ********************************************************************/
 
-int  _K33Search_CheckEmbeddingIntegrity(graphP theGraph, graphP origGraph)
+int _K33Search_CheckEmbeddingIntegrity(graphP theGraph, graphP origGraph)
 {
-     if (theGraph->embedFlags == EMBEDFLAGS_SEARCHFORK33)
-     {
-         return OK;
-     }
+    if (theGraph->embedFlags == EMBEDFLAGS_SEARCHFORK33)
+    {
+        return OK;
+    }
 
-     // When not searching for K3,3, we let the superclass do the work
-     else
-     {
+    // When not searching for K3,3, we let the superclass do the work
+    else
+    {
         K33SearchContext *context = NULL;
         gp_FindExtension(theGraph, K33SEARCH_ID, (void *)&context);
 
@@ -701,43 +702,43 @@ int  _K33Search_CheckEmbeddingIntegrity(graphP theGraph, graphP origGraph)
         {
             return context->functions.fpCheckEmbeddingIntegrity(theGraph, origGraph);
         }
-     }
+    }
 
-     return NOTOK;
+    return NOTOK;
 }
 
 /********************************************************************
  ********************************************************************/
 
-int  _K33Search_CheckObstructionIntegrity(graphP theGraph, graphP origGraph)
+int _K33Search_CheckObstructionIntegrity(graphP theGraph, graphP origGraph)
 {
-     // When searching for K3,3, we ensure that theGraph is a subgraph of
-     // the original graph and that it contains a K3,3 homeomorph
-     if (theGraph->embedFlags == EMBEDFLAGS_SEARCHFORK33)
-     {
-         int  degrees[5], imageVerts[6];
+    // When searching for K3,3, we ensure that theGraph is a subgraph of
+    // the original graph and that it contains a K3,3 homeomorph
+    if (theGraph->embedFlags == EMBEDFLAGS_SEARCHFORK33)
+    {
+        int degrees[5], imageVerts[6];
 
-         if (_TestSubgraph(theGraph, origGraph) != TRUE)
-         {
-             return NOTOK;
-         }
+        if (_TestSubgraph(theGraph, origGraph) != TRUE)
+        {
+            return NOTOK;
+        }
 
-         if (_getImageVertices(theGraph, degrees, 4, imageVerts, 6) != OK)
-         {
-             return NOTOK;
-         }
+        if (_getImageVertices(theGraph, degrees, 4, imageVerts, 6) != OK)
+        {
+            return NOTOK;
+        }
 
-         if (_TestForK33GraphObstruction(theGraph, degrees, imageVerts) == TRUE)
-         {
-             return OK;
-         }
+        if (_TestForK33GraphObstruction(theGraph, degrees, imageVerts) == TRUE)
+        {
+            return OK;
+        }
 
-         return NOTOK;
-     }
+        return NOTOK;
+    }
 
-     // When not searching for K3,3, we let the superclass do the work
-     else
-     {
+    // When not searching for K3,3, we let the superclass do the work
+    else
+    {
         K33SearchContext *context = NULL;
         gp_FindExtension(theGraph, K33SEARCH_ID, (void *)&context);
 
@@ -745,8 +746,7 @@ int  _K33Search_CheckObstructionIntegrity(graphP theGraph, graphP origGraph)
         {
             return context->functions.fpCheckObstructionIntegrity(theGraph, origGraph);
         }
-     }
+    }
 
-     return NOTOK;
+    return NOTOK;
 }
-

--- a/c/graphLib/homeomorphSearch/graphK4Search.c
+++ b/c/graphLib/homeomorphSearch/graphK4Search.c
@@ -89,307 +89,307 @@ int _K4_RestoreAndOrientReducedPaths(graphP theGraph, K4SearchContext *context);
 
 int _SearchForK4InBicomp(graphP theGraph, K4SearchContext *context, int v, int R)
 {
-	isolatorContextP IC = &theGraph->IC;
+    isolatorContextP IC = &theGraph->IC;
 
-	if (context == NULL)
-	{
-		gp_FindExtension(theGraph, K4SEARCH_ID, (void *)&context);
-		if (context == NULL)
-			return NOTOK;
-	}
+    if (context == NULL)
+    {
+        gp_FindExtension(theGraph, K4SEARCH_ID, (void *)&context);
+        if (context == NULL)
+            return NOTOK;
+    }
 
-	// Begin by determining whether minor A, B or E is detected
-	if (_K4_ChooseTypeOfNonOuterplanarityMinor(theGraph, v, R) != OK)
-		return NOTOK;
+    // Begin by determining whether minor A, B or E is detected
+    if (_K4_ChooseTypeOfNonOuterplanarityMinor(theGraph, v, R) != OK)
+        return NOTOK;
 
-	// Minor A indicates the existence of K_{2,3} homeomorphs, but
-	// we run additional tests to see whether we can either find an
-	// entwined K4 homeomorph or reduce the bicomp so that the WalkDown
-	// is enabled to continue to resolve pertinence
-	if (theGraph->IC.minorType & MINORTYPE_A)
-	{
-		// Now that we know we have minor A, we can afford to orient the
-		// bicomp because we will either find the desired K4 or we will
-		// reduce the bicomp to an edge. The tests for A1 and A2 are easier
-		// to implement on an oriented bicomp.
-		// NOTE: We're in the midst of the WalkDown, so the stack may be
-		//       non-empty, and it has to be preserved with constant cost.
-		//       The stack will have at most 4 integers per cut vertex
-		//       merge point, and this operation will push at most two
-		//       integers per tree edge in the bicomp, so the stack
-		//       will not overflow.
-		if (sp_GetCapacity(theGraph->theStack) < 6 * theGraph->N)
-			return NOTOK;
+    // Minor A indicates the existence of K_{2,3} homeomorphs, but
+    // we run additional tests to see whether we can either find an
+    // entwined K4 homeomorph or reduce the bicomp so that the WalkDown
+    // is enabled to continue to resolve pertinence
+    if (theGraph->IC.minorType & MINORTYPE_A)
+    {
+        // Now that we know we have minor A, we can afford to orient the
+        // bicomp because we will either find the desired K4 or we will
+        // reduce the bicomp to an edge. The tests for A1 and A2 are easier
+        // to implement on an oriented bicomp.
+        // NOTE: We're in the midst of the WalkDown, so the stack may be
+        //       non-empty, and it has to be preserved with constant cost.
+        //       The stack will have at most 4 integers per cut vertex
+        //       merge point, and this operation will push at most two
+        //       integers per tree edge in the bicomp, so the stack
+        //       will not overflow.
+        if (sp_GetCapacity(theGraph->theStack) < 6 * theGraph->N)
+            return NOTOK;
 
-		if (_OrientVerticesInBicomp(theGraph, R, 1) != OK)
-			return NOTOK;
+        if (_OrientVerticesInBicomp(theGraph, R, 1) != OK)
+            return NOTOK;
 
-		// Case A1: Test whether there is an active vertex Z other than W
-		// along the external face path [X, ..., W, ..., Y]
-		if (_K4_FindSecondActiveVertexOnLowExtFacePath(theGraph) == TRUE)
-		{
-			// Now that we know we can find a K4, the Walkdown will not continue
-			// and we can do away with the stack content.
-			sp_ClearStack(theGraph->theStack);
+        // Case A1: Test whether there is an active vertex Z other than W
+        // along the external face path [X, ..., W, ..., Y]
+        if (_K4_FindSecondActiveVertexOnLowExtFacePath(theGraph) == TRUE)
+        {
+            // Now that we know we can find a K4, the Walkdown will not continue
+            // and we can do away with the stack content.
+            sp_ClearStack(theGraph->theStack);
 
-			// Restore the orientations of the vertices in the bicomp, then orient
-			// the whole embedding, so we can restore and orient the reduced paths
-			if (_OrientVerticesInBicomp(theGraph, R, 1) != OK ||
-				_OrientVerticesInEmbedding(theGraph) != OK ||
-				_K4_RestoreAndOrientReducedPaths(theGraph, context) != OK)
-				return NOTOK;
+            // Restore the orientations of the vertices in the bicomp, then orient
+            // the whole embedding, so we can restore and orient the reduced paths
+            if (_OrientVerticesInBicomp(theGraph, R, 1) != OK ||
+                _OrientVerticesInEmbedding(theGraph) != OK ||
+                _K4_RestoreAndOrientReducedPaths(theGraph, context) != OK)
+                return NOTOK;
 
-			// Set up to isolate K4 homeomorph
-			_ClearVisitedFlags(theGraph);
+            // Set up to isolate K4 homeomorph
+            _ClearVisitedFlags(theGraph);
 
-			if (_FindUnembeddedEdgeToCurVertex(theGraph, IC->w, &IC->dw) != TRUE)
-				return NOTOK;
+            if (_FindUnembeddedEdgeToCurVertex(theGraph, IC->w, &IC->dw) != TRUE)
+                return NOTOK;
 
-			if (IC->uz < IC->v)
-			{
-				if (_FindUnembeddedEdgeToAncestor(theGraph, IC->z, &IC->uz, &IC->dz) != TRUE)
-					return NOTOK;
-			}
-			else
-			{
-				if (_FindUnembeddedEdgeToCurVertex(theGraph, IC->z, &IC->dz) != TRUE)
-					return NOTOK;
-			}
+            if (IC->uz < IC->v)
+            {
+                if (_FindUnembeddedEdgeToAncestor(theGraph, IC->z, &IC->uz, &IC->dz) != TRUE)
+                    return NOTOK;
+            }
+            else
+            {
+                if (_FindUnembeddedEdgeToCurVertex(theGraph, IC->z, &IC->dz) != TRUE)
+                    return NOTOK;
+            }
 
-			// Isolate the K4 homeomorph
-			if (_K4_IsolateMinorA1(theGraph) != OK ||
-				_DeleteUnmarkedVerticesAndEdges(theGraph) != OK)
-				return NOTOK;
+            // Isolate the K4 homeomorph
+            if (_K4_IsolateMinorA1(theGraph) != OK ||
+                _DeleteUnmarkedVerticesAndEdges(theGraph) != OK)
+                return NOTOK;
 
-			// Indicate success by returning NONEMBEDDABLE
-			return NONEMBEDDABLE;
-		}
+            // Indicate success by returning NONEMBEDDABLE
+            return NONEMBEDDABLE;
+        }
 
-		// Case A2: Test whether the bicomp has an XY path
-		// NOTE: As mentioned above, the stack is also preserved here.
-		//       It will have at most 4 integers per cut vertex merge point,
-		//       and this operation will push at most one integer per tree
-		//       edge in the bicomp, so the stack will not overflow.
-		if (_SetVertexTypesForMarkingXYPath(theGraph) != OK)
-			return NOTOK;
+        // Case A2: Test whether the bicomp has an XY path
+        // NOTE: As mentioned above, the stack is also preserved here.
+        //       It will have at most 4 integers per cut vertex merge point,
+        //       and this operation will push at most one integer per tree
+        //       edge in the bicomp, so the stack will not overflow.
+        if (_SetVertexTypesForMarkingXYPath(theGraph) != OK)
+            return NOTOK;
 
-		// Marking the X-Y path relies on the bicomp visited flags being cleared
-		if (_ClearVisitedFlagsInBicomp(theGraph, R) != OK)
-			return NOTOK;
+        // Marking the X-Y path relies on the bicomp visited flags being cleared
+        if (_ClearVisitedFlagsInBicomp(theGraph, R) != OK)
+            return NOTOK;
 
-		// Now Mark the X-Y path
-		// NOTE: This call preserves the stack and does not overflow. There
-		//       are at most 4 integers per cut vertex merge point, all of which
-		//       are not in the bicomp, and this call pushes at most 3 integers
-		//       per bicomp vertex, so the maximum stack requirement is 4N
-		if (_MarkHighestXYPath(theGraph) != OK)
-			return NOTOK;
+        // Now Mark the X-Y path
+        // NOTE: This call preserves the stack and does not overflow. There
+        //       are at most 4 integers per cut vertex merge point, all of which
+        //       are not in the bicomp, and this call pushes at most 3 integers
+        //       per bicomp vertex, so the maximum stack requirement is 4N
+        if (_MarkHighestXYPath(theGraph) != OK)
+            return NOTOK;
 
-		// If there was an X-Y path to mark...
-		if (theGraph->IC.py != NIL)
-		{
-			// Now that we know we can find a K4, the Walkdown will not continue
-			// and we can do away with the stack content.
-			sp_ClearStack(theGraph->theStack);
+        // If there was an X-Y path to mark...
+        if (theGraph->IC.py != NIL)
+        {
+            // Now that we know we can find a K4, the Walkdown will not continue
+            // and we can do away with the stack content.
+            sp_ClearStack(theGraph->theStack);
 
-			// Restore the orientations of the vertices in the bicomp, then orient
-			// the whole embedding, so we can restore and orient the reduced paths
-			if (_OrientVerticesInBicomp(theGraph, R, 1) != OK ||
-				_OrientVerticesInEmbedding(theGraph) != OK ||
-				_K4_RestoreAndOrientReducedPaths(theGraph, context) != OK)
-				return NOTOK;
+            // Restore the orientations of the vertices in the bicomp, then orient
+            // the whole embedding, so we can restore and orient the reduced paths
+            if (_OrientVerticesInBicomp(theGraph, R, 1) != OK ||
+                _OrientVerticesInEmbedding(theGraph) != OK ||
+                _K4_RestoreAndOrientReducedPaths(theGraph, context) != OK)
+                return NOTOK;
 
-			// Set up to isolate K4 homeomorph
-			_ClearVisitedFlags(theGraph);
+            // Set up to isolate K4 homeomorph
+            _ClearVisitedFlags(theGraph);
 
-			if (_FindUnembeddedEdgeToCurVertex(theGraph, IC->w, &IC->dw) != TRUE)
-			{
-				return NOTOK;
-			}
+            if (_FindUnembeddedEdgeToCurVertex(theGraph, IC->w, &IC->dw) != TRUE)
+            {
+                return NOTOK;
+            }
 
-			// Fail if there is an internal error or if there isn't an X-Y path
-			if (_MarkHighestXYPath(theGraph) != OK || theGraph->IC.py == NIL)
-				return NOTOK;
+            // Fail if there is an internal error or if there isn't an X-Y path
+            if (_MarkHighestXYPath(theGraph) != OK || theGraph->IC.py == NIL)
+                return NOTOK;
 
-			// Isolate the K4 homeomorph
-			if (_K4_IsolateMinorA2(theGraph) != OK ||
-				_DeleteUnmarkedVerticesAndEdges(theGraph) != OK)
-				return NOTOK;
+            // Isolate the K4 homeomorph
+            if (_K4_IsolateMinorA2(theGraph) != OK ||
+                _DeleteUnmarkedVerticesAndEdges(theGraph) != OK)
+                return NOTOK;
 
-			// Indicate success by returning NONEMBEDDABLE
-			return NONEMBEDDABLE;
-		}
+            // Indicate success by returning NONEMBEDDABLE
+            return NONEMBEDDABLE;
+        }
 
-		// else if there was no X-Y path, then we restore the vertex types to
-		// unknown (though it would suffice to do it just to R and W)
-		if (_ClearVertexTypeInBicomp(theGraph, R) != OK)
-			return NOTOK;
+        // else if there was no X-Y path, then we restore the vertex types to
+        // unknown (though it would suffice to do it just to R and W)
+        if (_ClearVertexTypeInBicomp(theGraph, R) != OK)
+            return NOTOK;
 
-		// Since neither A1 nor A2 is found, then we reduce the bicomp to the
-		// tree edge (R, W).
-		// NOTE: The visited flags for R and W are restored to values appropriate
-		//       for continuing with future embedding steps
-		// NOTE: This method invokes several routines that use the stack, but
-		//       all of them preserve the stack and each pushes at most one
-		//       integer per bicomp vertex and pops all of them before returning.
-		//       Again, this means the stack will not overflow.
-		if (_K4_ReduceBicompToEdge(theGraph, context, R, IC->w) != OK)
-			return NOTOK;
+        // Since neither A1 nor A2 is found, then we reduce the bicomp to the
+        // tree edge (R, W).
+        // NOTE: The visited flags for R and W are restored to values appropriate
+        //       for continuing with future embedding steps
+        // NOTE: This method invokes several routines that use the stack, but
+        //       all of them preserve the stack and each pushes at most one
+        //       integer per bicomp vertex and pops all of them before returning.
+        //       Again, this means the stack will not overflow.
+        if (_K4_ReduceBicompToEdge(theGraph, context, R, IC->w) != OK)
+            return NOTOK;
 
-		// Return OK so that the WalkDown can continue resolving the pertinence of v.
-		return OK;
-	}
+        // Return OK so that the WalkDown can continue resolving the pertinence of v.
+        return OK;
+    }
 
-	// Minor B also indicates the existence of K_{2,3} homeomorphs, but
-	// we run additional tests to see whether we can either find an
-	// entwined K4 homeomorph or reduce a portion of the bicomp so that
-	// the WalkDown can be reinvoked on the bicomp
-	else if (theGraph->IC.minorType & MINORTYPE_B)
-	{
-		int a_x, a_y;
+    // Minor B also indicates the existence of K_{2,3} homeomorphs, but
+    // we run additional tests to see whether we can either find an
+    // entwined K4 homeomorph or reduce a portion of the bicomp so that
+    // the WalkDown can be reinvoked on the bicomp
+    else if (theGraph->IC.minorType & MINORTYPE_B)
+    {
+        int a_x, a_y;
 
-		// Reality check on stack state
-		if (sp_NonEmpty(theGraph->theStack))
-			return NOTOK;
+        // Reality check on stack state
+        if (sp_NonEmpty(theGraph->theStack))
+            return NOTOK;
 
-		// Find the vertices a_x and a_y that are active (pertinent or future pertinent)
-		// and also first along the external face paths emanating from the bicomp root
-		if (_K4_FindPlanarityActiveVertex(theGraph, v, R, 1, &a_x) != OK ||
-			_K4_FindPlanarityActiveVertex(theGraph, v, R, 0, &a_y) != OK)
-			return NOTOK;
+        // Find the vertices a_x and a_y that are active (pertinent or future pertinent)
+        // and also first along the external face paths emanating from the bicomp root
+        if (_K4_FindPlanarityActiveVertex(theGraph, v, R, 1, &a_x) != OK ||
+            _K4_FindPlanarityActiveVertex(theGraph, v, R, 0, &a_y) != OK)
+            return NOTOK;
 
-		// Case B1: If both a_x and a_y are future pertinent, then we can stop and
-		// isolate a subgraph homeomorphic to K4.
-		gp_UpdateVertexFuturePertinentChild(theGraph, a_x, v);
-		gp_UpdateVertexFuturePertinentChild(theGraph, a_y, v);
-		if (a_x != a_y && FUTUREPERTINENT(theGraph, a_x, v) && FUTUREPERTINENT(theGraph, a_y, v))
-		{
-			if (_OrientVerticesInEmbedding(theGraph) != OK ||
-				_K4_RestoreAndOrientReducedPaths(theGraph, context) != OK)
-				return NOTOK;
+        // Case B1: If both a_x and a_y are future pertinent, then we can stop and
+        // isolate a subgraph homeomorphic to K4.
+        gp_UpdateVertexFuturePertinentChild(theGraph, a_x, v);
+        gp_UpdateVertexFuturePertinentChild(theGraph, a_y, v);
+        if (a_x != a_y && FUTUREPERTINENT(theGraph, a_x, v) && FUTUREPERTINENT(theGraph, a_y, v))
+        {
+            if (_OrientVerticesInEmbedding(theGraph) != OK ||
+                _K4_RestoreAndOrientReducedPaths(theGraph, context) != OK)
+                return NOTOK;
 
-			// Set up to isolate K4 homeomorph
-			_ClearVisitedFlags(theGraph);
+            // Set up to isolate K4 homeomorph
+            _ClearVisitedFlags(theGraph);
 
-			IC->x = a_x;
-			IC->y = a_y;
+            IC->x = a_x;
+            IC->y = a_y;
 
-			if (_FindUnembeddedEdgeToAncestor(theGraph, IC->x, &IC->ux, &IC->dx) != TRUE ||
-				_FindUnembeddedEdgeToAncestor(theGraph, IC->y, &IC->uy, &IC->dy) != TRUE)
-				return NOTOK;
+            if (_FindUnembeddedEdgeToAncestor(theGraph, IC->x, &IC->ux, &IC->dx) != TRUE ||
+                _FindUnembeddedEdgeToAncestor(theGraph, IC->y, &IC->uy, &IC->dy) != TRUE)
+                return NOTOK;
 
-			// Isolate the K4 homeomorph
-			if (_K4_IsolateMinorB1(theGraph) != OK ||
-				_DeleteUnmarkedVerticesAndEdges(theGraph) != OK)
-				return NOTOK;
+            // Isolate the K4 homeomorph
+            if (_K4_IsolateMinorB1(theGraph) != OK ||
+                _DeleteUnmarkedVerticesAndEdges(theGraph) != OK)
+                return NOTOK;
 
-			// Indicate success by returning NONEMBEDDABLE
-			return NONEMBEDDABLE;
-		}
+            // Indicate success by returning NONEMBEDDABLE
+            return NONEMBEDDABLE;
+        }
 
-		// Reality check: The bicomp with root R is pertinent, and the only
-		// pertinent or future pertinent vertex on the external face is a_x,
-		// so it must also be pertinent.
-		if (a_x == a_y && !PERTINENT(theGraph, a_x))
-			return NOTOK;
+        // Reality check: The bicomp with root R is pertinent, and the only
+        // pertinent or future pertinent vertex on the external face is a_x,
+        // so it must also be pertinent.
+        if (a_x == a_y && !PERTINENT(theGraph, a_x))
+            return NOTOK;
 
-		// Case B2: Determine whether there is an internal separating X-Y path for a_x or for a_y
-		// The method makes appropriate isolator context settings if the separator edge is found
-		if (_K4_FindSeparatingInternalEdge(theGraph, R, 1, a_x, &IC->w, &IC->px, &IC->py) == TRUE ||
-			_K4_FindSeparatingInternalEdge(theGraph, R, 0, a_y, &IC->w, &IC->py, &IC->px) == TRUE)
-		{
-			if (_OrientVerticesInEmbedding(theGraph) != OK ||
-				_K4_RestoreAndOrientReducedPaths(theGraph, context) != OK)
-				return NOTOK;
+        // Case B2: Determine whether there is an internal separating X-Y path for a_x or for a_y
+        // The method makes appropriate isolator context settings if the separator edge is found
+        if (_K4_FindSeparatingInternalEdge(theGraph, R, 1, a_x, &IC->w, &IC->px, &IC->py) == TRUE ||
+            _K4_FindSeparatingInternalEdge(theGraph, R, 0, a_y, &IC->w, &IC->py, &IC->px) == TRUE)
+        {
+            if (_OrientVerticesInEmbedding(theGraph) != OK ||
+                _K4_RestoreAndOrientReducedPaths(theGraph, context) != OK)
+                return NOTOK;
 
-			// Set up to isolate K4 homeomorph
-			_ClearVisitedFlags(theGraph);
+            // Set up to isolate K4 homeomorph
+            _ClearVisitedFlags(theGraph);
 
-			if (PERTINENT(theGraph, IC->w))
-			{
-				if (_FindUnembeddedEdgeToCurVertex(theGraph, IC->w, &IC->dw) != TRUE)
-					return NOTOK;
-			}
-			else
-			{
-				IC->z = IC->w;
-				if (_FindUnembeddedEdgeToAncestor(theGraph, IC->z, &IC->uz, &IC->dz) != TRUE)
-					return NOTOK;
-			}
+            if (PERTINENT(theGraph, IC->w))
+            {
+                if (_FindUnembeddedEdgeToCurVertex(theGraph, IC->w, &IC->dw) != TRUE)
+                    return NOTOK;
+            }
+            else
+            {
+                IC->z = IC->w;
+                if (_FindUnembeddedEdgeToAncestor(theGraph, IC->z, &IC->uz, &IC->dz) != TRUE)
+                    return NOTOK;
+            }
 
-			// The X-Y path doesn't have to be the same one that was associated with 
-			// the separating internal edge (but it has to be there, else error).
-			if (_SetVertexTypesForMarkingXYPath(theGraph) != OK ||
-				_MarkHighestXYPath(theGraph) != OK ||
-				theGraph->IC.py == NIL)
-				return NOTOK;
+            // The X-Y path doesn't have to be the same one that was associated with
+            // the separating internal edge (but it has to be there, else error).
+            if (_SetVertexTypesForMarkingXYPath(theGraph) != OK ||
+                _MarkHighestXYPath(theGraph) != OK ||
+                theGraph->IC.py == NIL)
+                return NOTOK;
 
-			// Isolate the K4 homeomorph
-			if (_K4_IsolateMinorB2(theGraph) != OK ||
-				_DeleteUnmarkedVerticesAndEdges(theGraph) != OK)
-				return NOTOK;
+            // Isolate the K4 homeomorph
+            if (_K4_IsolateMinorB2(theGraph) != OK ||
+                _DeleteUnmarkedVerticesAndEdges(theGraph) != OK)
+                return NOTOK;
 
-			// Indicate success by returning NONEMBEDDABLE
-			return NONEMBEDDABLE;
-		}
+            // Indicate success by returning NONEMBEDDABLE
+            return NONEMBEDDABLE;
+        }
 
-		// If K_4 homeomorph not found, make reductions along a_x and a_y paths.
-		if (a_x == a_y)
-		{
-			// In the special case where both paths lead to the same vertex, we can
-			// reduce the bicomp to a single edge, which avoids issues of reversed
-			// orientation between the bicomp root and the vertex.
-			if (_K4_ReduceBicompToEdge(theGraph, context, R, a_x) != OK)
-				return NOTOK;
-		}
-		else
-		{
-			// When a_x and a_y are distinct, we reduce each path from root to the vertex
-			if (_K4_ReducePathComponent(theGraph, context, R, 1, a_x) != OK ||
-				_K4_ReducePathComponent(theGraph, context, R, 0, a_y) != OK)
-				return NOTOK;
-		}
+        // If K_4 homeomorph not found, make reductions along a_x and a_y paths.
+        if (a_x == a_y)
+        {
+            // In the special case where both paths lead to the same vertex, we can
+            // reduce the bicomp to a single edge, which avoids issues of reversed
+            // orientation between the bicomp root and the vertex.
+            if (_K4_ReduceBicompToEdge(theGraph, context, R, a_x) != OK)
+                return NOTOK;
+        }
+        else
+        {
+            // When a_x and a_y are distinct, we reduce each path from root to the vertex
+            if (_K4_ReducePathComponent(theGraph, context, R, 1, a_x) != OK ||
+                _K4_ReducePathComponent(theGraph, context, R, 0, a_y) != OK)
+                return NOTOK;
+        }
 
-		// Return OK to indicate that WalkDown processing may proceed to resolve
-		// more of the pertinence of this bicomp.
-		return OK;
-	}
+        // Return OK to indicate that WalkDown processing may proceed to resolve
+        // more of the pertinence of this bicomp.
+        return OK;
+    }
 
-	// Minor E indicates the desired K4 homeomorph, so we isolate it and return NONEMBEDDABLE
-	else if (theGraph->IC.minorType & MINORTYPE_E)
-	{
-		// Reality check on stack state
-		if (sp_NonEmpty(theGraph->theStack))
-			return NOTOK;
+    // Minor E indicates the desired K4 homeomorph, so we isolate it and return NONEMBEDDABLE
+    else if (theGraph->IC.minorType & MINORTYPE_E)
+    {
+        // Reality check on stack state
+        if (sp_NonEmpty(theGraph->theStack))
+            return NOTOK;
 
-		// Impose consistent orientation on the embedding so we can then
-		// restore the reduced paths.
-		if (_OrientVerticesInEmbedding(theGraph) != OK ||
-			_K4_RestoreAndOrientReducedPaths(theGraph, context) != OK)
-			return NOTOK;
+        // Impose consistent orientation on the embedding so we can then
+        // restore the reduced paths.
+        if (_OrientVerticesInEmbedding(theGraph) != OK ||
+            _K4_RestoreAndOrientReducedPaths(theGraph, context) != OK)
+            return NOTOK;
 
-		// Set up to isolate minor E
-		_ClearVisitedFlags(theGraph);
+        // Set up to isolate minor E
+        _ClearVisitedFlags(theGraph);
 
-		if (_FindUnembeddedEdgeToCurVertex(theGraph, IC->w, &IC->dw) != TRUE)
-			return NOTOK;
+        if (_FindUnembeddedEdgeToCurVertex(theGraph, IC->w, &IC->dw) != TRUE)
+            return NOTOK;
 
-		if (_SetVertexTypesForMarkingXYPath(theGraph) != OK)
-			return NOTOK;
-		if (_MarkHighestXYPath(theGraph) != OK || theGraph->IC.py == NIL)
-			return NOTOK;
+        if (_SetVertexTypesForMarkingXYPath(theGraph) != OK)
+            return NOTOK;
+        if (_MarkHighestXYPath(theGraph) != OK || theGraph->IC.py == NIL)
+            return NOTOK;
 
-		// Isolate the K4 homeomorph
-		if (_IsolateOuterplanarityObstructionE(theGraph) != OK ||
-			_DeleteUnmarkedVerticesAndEdges(theGraph) != OK)
-			return NOTOK;
+        // Isolate the K4 homeomorph
+        if (_IsolateOuterplanarityObstructionE(theGraph) != OK ||
+            _DeleteUnmarkedVerticesAndEdges(theGraph) != OK)
+            return NOTOK;
 
-		// Return indication that K4 homeomorph has been found
-		return NONEMBEDDABLE;
-	}
+        // Return indication that K4 homeomorph has been found
+        return NONEMBEDDABLE;
+    }
 
-	// You never get here in an error-free implementation like this one
-	return NOTOK;
+    // You never get here in an error-free implementation like this one
+    return NOTOK;
 }
 
 /****************************************************************************
@@ -406,77 +406,77 @@ int _SearchForK4InBicomp(graphP theGraph, K4SearchContext *context, int v, int R
 
 int _K4_ChooseTypeOfNonOuterplanarityMinor(graphP theGraph, int v, int R)
 {
-	int XPrevLink = 1, YPrevLink = 0;
-	int Wx, WxPrevLink, Wy, WyPrevLink;
+    int XPrevLink = 1, YPrevLink = 0;
+    int Wx, WxPrevLink, Wy, WyPrevLink;
 
-	_InitIsolatorContext(theGraph);
+    _InitIsolatorContext(theGraph);
 
-	theGraph->IC.v = v;
-	theGraph->IC.r = R;
+    theGraph->IC.v = v;
+    theGraph->IC.r = R;
 
-	// Reality check on data structure integrity
-	if (!gp_VirtualVertexInUse(theGraph, R))
-		return NOTOK;
+    // Reality check on data structure integrity
+    if (!gp_VirtualVertexInUse(theGraph, R))
+        return NOTOK;
 
-	// We are essentially doing a _FindActiveVertices() here, except two things:
-	// 1) for outerplanarity we know the first vertices along the paths from R
-	//    are the desired vertices because no vertices are "inactive"
-	// 2) We have purposely not oriented the bicomp, so the XPrevLink result is
-	//    needed to help find the pertinent vertex W
-	theGraph->IC.x = _GetNeighborOnExtFace(theGraph, R, &XPrevLink);
-	theGraph->IC.y = _GetNeighborOnExtFace(theGraph, R, &YPrevLink);
+    // We are essentially doing a _FindActiveVertices() here, except two things:
+    // 1) for outerplanarity we know the first vertices along the paths from R
+    //    are the desired vertices because no vertices are "inactive"
+    // 2) We have purposely not oriented the bicomp, so the XPrevLink result is
+    //    needed to help find the pertinent vertex W
+    theGraph->IC.x = _GetNeighborOnExtFace(theGraph, R, &XPrevLink);
+    theGraph->IC.y = _GetNeighborOnExtFace(theGraph, R, &YPrevLink);
 
-	// We are essentially doing a _FindPertinentVertex() here, except two things:
-	// 1) It is not known whether the reduction of the path through X or the path
-	//    through Y will enable the pertinence of W to be resolved, so it is
-	//    necessary to perform parallel face traversal to find W with a cost no
-	//    more than twice what it will take to resolve the W's pertinence
-	//    (assuming we have to do a reduction rather than finding an entangled K4)
-	// 2) In the normal _FindPertinentVertex(), the bicomp is already oriented, so
-	//    the "prev link" is hard coded to traverse down the X side.  In this
-	//    implementation, the  bicomp is purposely not oriented, so we need to know
-	//    XPrevLink and YPrevLink in order to set off in the correct directions.
-	Wx = theGraph->IC.x;
-	WxPrevLink = XPrevLink;
-	Wy = theGraph->IC.y;
-	WyPrevLink = YPrevLink;
-	theGraph->IC.w = NIL;
+    // We are essentially doing a _FindPertinentVertex() here, except two things:
+    // 1) It is not known whether the reduction of the path through X or the path
+    //    through Y will enable the pertinence of W to be resolved, so it is
+    //    necessary to perform parallel face traversal to find W with a cost no
+    //    more than twice what it will take to resolve the W's pertinence
+    //    (assuming we have to do a reduction rather than finding an entangled K4)
+    // 2) In the normal _FindPertinentVertex(), the bicomp is already oriented, so
+    //    the "prev link" is hard coded to traverse down the X side.  In this
+    //    implementation, the  bicomp is purposely not oriented, so we need to know
+    //    XPrevLink and YPrevLink in order to set off in the correct directions.
+    Wx = theGraph->IC.x;
+    WxPrevLink = XPrevLink;
+    Wy = theGraph->IC.y;
+    WyPrevLink = YPrevLink;
+    theGraph->IC.w = NIL;
 
-	while (Wx != theGraph->IC.y)
-	{
-		Wx = _GetNeighborOnExtFace(theGraph, Wx, &WxPrevLink);
-		if (PERTINENT(theGraph, Wx))
-		{
-			theGraph->IC.w = Wx;
-			break;
-		}
-		Wy = _GetNeighborOnExtFace(theGraph, Wy, &WyPrevLink);
-		if (PERTINENT(theGraph, Wy))
-		{
-			theGraph->IC.w = Wy;
-			break;
-		}
-	}
+    while (Wx != theGraph->IC.y)
+    {
+        Wx = _GetNeighborOnExtFace(theGraph, Wx, &WxPrevLink);
+        if (PERTINENT(theGraph, Wx))
+        {
+            theGraph->IC.w = Wx;
+            break;
+        }
+        Wy = _GetNeighborOnExtFace(theGraph, Wy, &WyPrevLink);
+        if (PERTINENT(theGraph, Wy))
+        {
+            theGraph->IC.w = Wy;
+            break;
+        }
+    }
 
-	if (gp_IsNotVertex(theGraph->IC.w))
-		return NOTOK;
+    if (gp_IsNotVertex(theGraph->IC.w))
+        return NOTOK;
 
-	// If the root copy is not a root copy of the current vertex v,
-	// then the Walkdown terminated on a descendant bicomp, which is Minor A.
-	if (gp_GetPrimaryVertexFromRoot(theGraph, R) != v)
-		theGraph->IC.minorType |= MINORTYPE_A;
+    // If the root copy is not a root copy of the current vertex v,
+    // then the Walkdown terminated on a descendant bicomp, which is Minor A.
+    if (gp_GetPrimaryVertexFromRoot(theGraph, R) != v)
+        theGraph->IC.minorType |= MINORTYPE_A;
 
-	// If W has a pertinent child bicomp, then we've found Minor B.
-	// Notice this is different from planarity, in which minor B is indicated
-	// only if the pertinent child bicomp is also future pertinent.
-	else if (gp_IsVertex(gp_GetVertexPertinentRootsList(theGraph, theGraph->IC.w)))
-		theGraph->IC.minorType |= MINORTYPE_B;
+    // If W has a pertinent child bicomp, then we've found Minor B.
+    // Notice this is different from planarity, in which minor B is indicated
+    // only if the pertinent child bicomp is also future pertinent.
+    else if (gp_IsVertex(gp_GetVertexPertinentRootsList(theGraph, theGraph->IC.w)))
+        theGraph->IC.minorType |= MINORTYPE_B;
 
-	// The only other result is minor E (we will search for the X-Y path later)
-	else
-		theGraph->IC.minorType |= MINORTYPE_E;
+    // The only other result is minor E (we will search for the X-Y path later)
+    else
+        theGraph->IC.minorType |= MINORTYPE_E;
 
-	return OK;
+    return OK;
 }
 
 /****************************************************************************
@@ -494,57 +494,57 @@ int _K4_ChooseTypeOfNonOuterplanarityMinor(graphP theGraph, int v, int R)
 
 int _K4_FindSecondActiveVertexOnLowExtFacePath(graphP theGraph)
 {
-	int Z = theGraph->IC.r, ZPrevLink = 1;
+    int Z = theGraph->IC.r, ZPrevLink = 1;
 
-	// First we test X for future pertinence only (if it were pertinent, then
-	// we wouldn't have been blocked up on this bicomp)
-	Z = _GetNeighborOnExtFace(theGraph, Z, &ZPrevLink);
-	gp_UpdateVertexFuturePertinentChild(theGraph, Z, theGraph->IC.v);
-	if (FUTUREPERTINENT(theGraph, Z, theGraph->IC.v))
-	{
-		theGraph->IC.z = Z;
-		theGraph->IC.uz = _GetLeastAncestorConnection(theGraph, Z);
-		return TRUE;
-	}
+    // First we test X for future pertinence only (if it were pertinent, then
+    // we wouldn't have been blocked up on this bicomp)
+    Z = _GetNeighborOnExtFace(theGraph, Z, &ZPrevLink);
+    gp_UpdateVertexFuturePertinentChild(theGraph, Z, theGraph->IC.v);
+    if (FUTUREPERTINENT(theGraph, Z, theGraph->IC.v))
+    {
+        theGraph->IC.z = Z;
+        theGraph->IC.uz = _GetLeastAncestorConnection(theGraph, Z);
+        return TRUE;
+    }
 
-	// Now we move on to test all the vertices strictly between X and Y on
-	// the lower external face path, except W, for either pertinence or
-	// future pertinence.
-	Z = _GetNeighborOnExtFace(theGraph, Z, &ZPrevLink);
+    // Now we move on to test all the vertices strictly between X and Y on
+    // the lower external face path, except W, for either pertinence or
+    // future pertinence.
+    Z = _GetNeighborOnExtFace(theGraph, Z, &ZPrevLink);
 
-	while (Z != theGraph->IC.y)
-	{
-		if (Z != theGraph->IC.w)
-		{
-			gp_UpdateVertexFuturePertinentChild(theGraph, Z, theGraph->IC.v);
-			if (FUTUREPERTINENT(theGraph, Z, theGraph->IC.v))
-			{
-				theGraph->IC.z = Z;
-				theGraph->IC.uz = _GetLeastAncestorConnection(theGraph, Z);
-				return TRUE;
-			}
-			else if (PERTINENT(theGraph, Z))
-			{
-				theGraph->IC.z = Z;
-				theGraph->IC.uz = theGraph->IC.v;
-				return TRUE;
-			}
-		}
+    while (Z != theGraph->IC.y)
+    {
+        if (Z != theGraph->IC.w)
+        {
+            gp_UpdateVertexFuturePertinentChild(theGraph, Z, theGraph->IC.v);
+            if (FUTUREPERTINENT(theGraph, Z, theGraph->IC.v))
+            {
+                theGraph->IC.z = Z;
+                theGraph->IC.uz = _GetLeastAncestorConnection(theGraph, Z);
+                return TRUE;
+            }
+            else if (PERTINENT(theGraph, Z))
+            {
+                theGraph->IC.z = Z;
+                theGraph->IC.uz = theGraph->IC.v;
+                return TRUE;
+            }
+        }
 
-		Z = _GetNeighborOnExtFace(theGraph, Z, &ZPrevLink);
-	}
+        Z = _GetNeighborOnExtFace(theGraph, Z, &ZPrevLink);
+    }
 
-	// Now we test Y for future pertinence (same explanation as for X above)
-	gp_UpdateVertexFuturePertinentChild(theGraph, Z, theGraph->IC.v);
-	if (FUTUREPERTINENT(theGraph, Z, theGraph->IC.v))
-	{
-		theGraph->IC.z = Z;
-		theGraph->IC.uz = _GetLeastAncestorConnection(theGraph, Z);
-		return TRUE;
-	}
+    // Now we test Y for future pertinence (same explanation as for X above)
+    gp_UpdateVertexFuturePertinentChild(theGraph, Z, theGraph->IC.v);
+    if (FUTUREPERTINENT(theGraph, Z, theGraph->IC.v))
+    {
+        theGraph->IC.z = Z;
+        theGraph->IC.uz = _GetLeastAncestorConnection(theGraph, Z);
+        return TRUE;
+    }
 
-	// We didn't find the desired second vertex, so report FALSE
-	return FALSE;
+    // We didn't find the desired second vertex, so report FALSE
+    return FALSE;
 }
 
 /****************************************************************************
@@ -556,31 +556,31 @@ int _K4_FindSecondActiveVertexOnLowExtFacePath(graphP theGraph)
 
 int _K4_FindPlanarityActiveVertex(graphP theGraph, int v, int R, int prevLink, int *pW)
 {
-	int W = R, WPrevLink = prevLink;
+    int W = R, WPrevLink = prevLink;
 
-	W = _GetNeighborOnExtFace(theGraph, R, &WPrevLink);
+    W = _GetNeighborOnExtFace(theGraph, R, &WPrevLink);
 
-	while (W != R)
-	{
-		if (PERTINENT(theGraph, W))
-		{
-			*pW = W;
-			return OK;
-		}
-		else
-		{
-			gp_UpdateVertexFuturePertinentChild(theGraph, W, v);
-			if (FUTUREPERTINENT(theGraph, W, v))
-			{
-				*pW = W;
-				return OK;
-			}
-		}
+    while (W != R)
+    {
+        if (PERTINENT(theGraph, W))
+        {
+            *pW = W;
+            return OK;
+        }
+        else
+        {
+            gp_UpdateVertexFuturePertinentChild(theGraph, W, v);
+            if (FUTUREPERTINENT(theGraph, W, v))
+            {
+                *pW = W;
+                return OK;
+            }
+        }
 
-		W = _GetNeighborOnExtFace(theGraph, W, &WPrevLink);
-	}
+        W = _GetNeighborOnExtFace(theGraph, W, &WPrevLink);
+    }
 
-	return NOTOK;
+    return NOTOK;
 }
 
 /****************************************************************************
@@ -619,48 +619,48 @@ int _K4_FindPlanarityActiveVertex(graphP theGraph, int v, int R, int prevLink, i
 
 int _K4_FindSeparatingInternalEdge(graphP theGraph, int R, int prevLink, int A, int *pW, int *pX, int *pY)
 {
-	int Z, ZPrevLink, e, neighbor;
+    int Z, ZPrevLink, e, neighbor;
 
-	// Mark the vertex obstruction type settings along the path [R ... A]
-	_K4_MarkObstructionTypeOnExternalFacePath(theGraph, R, prevLink, A);
+    // Mark the vertex obstruction type settings along the path [R ... A]
+    _K4_MarkObstructionTypeOnExternalFacePath(theGraph, R, prevLink, A);
 
-	// Search each of the vertices in the range (R ... A)
-	*pX = *pY = NIL;
-	ZPrevLink = prevLink;
-	Z = _GetNeighborOnExtFace(theGraph, R, &ZPrevLink);
-	while (Z != A)
-	{
-		// Search for a separator among the edges of Z
-		// It is OK to not bother skipping the external face edges, since we
-		// know they are marked visited and so are ignored
-		e = gp_GetFirstArc(theGraph, Z);
-		while (gp_IsArc(e))
-		{
-			neighbor = gp_GetNeighbor(theGraph, e);
-			if (gp_GetVertexObstructionType(theGraph, neighbor) == VERTEX_OBSTRUCTIONTYPE_UNMARKED)
-			{
-				*pW = A;
-				*pX = Z;
-				*pY = neighbor;
-				break;
-			}
-			e = gp_GetNextArc(theGraph, e);
-		}
+    // Search each of the vertices in the range (R ... A)
+    *pX = *pY = NIL;
+    ZPrevLink = prevLink;
+    Z = _GetNeighborOnExtFace(theGraph, R, &ZPrevLink);
+    while (Z != A)
+    {
+        // Search for a separator among the edges of Z
+        // It is OK to not bother skipping the external face edges, since we
+        // know they are marked visited and so are ignored
+        e = gp_GetFirstArc(theGraph, Z);
+        while (gp_IsArc(e))
+        {
+            neighbor = gp_GetNeighbor(theGraph, e);
+            if (gp_GetVertexObstructionType(theGraph, neighbor) == VERTEX_OBSTRUCTIONTYPE_UNMARKED)
+            {
+                *pW = A;
+                *pX = Z;
+                *pY = neighbor;
+                break;
+            }
+            e = gp_GetNextArc(theGraph, e);
+        }
 
-		// If we found the separator edge, then we don't need to go on
-		if (gp_IsVertex(*pX))
-		{
-			break;
-		}
+        // If we found the separator edge, then we don't need to go on
+        if (gp_IsVertex(*pX))
+        {
+            break;
+        }
 
-		// Go to the next vertex
-		Z = _GetNeighborOnExtFace(theGraph, Z, &ZPrevLink);
-	}
+        // Go to the next vertex
+        Z = _GetNeighborOnExtFace(theGraph, Z, &ZPrevLink);
+    }
 
-	// Restore the unmarked obstruction type settings on the path [R ... A]
-	_K4_UnmarkObstructionTypeOnExternalFacePath(theGraph, R, prevLink, A);
+    // Restore the unmarked obstruction type settings on the path [R ... A]
+    _K4_UnmarkObstructionTypeOnExternalFacePath(theGraph, R, prevLink, A);
 
-	return gp_IsVertex(*pX) ? TRUE : FALSE;
+    return gp_IsVertex(*pX) ? TRUE : FALSE;
 }
 
 /****************************************************************************
@@ -673,16 +673,16 @@ int _K4_FindSeparatingInternalEdge(graphP theGraph, int R, int prevLink, int A, 
 
 void _K4_MarkObstructionTypeOnExternalFacePath(graphP theGraph, int R, int prevLink, int A)
 {
-	int Z, ZPrevLink;
+    int Z, ZPrevLink;
 
-	gp_SetVertexObstructionType(theGraph, R, VERTEX_OBSTRUCTIONTYPE_MARKED);
-	ZPrevLink = prevLink;
-	Z = R;
-	while (Z != A)
-	{
-		Z = _GetNeighborOnExtFace(theGraph, Z, &ZPrevLink);
-		gp_SetVertexObstructionType(theGraph, Z, VERTEX_OBSTRUCTIONTYPE_MARKED);
-	}
+    gp_SetVertexObstructionType(theGraph, R, VERTEX_OBSTRUCTIONTYPE_MARKED);
+    ZPrevLink = prevLink;
+    Z = R;
+    while (Z != A)
+    {
+        Z = _GetNeighborOnExtFace(theGraph, Z, &ZPrevLink);
+        gp_SetVertexObstructionType(theGraph, Z, VERTEX_OBSTRUCTIONTYPE_MARKED);
+    }
 }
 
 /****************************************************************************
@@ -695,16 +695,16 @@ void _K4_MarkObstructionTypeOnExternalFacePath(graphP theGraph, int R, int prevL
 
 void _K4_UnmarkObstructionTypeOnExternalFacePath(graphP theGraph, int R, int prevLink, int A)
 {
-	int Z, ZPrevLink;
+    int Z, ZPrevLink;
 
-	gp_ClearVertexObstructionType(theGraph, R);
-	ZPrevLink = prevLink;
-	Z = R;
-	while (Z != A)
-	{
-		Z = _GetNeighborOnExtFace(theGraph, Z, &ZPrevLink);
-		gp_ClearVertexObstructionType(theGraph, Z);
-	}
+    gp_ClearVertexObstructionType(theGraph, R);
+    ZPrevLink = prevLink;
+    Z = R;
+    while (Z != A)
+    {
+        Z = _GetNeighborOnExtFace(theGraph, Z, &ZPrevLink);
+        gp_ClearVertexObstructionType(theGraph, Z);
+    }
 }
 
 /****************************************************************************
@@ -718,26 +718,26 @@ void _K4_UnmarkObstructionTypeOnExternalFacePath(graphP theGraph, int R, int pre
 
 int _K4_IsolateMinorA1(graphP theGraph)
 {
-	isolatorContextP IC = &theGraph->IC;
+    isolatorContextP IC = &theGraph->IC;
 
-	if (IC->uz < IC->v)
-	{
-		if (theGraph->functions.fpMarkDFSPath(theGraph, IC->uz, IC->v) != OK)
-			return NOTOK;
-	}
+    if (IC->uz < IC->v)
+    {
+        if (theGraph->functions.fpMarkDFSPath(theGraph, IC->uz, IC->v) != OK)
+            return NOTOK;
+    }
 
-	if (theGraph->functions.fpMarkDFSPath(theGraph, IC->z, IC->dz) != OK)
-		return NOTOK;
+    if (theGraph->functions.fpMarkDFSPath(theGraph, IC->z, IC->dz) != OK)
+        return NOTOK;
 
-	if (_IsolateOuterplanarityObstructionA(theGraph) != OK)
-		return NOTOK;
+    if (_IsolateOuterplanarityObstructionA(theGraph) != OK)
+        return NOTOK;
 
-	if (_AddAndMarkEdge(theGraph, IC->uz, IC->dz) != OK)
-	{
-		return NOTOK;
-	}
+    if (_AddAndMarkEdge(theGraph, IC->uz, IC->dz) != OK)
+    {
+        return NOTOK;
+    }
 
-	return OK;
+    return OK;
 }
 
 /****************************************************************************
@@ -755,13 +755,13 @@ int _K4_IsolateMinorA1(graphP theGraph)
 
 int _K4_IsolateMinorA2(graphP theGraph)
 {
-	isolatorContextP IC = &theGraph->IC;
+    isolatorContextP IC = &theGraph->IC;
 
-	// We assume the X-Y path was already marked
-	if (!gp_GetVertexVisited(theGraph, IC->px) || !gp_GetVertexVisited(theGraph, IC->py))
-		return NOTOK;
+    // We assume the X-Y path was already marked
+    if (!gp_GetVertexVisited(theGraph, IC->px) || !gp_GetVertexVisited(theGraph, IC->py))
+        return NOTOK;
 
-	return _IsolateOuterplanarityObstructionA(theGraph);
+    return _IsolateOuterplanarityObstructionA(theGraph);
 }
 
 /****************************************************************************
@@ -782,37 +782,37 @@ int _K4_IsolateMinorA2(graphP theGraph)
 
 int _K4_IsolateMinorB1(graphP theGraph)
 {
-	isolatorContextP IC = &theGraph->IC;
+    isolatorContextP IC = &theGraph->IC;
 
-	if (theGraph->functions.fpMarkDFSPath(theGraph, IC->x, IC->dx) != OK)
-		return NOTOK;
+    if (theGraph->functions.fpMarkDFSPath(theGraph, IC->x, IC->dx) != OK)
+        return NOTOK;
 
-	if (theGraph->functions.fpMarkDFSPath(theGraph, IC->y, IC->dy) != OK)
-		return NOTOK;
+    if (theGraph->functions.fpMarkDFSPath(theGraph, IC->y, IC->dy) != OK)
+        return NOTOK;
 
-	// The path from the bicomp root to MIN(ux,uy) is marked to ensure the
-	// connection from the image vertices v and MAX(ux,uy) as well as the
-	// connection from MAX(ux,uy) through MIN(ux,uy) to (ux==MIN(ux,uy)?x:y)
-	if (theGraph->functions.fpMarkDFSPath(theGraph, MIN(IC->ux, IC->uy), IC->r) != OK)
-		return NOTOK;
+    // The path from the bicomp root to MIN(ux,uy) is marked to ensure the
+    // connection from the image vertices v and MAX(ux,uy) as well as the
+    // connection from MAX(ux,uy) through MIN(ux,uy) to (ux==MIN(ux,uy)?x:y)
+    if (theGraph->functions.fpMarkDFSPath(theGraph, MIN(IC->ux, IC->uy), IC->r) != OK)
+        return NOTOK;
 
-	// This makes the following connections (a_x ... v), (a_y ... v), and
-	// (a_x ... w ... a_y), the last being tolerant of a_x==w or a_y==w
-	if (_MarkPathAlongBicompExtFace(theGraph, IC->r, IC->r) != OK)
-		return NOTOK;
+    // This makes the following connections (a_x ... v), (a_y ... v), and
+    // (a_x ... w ... a_y), the last being tolerant of a_x==w or a_y==w
+    if (_MarkPathAlongBicompExtFace(theGraph, IC->r, IC->r) != OK)
+        return NOTOK;
 
-	if (_JoinBicomps(theGraph) != OK)
-		return NOTOK;
+    if (_JoinBicomps(theGraph) != OK)
+        return NOTOK;
 
-	if (_AddAndMarkEdge(theGraph, IC->ux, IC->dx) != OK)
-		return NOTOK;
+    if (_AddAndMarkEdge(theGraph, IC->ux, IC->dx) != OK)
+        return NOTOK;
 
-	if (_AddAndMarkEdge(theGraph, IC->uy, IC->dy) != OK)
-	{
-		return NOTOK;
-	}
+    if (_AddAndMarkEdge(theGraph, IC->uy, IC->dy) != OK)
+    {
+        return NOTOK;
+    }
 
-	return OK;
+    return OK;
 }
 
 /****************************************************************************
@@ -824,28 +824,28 @@ int _K4_IsolateMinorB1(graphP theGraph)
 
 int _K4_IsolateMinorB2(graphP theGraph)
 {
-	isolatorContextP IC = &theGraph->IC;
+    isolatorContextP IC = &theGraph->IC;
 
-	// First subcase, the active vertex is pertinent
-	if (PERTINENT(theGraph, IC->w))
-	{
-		// We assume the X-Y path was already marked
-		if (!gp_GetVertexVisited(theGraph, IC->px) || !gp_GetVertexVisited(theGraph, IC->py))
-			return NOTOK;
+    // First subcase, the active vertex is pertinent
+    if (PERTINENT(theGraph, IC->w))
+    {
+        // We assume the X-Y path was already marked
+        if (!gp_GetVertexVisited(theGraph, IC->px) || !gp_GetVertexVisited(theGraph, IC->py))
+            return NOTOK;
 
-		return _IsolateOuterplanarityObstructionE(theGraph);
-	}
+        return _IsolateOuterplanarityObstructionE(theGraph);
+    }
 
-	// Second subcase, the active vertex is future pertinent
-	else if (FUTUREPERTINENT(theGraph, IC->w, IC->v))
-	{
-		IC->v = IC->uz;
-		IC->dw = IC->dz;
+    // Second subcase, the active vertex is future pertinent
+    else if (FUTUREPERTINENT(theGraph, IC->w, IC->v))
+    {
+        IC->v = IC->uz;
+        IC->dw = IC->dz;
 
-		return _K4_IsolateMinorA2(theGraph);
-	}
+        return _K4_IsolateMinorA2(theGraph);
+    }
 
-	return OK;
+    return OK;
 }
 
 /****************************************************************************
@@ -864,27 +864,27 @@ int _K4_IsolateMinorB2(graphP theGraph)
 
 int _K4_ReduceBicompToEdge(graphP theGraph, K4SearchContext *context, int R, int W)
 {
-	int newEdge;
+    int newEdge;
 
-	if (_OrientVerticesInBicomp(theGraph, R, 0) != OK ||
-		_ClearVisitedFlagsInBicomp(theGraph, R) != OK)
-		return NOTOK;
-	if (theGraph->functions.fpMarkDFSPath(theGraph, R, W) != OK)
-		return NOTOK;
-	if (_K4_DeleteUnmarkedEdgesInBicomp(theGraph, context, R) != OK)
-		return NOTOK;
+    if (_OrientVerticesInBicomp(theGraph, R, 0) != OK ||
+        _ClearVisitedFlagsInBicomp(theGraph, R) != OK)
+        return NOTOK;
+    if (theGraph->functions.fpMarkDFSPath(theGraph, R, W) != OK)
+        return NOTOK;
+    if (_K4_DeleteUnmarkedEdgesInBicomp(theGraph, context, R) != OK)
+        return NOTOK;
 
-	// Now we have to reduce the path W -> R to the DFS tree edge (R, W)
-	newEdge = _K4_ReducePathToEdge(theGraph, context, EDGE_TYPE_PARENT,
-								   R, gp_GetFirstArc(theGraph, R), W, gp_GetFirstArc(theGraph, W));
-	if (gp_IsNotArc(newEdge))
-		return NOTOK;
+    // Now we have to reduce the path W -> R to the DFS tree edge (R, W)
+    newEdge = _K4_ReducePathToEdge(theGraph, context, EDGE_TYPE_PARENT,
+                                   R, gp_GetFirstArc(theGraph, R), W, gp_GetFirstArc(theGraph, W));
+    if (gp_IsNotArc(newEdge))
+        return NOTOK;
 
-	// Finally, set the visited info state of W to unvisited so that
-	// the core embedder (esp. Walkup) will not have any problems.
-	gp_SetVertexVisitedInfo(theGraph, W, theGraph->N);
+    // Finally, set the visited info state of W to unvisited so that
+    // the core embedder (esp. Walkup) will not have any problems.
+    gp_SetVertexVisitedInfo(theGraph, W, theGraph->N);
 
-	return OK;
+    return OK;
 }
 
 /****************************************************************************
@@ -943,71 +943,71 @@ int _K4_ReduceBicompToEdge(graphP theGraph, K4SearchContext *context, int R, int
 
 int _K4_ReducePathComponent(graphP theGraph, K4SearchContext *context, int R, int prevLink, int A)
 {
-	int e_R, e_A, Z, ZPrevLink, edgeType, invertedFlag = 0;
+    int e_R, e_A, Z, ZPrevLink, edgeType, invertedFlag = 0;
 
-	// Check whether the external face path (R, ..., A) is just an edge
-	e_R = gp_GetArc(theGraph, R, 1 ^ prevLink);
-	if (gp_GetNeighbor(theGraph, e_R) == A)
-		return OK;
+    // Check whether the external face path (R, ..., A) is just an edge
+    e_R = gp_GetArc(theGraph, R, 1 ^ prevLink);
+    if (gp_GetNeighbor(theGraph, e_R) == A)
+        return OK;
 
-	// Check for Case 1: The DFS tree path from A to R is within the reduction component
-	if (_K4_TestPathComponentForAncestor(theGraph, R, prevLink, A))
-	{
-		_K4_ClearVisitedInPathComponent(theGraph, R, prevLink, A);
-		if (theGraph->functions.fpMarkDFSPath(theGraph, R, A) != OK)
-			return NOTOK;
-		edgeType = EDGE_TYPE_PARENT;
+    // Check for Case 1: The DFS tree path from A to R is within the reduction component
+    if (_K4_TestPathComponentForAncestor(theGraph, R, prevLink, A))
+    {
+        _K4_ClearVisitedInPathComponent(theGraph, R, prevLink, A);
+        if (theGraph->functions.fpMarkDFSPath(theGraph, R, A) != OK)
+            return NOTOK;
+        edgeType = EDGE_TYPE_PARENT;
 
-		invertedFlag = _K4_GetCumulativeOrientationOnDFSPath(theGraph, R, A);
-	}
+        invertedFlag = _K4_GetCumulativeOrientationOnDFSPath(theGraph, R, A);
+    }
 
-	// Otherwise Case 2: The DFS tree path from A to R is not within the reduction component
-	else
-	{
-		_K4_ClearVisitedInPathComponent(theGraph, R, prevLink, A);
-		Z = gp_GetNeighbor(theGraph, e_R);
-		gp_SetEdgeVisited(theGraph, e_R);
-		gp_SetEdgeVisited(theGraph, gp_GetTwinArc(theGraph, e_R));
-		if (theGraph->functions.fpMarkDFSPath(theGraph, A, Z) != OK)
-		{
-			return NOTOK;
-		}
-		edgeType = EDGE_TYPE_BACK;
-	}
+    // Otherwise Case 2: The DFS tree path from A to R is not within the reduction component
+    else
+    {
+        _K4_ClearVisitedInPathComponent(theGraph, R, prevLink, A);
+        Z = gp_GetNeighbor(theGraph, e_R);
+        gp_SetEdgeVisited(theGraph, e_R);
+        gp_SetEdgeVisited(theGraph, gp_GetTwinArc(theGraph, e_R));
+        if (theGraph->functions.fpMarkDFSPath(theGraph, A, Z) != OK)
+        {
+            return NOTOK;
+        }
+        edgeType = EDGE_TYPE_BACK;
+    }
 
-	// The path to be kept/reduced is marked, so the other edges can go
-	if (_K4_DeleteUnmarkedEdgesInPathComponent(theGraph, R, prevLink, A) != OK)
-		return NOTOK;
+    // The path to be kept/reduced is marked, so the other edges can go
+    if (_K4_DeleteUnmarkedEdgesInPathComponent(theGraph, R, prevLink, A) != OK)
+        return NOTOK;
 
-	// Clear all the visited flags for safety, except the vertices R and A
-	// will remain in the embedding, and the core embedder (Walkup) uses a
-	// value greater than the current vertex to indicate an unvisited vertex
-	_K4_ClearVisitedInPathComponent(theGraph, R, prevLink, A);
-	gp_SetVertexVisitedInfo(theGraph, A, theGraph->N);
+    // Clear all the visited flags for safety, except the vertices R and A
+    // will remain in the embedding, and the core embedder (Walkup) uses a
+    // value greater than the current vertex to indicate an unvisited vertex
+    _K4_ClearVisitedInPathComponent(theGraph, R, prevLink, A);
+    gp_SetVertexVisitedInfo(theGraph, A, theGraph->N);
 
-	// Find the component's remaining edges e_A and e_R incident to A and R
-	ZPrevLink = prevLink;
-	Z = R;
-	while (Z != A)
-	{
-		Z = _GetNeighborOnExtFace(theGraph, Z, &ZPrevLink);
-	}
-	e_A = gp_GetArc(theGraph, A, ZPrevLink);
-	e_R = gp_GetArc(theGraph, R, 1 ^ prevLink);
+    // Find the component's remaining edges e_A and e_R incident to A and R
+    ZPrevLink = prevLink;
+    Z = R;
+    while (Z != A)
+    {
+        Z = _GetNeighborOnExtFace(theGraph, Z, &ZPrevLink);
+    }
+    e_A = gp_GetArc(theGraph, A, ZPrevLink);
+    e_R = gp_GetArc(theGraph, R, 1 ^ prevLink);
 
-	// Reduce the path (R ... A) to an edge
-	e_R = _K4_ReducePathToEdge(theGraph, context, edgeType, R, e_R, A, e_A);
-	if (gp_IsNotArc(e_R))
-		return NOTOK;
+    // Reduce the path (R ... A) to an edge
+    e_R = _K4_ReducePathToEdge(theGraph, context, edgeType, R, e_R, A, e_A);
+    if (gp_IsNotArc(e_R))
+        return NOTOK;
 
-	// Preserve the net orientation along the DFS path in the case of a tree edge
-	if (gp_GetEdgeType(theGraph, e_R) == EDGE_TYPE_CHILD)
-	{
-		if (invertedFlag)
-			gp_SetEdgeFlagInverted(theGraph, e_R);
-	}
+    // Preserve the net orientation along the DFS path in the case of a tree edge
+    if (gp_GetEdgeType(theGraph, e_R) == EDGE_TYPE_CHILD)
+    {
+        if (invertedFlag)
+            gp_SetEdgeFlagInverted(theGraph, e_R);
+    }
 
-	return OK;
+    return OK;
 }
 
 /********************************************************************
@@ -1020,10 +1020,10 @@ int _K4_ReducePathComponent(graphP theGraph, K4SearchContext *context, int R, in
 
 int _K4_DeleteEdge(graphP theGraph, K4SearchContext *context, int e, int nextLink)
 {
-	_K4Search_InitEdgeRec(context, e);
-	_K4Search_InitEdgeRec(context, gp_GetTwinArc(theGraph, e));
+    _K4Search_InitEdgeRec(context, e);
+    _K4Search_InitEdgeRec(context, gp_GetTwinArc(theGraph, e));
 
-	return gp_DeleteEdge(theGraph, e, nextLink);
+    return gp_DeleteEdge(theGraph, e, nextLink);
 }
 
 /********************************************************************
@@ -1044,26 +1044,26 @@ int _K4_DeleteEdge(graphP theGraph, K4SearchContext *context, int e, int nextLin
 
 int _K4_DeleteUnmarkedEdgesInBicomp(graphP theGraph, K4SearchContext *context, int BicompRoot)
 {
-	int V, e;
-	int stackBottom = sp_GetCurrentSize(theGraph->theStack);
+    int V, e;
+    int stackBottom = sp_GetCurrentSize(theGraph->theStack);
 
-	sp_Push(theGraph->theStack, BicompRoot);
-	while (sp_GetCurrentSize(theGraph->theStack) > stackBottom)
-	{
-		sp_Pop(theGraph->theStack, V);
+    sp_Push(theGraph->theStack, BicompRoot);
+    while (sp_GetCurrentSize(theGraph->theStack) > stackBottom)
+    {
+        sp_Pop(theGraph->theStack, V);
 
-		e = gp_GetFirstArc(theGraph, V);
-		while (gp_IsArc(e))
-		{
-			if (gp_GetEdgeType(theGraph, e) == EDGE_TYPE_CHILD)
-				sp_Push(theGraph->theStack, gp_GetNeighbor(theGraph, e));
+        e = gp_GetFirstArc(theGraph, V);
+        while (gp_IsArc(e))
+        {
+            if (gp_GetEdgeType(theGraph, e) == EDGE_TYPE_CHILD)
+                sp_Push(theGraph->theStack, gp_GetNeighbor(theGraph, e));
 
-			e = gp_GetEdgeVisited(theGraph, e)
-					? gp_GetNextArc(theGraph, e)
-					: _K4_DeleteEdge(theGraph, context, e, 0);
-		}
-	}
-	return OK;
+            e = gp_GetEdgeVisited(theGraph, e)
+                    ? gp_GetNextArc(theGraph, e)
+                    : _K4_DeleteEdge(theGraph, context, e, 0);
+        }
+    }
+    return OK;
 }
 
 /****************************************************************************
@@ -1071,58 +1071,58 @@ int _K4_DeleteUnmarkedEdgesInBicomp(graphP theGraph, K4SearchContext *context, i
  ****************************************************************************/
 int _K4_GetCumulativeOrientationOnDFSPath(graphP theGraph, int ancestor, int descendant)
 {
-	int e, parent;
-	int invertedFlag = 0;
+    int e, parent;
+    int invertedFlag = 0;
 
-	/* If we are marking from a root vertex upward, then go up to the parent
-	   copy before starting the loop */
+    /* If we are marking from a root vertex upward, then go up to the parent
+       copy before starting the loop */
 
-	if (gp_IsVirtualVertex(theGraph, descendant))
-		descendant = gp_GetPrimaryVertexFromRoot(theGraph, descendant);
+    if (gp_IsVirtualVertex(theGraph, descendant))
+        descendant = gp_GetPrimaryVertexFromRoot(theGraph, descendant);
 
-	while (descendant != ancestor)
-	{
-		if (gp_IsNotVertex(descendant))
-			return NOTOK;
+    while (descendant != ancestor)
+    {
+        if (gp_IsNotVertex(descendant))
+            return NOTOK;
 
-		// If we are at a bicomp root, then ascend to its parent copy
-		if (gp_IsVirtualVertex(theGraph, descendant))
-		{
-			parent = gp_GetPrimaryVertexFromRoot(theGraph, descendant);
-		}
+        // If we are at a bicomp root, then ascend to its parent copy
+        if (gp_IsVirtualVertex(theGraph, descendant))
+        {
+            parent = gp_GetPrimaryVertexFromRoot(theGraph, descendant);
+        }
 
-		// If we are on a regular, non-virtual vertex then get the edge to the parent
-		else
-		{
-			// Scan the edges for the one marked as the DFS parent
-			parent = NIL;
-			e = gp_GetFirstArc(theGraph, descendant);
-			while (gp_IsArc(e))
-			{
-				if (gp_GetEdgeType(theGraph, e) == EDGE_TYPE_PARENT)
-				{
-					parent = gp_GetNeighbor(theGraph, e);
-					break;
-				}
-				e = gp_GetNextArc(theGraph, e);
-			}
+        // If we are on a regular, non-virtual vertex then get the edge to the parent
+        else
+        {
+            // Scan the edges for the one marked as the DFS parent
+            parent = NIL;
+            e = gp_GetFirstArc(theGraph, descendant);
+            while (gp_IsArc(e))
+            {
+                if (gp_GetEdgeType(theGraph, e) == EDGE_TYPE_PARENT)
+                {
+                    parent = gp_GetNeighbor(theGraph, e);
+                    break;
+                }
+                e = gp_GetNextArc(theGraph, e);
+            }
 
-			// If the edge to the parent vertex was not found, then the data structure is corrupt
-			if (gp_IsNotVertex(parent))
-				return NOTOK;
+            // If the edge to the parent vertex was not found, then the data structure is corrupt
+            if (gp_IsNotVertex(parent))
+                return NOTOK;
 
-			// Add the inversion flag on the child arc to the cumulative result
-			e = gp_GetTwinArc(theGraph, e);
-			if (gp_GetEdgeType(theGraph, e) != EDGE_TYPE_CHILD || gp_GetNeighbor(theGraph, e) != descendant)
-				return NOTOK;
-			invertedFlag ^= gp_GetEdgeFlagInverted(theGraph, e);
-		}
+            // Add the inversion flag on the child arc to the cumulative result
+            e = gp_GetTwinArc(theGraph, e);
+            if (gp_GetEdgeType(theGraph, e) != EDGE_TYPE_CHILD || gp_GetNeighbor(theGraph, e) != descendant)
+                return NOTOK;
+            invertedFlag ^= gp_GetEdgeFlagInverted(theGraph, e);
+        }
 
-		// Hop to the parent and reiterate
-		descendant = parent;
-	}
+        // Hop to the parent and reiterate
+        descendant = parent;
+    }
 
-	return invertedFlag;
+    return invertedFlag;
 }
 
 /****************************************************************************
@@ -1133,17 +1133,17 @@ int _K4_GetCumulativeOrientationOnDFSPath(graphP theGraph, int ancestor, int des
 
 int _K4_TestPathComponentForAncestor(graphP theGraph, int R, int prevLink, int A)
 {
-	int Z, ZPrevLink;
+    int Z, ZPrevLink;
 
-	ZPrevLink = prevLink;
-	Z = R;
-	while (Z != A)
-	{
-		Z = _GetNeighborOnExtFace(theGraph, Z, &ZPrevLink);
-		if (Z < A)
-			return TRUE;
-	}
-	return FALSE;
+    ZPrevLink = prevLink;
+    Z = R;
+    while (Z != A)
+    {
+        Z = _GetNeighborOnExtFace(theGraph, Z, &ZPrevLink);
+        if (Z < A)
+            return TRUE;
+    }
+    return FALSE;
 }
 
 /****************************************************************************
@@ -1167,25 +1167,25 @@ int _K4_TestPathComponentForAncestor(graphP theGraph, int R, int prevLink, int A
 
 void _K4_ClearVisitedInPathComponent(graphP theGraph, int R, int prevLink, int A)
 {
-	int Z, ZPrevLink, e;
+    int Z, ZPrevLink, e;
 
-	ZPrevLink = prevLink;
-	Z = _GetNeighborOnExtFace(theGraph, R, &ZPrevLink);
-	while (Z != A)
-	{
-		gp_ClearVertexVisited(theGraph, Z);
-		e = gp_GetFirstArc(theGraph, Z);
-		while (gp_IsArc(e))
-		{
-			gp_ClearEdgeVisited(theGraph, e);
-			gp_ClearEdgeVisited(theGraph, gp_GetTwinArc(theGraph, e));
-			gp_ClearVertexVisited(theGraph, gp_GetNeighbor(theGraph, e));
+    ZPrevLink = prevLink;
+    Z = _GetNeighborOnExtFace(theGraph, R, &ZPrevLink);
+    while (Z != A)
+    {
+        gp_ClearVertexVisited(theGraph, Z);
+        e = gp_GetFirstArc(theGraph, Z);
+        while (gp_IsArc(e))
+        {
+            gp_ClearEdgeVisited(theGraph, e);
+            gp_ClearEdgeVisited(theGraph, gp_GetTwinArc(theGraph, e));
+            gp_ClearVertexVisited(theGraph, gp_GetNeighbor(theGraph, e));
 
-			e = gp_GetNextArc(theGraph, e);
-		}
+            e = gp_GetNextArc(theGraph, e);
+        }
 
-		Z = _GetNeighborOnExtFace(theGraph, Z, &ZPrevLink);
-	}
+        Z = _GetNeighborOnExtFace(theGraph, Z, &ZPrevLink);
+    }
 }
 
 /****************************************************************************
@@ -1200,65 +1200,65 @@ void _K4_ClearVisitedInPathComponent(graphP theGraph, int R, int prevLink, int A
  intend to preserve. This routine deletes the unvisited edges.
 
  NOTE: This reduction invalidates the short-circuit extFace data structure,
-	   but it will be repaired for use by WalkUp and WalkDown when the path
-	   component reduction is completed.
+       but it will be repaired for use by WalkUp and WalkDown when the path
+       component reduction is completed.
 
  Returns OK on success, NOTOK on internal error
  ****************************************************************************/
 
 int _K4_DeleteUnmarkedEdgesInPathComponent(graphP theGraph, int R, int prevLink, int A)
 {
-	int Z, ZPrevLink, e;
-	K4SearchContext *context = NULL;
-	gp_FindExtension(theGraph, K4SEARCH_ID, (void *)&context);
+    int Z, ZPrevLink, e;
+    K4SearchContext *context = NULL;
+    gp_FindExtension(theGraph, K4SEARCH_ID, (void *)&context);
 
-	if (context == NULL)
-	{
-		return NOTOK;
-	}
+    if (context == NULL)
+    {
+        return NOTOK;
+    }
 
-	// We need to use the stack to store up the edges we're going to delete.
-	// We want to make sure there is enough stack capacity to handle it,
-	// which is of course true because the stack is supposed to be empty.
-	// We're doing a reduction on a bicomp on which the WalkDown has completed,
-	// so the stack contains no bicomp roots to merge.
-	if (sp_NonEmpty(theGraph->theStack))
-		return NOTOK;
+    // We need to use the stack to store up the edges we're going to delete.
+    // We want to make sure there is enough stack capacity to handle it,
+    // which is of course true because the stack is supposed to be empty.
+    // We're doing a reduction on a bicomp on which the WalkDown has completed,
+    // so the stack contains no bicomp roots to merge.
+    if (sp_NonEmpty(theGraph->theStack))
+        return NOTOK;
 
-	// Traverse all vertices internal to the path (R ... A) and push
-	// all non-visited edges
-	ZPrevLink = prevLink;
-	Z = _GetNeighborOnExtFace(theGraph, R, &ZPrevLink);
-	while (Z != A)
-	{
-		e = gp_GetFirstArc(theGraph, Z);
-		while (gp_IsArc(e))
-		{
-			// The comparison of e to its twin is a useful way of ensuring we
-			// don't push the edge twice, which is of course only applicable
-			// when processing an edge whose endpoints are both internal to
-			// the path (R ... A)
-			if (!gp_GetEdgeVisited(theGraph, e) &&
-				(e < gp_GetTwinArc(theGraph, e) ||
-				 gp_GetNeighbor(theGraph, e) == R || gp_GetNeighbor(theGraph, e) == A))
-			{
-				sp_Push(theGraph->theStack, e);
-			}
+    // Traverse all vertices internal to the path (R ... A) and push
+    // all non-visited edges
+    ZPrevLink = prevLink;
+    Z = _GetNeighborOnExtFace(theGraph, R, &ZPrevLink);
+    while (Z != A)
+    {
+        e = gp_GetFirstArc(theGraph, Z);
+        while (gp_IsArc(e))
+        {
+            // The comparison of e to its twin is a useful way of ensuring we
+            // don't push the edge twice, which is of course only applicable
+            // when processing an edge whose endpoints are both internal to
+            // the path (R ... A)
+            if (!gp_GetEdgeVisited(theGraph, e) &&
+                (e < gp_GetTwinArc(theGraph, e) ||
+                 gp_GetNeighbor(theGraph, e) == R || gp_GetNeighbor(theGraph, e) == A))
+            {
+                sp_Push(theGraph->theStack, e);
+            }
 
-			e = gp_GetNextArc(theGraph, e);
-		}
+            e = gp_GetNextArc(theGraph, e);
+        }
 
-		Z = _GetNeighborOnExtFace(theGraph, Z, &ZPrevLink);
-	}
+        Z = _GetNeighborOnExtFace(theGraph, Z, &ZPrevLink);
+    }
 
-	// Delete all the non-visited edges
-	while (sp_NonEmpty(theGraph->theStack))
-	{
-		sp_Pop(theGraph->theStack, e);
-		_K4_DeleteEdge(theGraph, context, e, 0);
-	}
+    // Delete all the non-visited edges
+    while (sp_NonEmpty(theGraph->theStack))
+    {
+        sp_Pop(theGraph->theStack, e);
+        _K4_DeleteEdge(theGraph, context, e, 0);
+    }
 
-	return OK;
+    return OK;
 }
 
 /****************************************************************************
@@ -1271,76 +1271,76 @@ int _K4_DeleteUnmarkedEdgesInPathComponent(graphP theGraph, int R, int prevLink,
 
 int _K4_ReducePathToEdge(graphP theGraph, K4SearchContext *context, int edgeType, int R, int e_R, int A, int e_A)
 {
-	// Find out the links used in vertex R for edge e_R and in vertex A for edge e_A
-	int Rlink = gp_GetFirstArc(theGraph, R) == e_R ? 0 : 1;
-	int Alink = gp_GetFirstArc(theGraph, A) == e_A ? 0 : 1;
+    // Find out the links used in vertex R for edge e_R and in vertex A for edge e_A
+    int Rlink = gp_GetFirstArc(theGraph, R) == e_R ? 0 : 1;
+    int Alink = gp_GetFirstArc(theGraph, A) == e_A ? 0 : 1;
 
-	// If the path is more than a single edge, then it must be reduced to an edge.
-	// Note that even if the path is a single edge, the external face data structure
-	// must still be modified since many edges connecting the external face have
-	// been deleted
-	if (gp_GetNeighbor(theGraph, e_R) != A)
-	{
-		int v_R, v_A;
+    // If the path is more than a single edge, then it must be reduced to an edge.
+    // Note that even if the path is a single edge, the external face data structure
+    // must still be modified since many edges connecting the external face have
+    // been deleted
+    if (gp_GetNeighbor(theGraph, e_R) != A)
+    {
+        int v_R, v_A;
 
-		// Prepare for removing each of the two edges that join the path to the bicomp by
-		// restoring it if it is a reduction edge (a constant time operation)
-		if (gp_IsVertex(context->E[e_R].pathConnector))
-		{
-			if (_K4_RestoreReducedPath(theGraph, context, e_R) != OK)
-				return NOTOK;
+        // Prepare for removing each of the two edges that join the path to the bicomp by
+        // restoring it if it is a reduction edge (a constant time operation)
+        if (gp_IsVertex(context->E[e_R].pathConnector))
+        {
+            if (_K4_RestoreReducedPath(theGraph, context, e_R) != OK)
+                return NOTOK;
 
-			e_R = gp_GetArc(theGraph, R, Rlink);
-		}
+            e_R = gp_GetArc(theGraph, R, Rlink);
+        }
 
-		if (gp_IsVertex(context->E[e_A].pathConnector))
-		{
-			if (_K4_RestoreReducedPath(theGraph, context, e_A) != OK)
-				return NOTOK;
-			e_A = gp_GetArc(theGraph, A, Alink);
-		}
+        if (gp_IsVertex(context->E[e_A].pathConnector))
+        {
+            if (_K4_RestoreReducedPath(theGraph, context, e_A) != OK)
+                return NOTOK;
+            e_A = gp_GetArc(theGraph, A, Alink);
+        }
 
-		// Save the vertex neighbors of R and A indicated by e_R and e_A for
-		// later use in setting up the path connectors.
-		v_R = gp_GetNeighbor(theGraph, e_R);
-		v_A = gp_GetNeighbor(theGraph, e_A);
+        // Save the vertex neighbors of R and A indicated by e_R and e_A for
+        // later use in setting up the path connectors.
+        v_R = gp_GetNeighbor(theGraph, e_R);
+        v_A = gp_GetNeighbor(theGraph, e_A);
 
-		// Now delete the two edges that join the path to the bicomp.
-		_K4_DeleteEdge(theGraph, context, e_R, 0);
-		_K4_DeleteEdge(theGraph, context, e_A, 0);
+        // Now delete the two edges that join the path to the bicomp.
+        _K4_DeleteEdge(theGraph, context, e_R, 0);
+        _K4_DeleteEdge(theGraph, context, e_A, 0);
 
-		// Now add a single edge to represent the path
-		// We use 1^Rlink, for example, because Rlink was the link from R that indicated e_R,
-		// so 1^Rlink is the link that indicated e_R in the other arc that was adjacent to e_R.
-		// We want gp_InsertEdge to place the new arc where e_R was in R's adjacency list
-		gp_InsertEdge(theGraph, R, gp_GetArc(theGraph, R, Rlink), 1 ^ Rlink,
-					  A, gp_GetArc(theGraph, A, Alink), 1 ^ Alink);
+        // Now add a single edge to represent the path
+        // We use 1^Rlink, for example, because Rlink was the link from R that indicated e_R,
+        // so 1^Rlink is the link that indicated e_R in the other arc that was adjacent to e_R.
+        // We want gp_InsertEdge to place the new arc where e_R was in R's adjacency list
+        gp_InsertEdge(theGraph, R, gp_GetArc(theGraph, R, Rlink), 1 ^ Rlink,
+                      A, gp_GetArc(theGraph, A, Alink), 1 ^ Alink);
 
-		// Now set up the path connectors so the original path can be recovered if needed.
-		e_R = gp_GetArc(theGraph, R, Rlink);
-		context->E[e_R].pathConnector = v_R;
+        // Now set up the path connectors so the original path can be recovered if needed.
+        e_R = gp_GetArc(theGraph, R, Rlink);
+        context->E[e_R].pathConnector = v_R;
 
-		e_A = gp_GetArc(theGraph, A, Alink);
-		context->E[e_A].pathConnector = v_A;
+        e_A = gp_GetArc(theGraph, A, Alink);
+        context->E[e_A].pathConnector = v_A;
 
-		// Also, set the reduction edge's type to preserve the DFS tree structure
-		gp_SetEdgeType(theGraph, e_R, _ComputeArcType(theGraph, R, A, edgeType));
-		gp_SetEdgeType(theGraph, e_A, _ComputeArcType(theGraph, A, R, edgeType));
-	}
+        // Also, set the reduction edge's type to preserve the DFS tree structure
+        gp_SetEdgeType(theGraph, e_R, _ComputeArcType(theGraph, R, A, edgeType));
+        gp_SetEdgeType(theGraph, e_A, _ComputeArcType(theGraph, A, R, edgeType));
+    }
 
-	// Set the external face data structure
-	gp_SetExtFaceVertex(theGraph, R, Rlink, A);
-	gp_SetExtFaceVertex(theGraph, A, Alink, R);
+    // Set the external face data structure
+    gp_SetExtFaceVertex(theGraph, R, Rlink, A);
+    gp_SetExtFaceVertex(theGraph, A, Alink, R);
 
-	// If the edge represents an entire bicomp, then more external face
-	// settings are needed.
-	if (gp_GetFirstArc(theGraph, R) == gp_GetLastArc(theGraph, R))
-	{
-		gp_SetExtFaceVertex(theGraph, R, 1 ^ Rlink, A);
-		gp_SetExtFaceVertex(theGraph, A, 1 ^ Alink, R);
-	}
+    // If the edge represents an entire bicomp, then more external face
+    // settings are needed.
+    if (gp_GetFirstArc(theGraph, R) == gp_GetLastArc(theGraph, R))
+    {
+        gp_SetExtFaceVertex(theGraph, R, 1 ^ Rlink, A);
+        gp_SetExtFaceVertex(theGraph, A, 1 ^ Alink, R);
+    }
 
-	return e_R;
+    return e_R;
 }
 
 /****************************************************************************
@@ -1361,62 +1361,62 @@ int _K4_ReducePathToEdge(graphP theGraph, K4SearchContext *context, int edgeType
 
 int _K4_RestoreReducedPath(graphP theGraph, K4SearchContext *context, int e)
 {
-	int eTwin, u, v, w, x;
-	int e0, e1, eTwin0, eTwin1;
+    int eTwin, u, v, w, x;
+    int e0, e1, eTwin0, eTwin1;
 
-	if (gp_IsNotVertex(context->E[e].pathConnector))
-		return OK;
+    if (gp_IsNotVertex(context->E[e].pathConnector))
+        return OK;
 
-	eTwin = gp_GetTwinArc(theGraph, e);
+    eTwin = gp_GetTwinArc(theGraph, e);
 
-	u = gp_GetNeighbor(theGraph, eTwin);
-	v = context->E[e].pathConnector;
-	w = context->E[eTwin].pathConnector;
-	x = gp_GetNeighbor(theGraph, e);
+    u = gp_GetNeighbor(theGraph, eTwin);
+    v = context->E[e].pathConnector;
+    w = context->E[eTwin].pathConnector;
+    x = gp_GetNeighbor(theGraph, e);
 
-	// Get the locations of the EdgeRecs between which the new EdgeRecs
-	// must be added in order to reconnect the path parallel to the edge.
-	e0 = gp_GetNextArc(theGraph, e);
-	e1 = gp_GetPrevArc(theGraph, e);
-	eTwin0 = gp_GetNextArc(theGraph, eTwin);
-	eTwin1 = gp_GetPrevArc(theGraph, eTwin);
+    // Get the locations of the EdgeRecs between which the new EdgeRecs
+    // must be added in order to reconnect the path parallel to the edge.
+    e0 = gp_GetNextArc(theGraph, e);
+    e1 = gp_GetPrevArc(theGraph, e);
+    eTwin0 = gp_GetNextArc(theGraph, eTwin);
+    eTwin1 = gp_GetPrevArc(theGraph, eTwin);
 
-	// We first delete the edge represented by e and eTwin. We do so before
-	// restoring the path to ensure we do not exceed the maximum arc capacity.
-	_K4_DeleteEdge(theGraph, context, e, 0);
+    // We first delete the edge represented by e and eTwin. We do so before
+    // restoring the path to ensure we do not exceed the maximum arc capacity.
+    _K4_DeleteEdge(theGraph, context, e, 0);
 
-	// Now we add the two edges to reconnect the reduced path represented
-	// by the edge [e, eTwin].  The edge record in u is added between e0 and e1.
-	// Likewise, the new edge record in x is added between eTwin0 and eTwin1.
-	if (gp_IsArc(e0))
-	{
-		if (gp_InsertEdge(theGraph, u, e0, 1, v, NIL, 0) != OK)
-			return NOTOK;
-	}
-	else
-	{
-		if (gp_InsertEdge(theGraph, u, e1, 0, v, NIL, 0) != OK)
-			return NOTOK;
-	}
+    // Now we add the two edges to reconnect the reduced path represented
+    // by the edge [e, eTwin].  The edge record in u is added between e0 and e1.
+    // Likewise, the new edge record in x is added between eTwin0 and eTwin1.
+    if (gp_IsArc(e0))
+    {
+        if (gp_InsertEdge(theGraph, u, e0, 1, v, NIL, 0) != OK)
+            return NOTOK;
+    }
+    else
+    {
+        if (gp_InsertEdge(theGraph, u, e1, 0, v, NIL, 0) != OK)
+            return NOTOK;
+    }
 
-	if (gp_IsArc(eTwin0))
-	{
-		if (gp_InsertEdge(theGraph, x, eTwin0, 1, w, NIL, 0) != OK)
-			return NOTOK;
-	}
-	else
-	{
-		if (gp_InsertEdge(theGraph, x, eTwin1, 0, w, NIL, 0) != OK)
-			return NOTOK;
-	}
+    if (gp_IsArc(eTwin0))
+    {
+        if (gp_InsertEdge(theGraph, x, eTwin0, 1, w, NIL, 0) != OK)
+            return NOTOK;
+    }
+    else
+    {
+        if (gp_InsertEdge(theGraph, x, eTwin1, 0, w, NIL, 0) != OK)
+            return NOTOK;
+    }
 
-	// Set the types of the newly added edges. In both cases, the first of the two
-	// vertex parameters is known to be degree 2 because they are internal to the
-	// path being restored, so this operation is constant time.
-	if (_SetEdgeType(theGraph, v, u) != OK || _SetEdgeType(theGraph, w, x) != OK)
-		return NOTOK;
+    // Set the types of the newly added edges. In both cases, the first of the two
+    // vertex parameters is known to be degree 2 because they are internal to the
+    // path being restored, so this operation is constant time.
+    if (_SetEdgeType(theGraph, v, u) != OK || _SetEdgeType(theGraph, w, x) != OK)
+        return NOTOK;
 
-	return OK;
+    return OK;
 }
 
 /****************************************************************************
@@ -1439,52 +1439,52 @@ int _K4_RestoreReducedPath(graphP theGraph, K4SearchContext *context, int e)
 
 int _K4_RestoreAndOrientReducedPaths(graphP theGraph, K4SearchContext *context)
 {
-	int EsizeOccupied, e, eTwin, u, v, w, x, visited;
+    int EsizeOccupied, e, eTwin, u, v, w, x, visited;
 
-	EsizeOccupied = gp_EdgeInUseIndexBound(theGraph);
-	for (e = gp_GetFirstEdge(theGraph); e < EsizeOccupied;)
-	{
-		if (gp_IsVertex(context->E[e].pathConnector))
-		{
-			visited = gp_GetEdgeVisited(theGraph, e);
+    EsizeOccupied = gp_EdgeInUseIndexBound(theGraph);
+    for (e = gp_GetFirstEdge(theGraph); e < EsizeOccupied;)
+    {
+        if (gp_IsVertex(context->E[e].pathConnector))
+        {
+            visited = gp_GetEdgeVisited(theGraph, e);
 
-			eTwin = gp_GetTwinArc(theGraph, e);
-			u = gp_GetNeighbor(theGraph, eTwin);
-			v = context->E[e].pathConnector;
-			w = context->E[eTwin].pathConnector;
-			x = gp_GetNeighbor(theGraph, e);
+            eTwin = gp_GetTwinArc(theGraph, e);
+            u = gp_GetNeighbor(theGraph, eTwin);
+            v = context->E[e].pathConnector;
+            w = context->E[eTwin].pathConnector;
+            x = gp_GetNeighbor(theGraph, e);
 
-			if (_K4_RestoreReducedPath(theGraph, context, e) != OK)
-				return NOTOK;
+            if (_K4_RestoreReducedPath(theGraph, context, e) != OK)
+                return NOTOK;
 
-			// If the path is on the external face, orient it
-			if (gp_GetNeighbor(theGraph, gp_GetFirstArc(theGraph, u)) == v ||
-				gp_GetNeighbor(theGraph, gp_GetLastArc(theGraph, u)) == v)
-			{
-				// Reality check: ensure the path is connected to the
-				// external face at both vertices.
-				if (gp_GetNeighbor(theGraph, gp_GetFirstArc(theGraph, x)) != w &&
-					gp_GetNeighbor(theGraph, gp_GetLastArc(theGraph, x)) != w)
-					return NOTOK;
+            // If the path is on the external face, orient it
+            if (gp_GetNeighbor(theGraph, gp_GetFirstArc(theGraph, u)) == v ||
+                gp_GetNeighbor(theGraph, gp_GetLastArc(theGraph, u)) == v)
+            {
+                // Reality check: ensure the path is connected to the
+                // external face at both vertices.
+                if (gp_GetNeighbor(theGraph, gp_GetFirstArc(theGraph, x)) != w &&
+                    gp_GetNeighbor(theGraph, gp_GetLastArc(theGraph, x)) != w)
+                    return NOTOK;
 
-				if (_OrientExternalFacePath(theGraph, u, v, w, x) != OK)
-					return NOTOK;
-			}
+                if (_OrientExternalFacePath(theGraph, u, v, w, x) != OK)
+                    return NOTOK;
+            }
 
-			if (visited)
-			{
-				if (_SetVisitedFlagsOnPath(theGraph, u, v, w, x) != OK)
-					return NOTOK;
-			}
-			else
-			{
-				if (_ClearVisitedFlagsOnPath(theGraph, u, v, w, x) != OK)
-					return NOTOK;
-			}
-		}
-		else
-			e += 2;
-	}
+            if (visited)
+            {
+                if (_SetVisitedFlagsOnPath(theGraph, u, v, w, x) != OK)
+                    return NOTOK;
+            }
+            else
+            {
+                if (_ClearVisitedFlagsOnPath(theGraph, u, v, w, x) != OK)
+                    return NOTOK;
+            }
+        }
+        else
+            e += 2;
+    }
 
-	return OK;
+    return OK;
 }

--- a/c/graphLib/homeomorphSearch/graphK4Search_Extensions.c
+++ b/c/graphLib/homeomorphSearch/graphK4Search_Extensions.c
@@ -9,33 +9,33 @@ See the LICENSE.TXT file for licensing information.
 #include "graphK4Search.private.h"
 #include "graphK4Search.h"
 
-extern int  _SearchForK4InBicomp(graphP theGraph, K4SearchContext *context, int v, int R);
+extern int _SearchForK4InBicomp(graphP theGraph, K4SearchContext *context, int v, int R);
 
 extern int _TestForCompleteGraphObstruction(graphP theGraph, int numVerts,
                                             int *degrees, int *imageVerts);
 
-extern int  _getImageVertices(graphP theGraph, int *degrees, int maxDegree,
-                              int *imageVerts, int maxNumImageVerts);
+extern int _getImageVertices(graphP theGraph, int *degrees, int maxDegree,
+                             int *imageVerts, int maxNumImageVerts);
 
-extern int  _TestSubgraph(graphP theSubgraph, graphP theGraph);
+extern int _TestSubgraph(graphP theSubgraph, graphP theGraph);
 
 /* Forward declarations of local functions */
 
 void _K4Search_ClearStructures(K4SearchContext *context);
-int  _K4Search_CreateStructures(K4SearchContext *context);
-int  _K4Search_InitStructures(K4SearchContext *context);
+int _K4Search_CreateStructures(K4SearchContext *context);
+int _K4Search_InitStructures(K4SearchContext *context);
 
 void _K4Search_InitEdgeRec(K4SearchContext *context, int e);
 
 /* Forward declarations of overloading functions */
-int  _K4Search_HandleBlockedBicomp(graphP theGraph, int v, int RootVertex, int R);
-int  _K4Search_EmbedPostprocess(graphP theGraph, int v, int edgeEmbeddingResult);
-int  _K4Search_CheckEmbeddingIntegrity(graphP theGraph, graphP origGraph);
-int  _K4Search_CheckObstructionIntegrity(graphP theGraph, graphP origGraph);
+int _K4Search_HandleBlockedBicomp(graphP theGraph, int v, int RootVertex, int R);
+int _K4Search_EmbedPostprocess(graphP theGraph, int v, int edgeEmbeddingResult);
+int _K4Search_CheckEmbeddingIntegrity(graphP theGraph, graphP origGraph);
+int _K4Search_CheckObstructionIntegrity(graphP theGraph, graphP origGraph);
 
-int  _K4Search_InitGraph(graphP theGraph, int N);
+int _K4Search_InitGraph(graphP theGraph, int N);
 void _K4Search_ReinitializeGraph(graphP theGraph);
-int  _K4Search_EnsureArcCapacity(graphP theGraph, int requiredArcCapacity);
+int _K4Search_EnsureArcCapacity(graphP theGraph, int requiredArcCapacity);
 
 /* Forward declarations of functions used by the extension system */
 
@@ -57,73 +57,73 @@ int K4SEARCH_ID = 0;
  feature.
  ****************************************************************************/
 
-int  gp_AttachK4Search(graphP theGraph)
+int gp_AttachK4Search(graphP theGraph)
 {
-     K4SearchContext *context = NULL;
+    K4SearchContext *context = NULL;
 
-     // If the K4 search feature has already been attached to the graph,
-     // then there is no need to attach it again
-     gp_FindExtension(theGraph, K4SEARCH_ID, (void *)&context);
-     if (context != NULL)
-     {
-         return OK;
-     }
+    // If the K4 search feature has already been attached to the graph,
+    // then there is no need to attach it again
+    gp_FindExtension(theGraph, K4SEARCH_ID, (void *)&context);
+    if (context != NULL)
+    {
+        return OK;
+    }
 
-     // Allocate a new extension context
-     context = (K4SearchContext *) malloc(sizeof(K4SearchContext));
-     if (context == NULL)
-     {
-         return NOTOK;
-     }
+    // Allocate a new extension context
+    context = (K4SearchContext *)malloc(sizeof(K4SearchContext));
+    if (context == NULL)
+    {
+        return NOTOK;
+    }
 
-     // First, tell the context that it is not initialized
-     context->initialized = 0;
+    // First, tell the context that it is not initialized
+    context->initialized = 0;
 
-     // Save a pointer to theGraph in the context
-     context->theGraph = theGraph;
+    // Save a pointer to theGraph in the context
+    context->theGraph = theGraph;
 
-     // Put the overload functions into the context function table.
-     // gp_AddExtension will overload the graph's functions with these, and
-     // return the base function pointers in the context function table
-     memset(&context->functions, 0, sizeof(graphFunctionTable));
-     context->functions.fpHandleBlockedBicomp = _K4Search_HandleBlockedBicomp;
-     context->functions.fpEmbedPostprocess = _K4Search_EmbedPostprocess;
-     context->functions.fpCheckEmbeddingIntegrity = _K4Search_CheckEmbeddingIntegrity;
-     context->functions.fpCheckObstructionIntegrity = _K4Search_CheckObstructionIntegrity;
+    // Put the overload functions into the context function table.
+    // gp_AddExtension will overload the graph's functions with these, and
+    // return the base function pointers in the context function table
+    memset(&context->functions, 0, sizeof(graphFunctionTable));
+    context->functions.fpHandleBlockedBicomp = _K4Search_HandleBlockedBicomp;
+    context->functions.fpEmbedPostprocess = _K4Search_EmbedPostprocess;
+    context->functions.fpCheckEmbeddingIntegrity = _K4Search_CheckEmbeddingIntegrity;
+    context->functions.fpCheckObstructionIntegrity = _K4Search_CheckObstructionIntegrity;
 
-     context->functions.fpInitGraph = _K4Search_InitGraph;
-     context->functions.fpReinitializeGraph = _K4Search_ReinitializeGraph;
-     context->functions.fpEnsureArcCapacity = _K4Search_EnsureArcCapacity;
+    context->functions.fpInitGraph = _K4Search_InitGraph;
+    context->functions.fpReinitializeGraph = _K4Search_ReinitializeGraph;
+    context->functions.fpEnsureArcCapacity = _K4Search_EnsureArcCapacity;
 
-     _K4Search_ClearStructures(context);
+    _K4Search_ClearStructures(context);
 
-     // Store the K4 search context, including the data structure and the
-     // function pointers, as an extension of the graph
-     if (gp_AddExtension(theGraph, &K4SEARCH_ID, (void *) context,
-                         _K4Search_DupContext, _K4Search_FreeContext,
-                         &context->functions) != OK)
-     {
-         _K4Search_FreeContext(context);
-         return NOTOK;
-     }
+    // Store the K4 search context, including the data structure and the
+    // function pointers, as an extension of the graph
+    if (gp_AddExtension(theGraph, &K4SEARCH_ID, (void *)context,
+                        _K4Search_DupContext, _K4Search_FreeContext,
+                        &context->functions) != OK)
+    {
+        _K4Search_FreeContext(context);
+        return NOTOK;
+    }
 
-     // Create the K4-specific structures if the size of the graph is known
-     // Attach functions are always invoked after gp_New(), but if a graph
-     // extension must be attached before gp_Read(), then the attachment
-     // also happens before gp_InitGraph(), which means N==0.
-     // However, sometimes a feature is attached after gp_InitGraph(), in
-     // which case N > 0
-     if (theGraph->N > 0)
-     {
-         if (_K4Search_CreateStructures(context) != OK ||
-             _K4Search_InitStructures(context) != OK)
-         {
-             _K4Search_FreeContext(context);
-             return NOTOK;
-         }
-     }
+    // Create the K4-specific structures if the size of the graph is known
+    // Attach functions are always invoked after gp_New(), but if a graph
+    // extension must be attached before gp_Read(), then the attachment
+    // also happens before gp_InitGraph(), which means N==0.
+    // However, sometimes a feature is attached after gp_InitGraph(), in
+    // which case N > 0
+    if (theGraph->N > 0)
+    {
+        if (_K4Search_CreateStructures(context) != OK ||
+            _K4Search_InitStructures(context) != OK)
+        {
+            _K4Search_FreeContext(context);
+            return NOTOK;
+        }
+    }
 
-     return OK;
+    return OK;
 }
 
 /********************************************************************
@@ -167,44 +167,44 @@ void _K4Search_ClearStructures(K4SearchContext *context)
  Create uninitialized structures for the vertex and edge levels, and
  initialized structures for the graph level
  ********************************************************************/
-int  _K4Search_CreateStructures(K4SearchContext *context)
+int _K4Search_CreateStructures(K4SearchContext *context)
 {
-     int Esize = gp_EdgeIndexBound(context->theGraph);
+    int Esize = gp_EdgeIndexBound(context->theGraph);
 
-     if (context->theGraph->N <= 0)
-         return NOTOK;
+    if (context->theGraph->N <= 0)
+        return NOTOK;
 
-     if ((context->E = (K4Search_EdgeRecP) malloc(Esize*sizeof(K4Search_EdgeRec))) == NULL ||
+    if ((context->E = (K4Search_EdgeRecP)malloc(Esize * sizeof(K4Search_EdgeRec))) == NULL ||
         0)
-     {
-         return NOTOK;
-     }
+    {
+        return NOTOK;
+    }
 
-     return OK;
+    return OK;
 }
 
 /********************************************************************
  _K4Search_InitStructures()
  ********************************************************************/
-int  _K4Search_InitStructures(K4SearchContext *context)
+int _K4Search_InitStructures(K4SearchContext *context)
 {
 #if NIL == 0 || NIL == -1
-	memset(context->E, NIL_CHAR, gp_EdgeIndexBound(context->theGraph) * sizeof(K4Search_EdgeRec));
+    memset(context->E, NIL_CHAR, gp_EdgeIndexBound(context->theGraph) * sizeof(K4Search_EdgeRec));
 #else
     int e, Esize;
 
-     Esize = gp_EdgeIndexBound(context->theGraph);
-     for (e = gp_GetFirstEdge(context->theGraph); e < Esize; e++)
-          _K4Search_InitEdgeRec(context, e);
+    Esize = gp_EdgeIndexBound(context->theGraph);
+    for (e = gp_GetFirstEdge(context->theGraph); e < Esize; e++)
+        _K4Search_InitEdgeRec(context, e);
 #endif
 
-     return OK;
+    return OK;
 }
 
 /********************************************************************
  ********************************************************************/
 
-int  _K4Search_InitGraph(graphP theGraph, int N)
+int _K4Search_InitGraph(graphP theGraph, int N)
 {
     K4SearchContext *context = NULL;
     gp_FindExtension(theGraph, K4SEARCH_ID, (void *)&context);
@@ -213,15 +213,15 @@ int  _K4Search_InitGraph(graphP theGraph, int N)
         return NOTOK;
 
     theGraph->N = N;
-	theGraph->NV = N;
-	if (theGraph->arcCapacity == 0)
-		theGraph->arcCapacity = 2*DEFAULT_EDGE_LIMIT*N;
+    theGraph->NV = N;
+    if (theGraph->arcCapacity == 0)
+        theGraph->arcCapacity = 2 * DEFAULT_EDGE_LIMIT * N;
 
-	if (_K4Search_CreateStructures(context) != OK ||
-		_K4Search_InitStructures(context) != OK)
-		return NOTOK;
+    if (_K4Search_CreateStructures(context) != OK ||
+        _K4Search_InitStructures(context) != OK)
+        return NOTOK;
 
-	context->functions.fpInitGraph(theGraph, N);
+    context->functions.fpInitGraph(theGraph, N);
 
     return OK;
 }
@@ -236,11 +236,11 @@ void _K4Search_ReinitializeGraph(graphP theGraph)
 
     if (context != NULL)
     {
-		// Reinitialize the graph
-		context->functions.fpReinitializeGraph(theGraph);
+        // Reinitialize the graph
+        context->functions.fpReinitializeGraph(theGraph);
 
-		// Do the reinitialization that is specific to this module
-		_K4Search_InitStructures(context);
+        // Do the reinitialization that is specific to this module
+        _K4Search_InitStructures(context);
     }
 }
 
@@ -253,9 +253,9 @@ void _K4Search_ReinitializeGraph(graphP theGraph)
  reason to do so.
  ********************************************************************/
 
-int  _K4Search_EnsureArcCapacity(graphP theGraph, int requiredArcCapacity)
+int _K4Search_EnsureArcCapacity(graphP theGraph, int requiredArcCapacity)
 {
-	return NOTOK;
+    return NOTOK;
 }
 
 /********************************************************************
@@ -264,32 +264,32 @@ int  _K4Search_EnsureArcCapacity(graphP theGraph, int requiredArcCapacity)
 
 void *_K4Search_DupContext(void *pContext, void *theGraph)
 {
-     K4SearchContext *context = (K4SearchContext *) pContext;
-     K4SearchContext *newContext = (K4SearchContext *) malloc(sizeof(K4SearchContext));
+    K4SearchContext *context = (K4SearchContext *)pContext;
+    K4SearchContext *newContext = (K4SearchContext *)malloc(sizeof(K4SearchContext));
 
-     if (newContext != NULL)
-     {
-         int Esize = gp_EdgeIndexBound((graphP) theGraph);
+    if (newContext != NULL)
+    {
+        int Esize = gp_EdgeIndexBound((graphP)theGraph);
 
-         *newContext = *context;
+        *newContext = *context;
 
-         newContext->theGraph = (graphP) theGraph;
+        newContext->theGraph = (graphP)theGraph;
 
-         newContext->initialized = 0;
-         _K4Search_ClearStructures(newContext);
-         if (((graphP) theGraph)->N > 0)
-         {
-             if (_K4Search_CreateStructures(newContext) != OK)
-             {
-                 _K4Search_FreeContext(newContext);
-                 return NULL;
-             }
+        newContext->initialized = 0;
+        _K4Search_ClearStructures(newContext);
+        if (((graphP)theGraph)->N > 0)
+        {
+            if (_K4Search_CreateStructures(newContext) != OK)
+            {
+                _K4Search_FreeContext(newContext);
+                return NULL;
+            }
 
-             memcpy(newContext->E, context->E, Esize*sizeof(K4Search_EdgeRec));
-         }
-     }
+            memcpy(newContext->E, context->E, Esize * sizeof(K4Search_EdgeRec));
+        }
+    }
 
-     return newContext;
+    return newContext;
 }
 
 /********************************************************************
@@ -298,10 +298,10 @@ void *_K4Search_DupContext(void *pContext, void *theGraph)
 
 void _K4Search_FreeContext(void *pContext)
 {
-     K4SearchContext *context = (K4SearchContext *) pContext;
+    K4SearchContext *context = (K4SearchContext *)pContext;
 
-     _K4Search_ClearStructures(context);
-     free(pContext);
+    _K4Search_ClearStructures(context);
+    free(pContext);
 }
 
 /********************************************************************
@@ -315,88 +315,89 @@ void _K4Search_InitEdgeRec(K4SearchContext *context, int e)
 /********************************************************************
  _K4Search_HandleBlockedBicomp()
  Returns OK if no K4 homeomorph found and blockage cleared (OK to
- 	 	 	 proceed with Walkdown embedding)
- 	 	 NONEMBEDDABLE if K4 homeomorph found, and Walkdown embedding
- 	 	 	 should be terminated.
- 	 	 NOTOK on internal error
+             proceed with Walkdown embedding)
+         NONEMBEDDABLE if K4 homeomorph found, and Walkdown embedding
+             should be terminated.
+         NOTOK on internal error
  ********************************************************************/
 
-int  _K4Search_HandleBlockedBicomp(graphP theGraph, int v, int RootVertex, int R)
+int _K4Search_HandleBlockedBicomp(graphP theGraph, int v, int RootVertex, int R)
 {
-	K4SearchContext *context = NULL;
+    K4SearchContext *context = NULL;
 
-	gp_FindExtension(theGraph, K4SEARCH_ID, (void *)&context);
-	if (context == NULL)
-		return NOTOK;
+    gp_FindExtension(theGraph, K4SEARCH_ID, (void *)&context);
+    if (context == NULL)
+        return NOTOK;
 
     if (theGraph->embedFlags == EMBEDFLAGS_SEARCHFORK4)
     {
-    	int RetVal = OK;
+        int RetVal = OK;
 
-    	// If invoked on a descendant bicomp, then we push its root then search once
-    	// since not finding a K4 homeomorph will also clear the blockage and allow
-    	// the Walkdown to continue walking down
-    	if (R != RootVertex)
-    	{
-    	    sp_Push2(theGraph->theStack, R, 0);
+        // If invoked on a descendant bicomp, then we push its root then search once
+        // since not finding a K4 homeomorph will also clear the blockage and allow
+        // the Walkdown to continue walking down
+        if (R != RootVertex)
+        {
+            sp_Push2(theGraph->theStack, R, 0);
             if ((RetVal = _SearchForK4InBicomp(theGraph, context, v, R)) == OK)
             {
-            	// If the Walkdown will be told it is OK to continue, then we have to take the descendant
-            	// bicomp root back off the stack so the Walkdown can try to descend to it again.
-            	// The top of stack has the pair R and 0/1 direction Walkdown traversal proceeds from R
-            	// Need only R, so pop and discard the direction, then pop R
-            	sp_Pop2_Discard1(theGraph->theStack, R);
+                // If the Walkdown will be told it is OK to continue, then we have to take the descendant
+                // bicomp root back off the stack so the Walkdown can try to descend to it again.
+                // The top of stack has the pair R and 0/1 direction Walkdown traversal proceeds from R
+                // Need only R, so pop and discard the direction, then pop R
+                sp_Pop2_Discard1(theGraph->theStack, R);
 
-            	// And we have to clear the indicator of the minor A that was reduced, since it was eliminated.
-            	theGraph->IC.minorType = 0;
+                // And we have to clear the indicator of the minor A that was reduced, since it was eliminated.
+                theGraph->IC.minorType = 0;
             }
-    	}
+        }
 
-    	// Otherwise, if invoked on a child bicomp rooted by a virtual copy of v,
-    	// then we search for a K4 homeomorph, and if OK is returned, then that indicates
-    	// the blockage has been cleared and it is OK to Walkdown the bicomp.
-    	// But the Walkdown finished, already, so we launch it again.
-    	// If the Walkdown returns OK then all forward arcs were embedded.  If NONEMBEDDABLE
-    	// is returned, then the bicomp got blocked again, so we have to reiterate the K4 search
-    	else
-    	{
-    		// If Walkdown has recursively called this handler on the bicomp rooted by RootVertex,
-    		// then it is still blocked, so we just return NONEMBEDDABLE, which causes Walkdown to
-    		// return to the loop below and signal that the loop should invoke the Walkdown again.
-    		if (context->handlingBlockedBicomp)
-    			return NONEMBEDDABLE;
+        // Otherwise, if invoked on a child bicomp rooted by a virtual copy of v,
+        // then we search for a K4 homeomorph, and if OK is returned, then that indicates
+        // the blockage has been cleared and it is OK to Walkdown the bicomp.
+        // But the Walkdown finished, already, so we launch it again.
+        // If the Walkdown returns OK then all forward arcs were embedded.  If NONEMBEDDABLE
+        // is returned, then the bicomp got blocked again, so we have to reiterate the K4 search
+        else
+        {
+            // If Walkdown has recursively called this handler on the bicomp rooted by RootVertex,
+            // then it is still blocked, so we just return NONEMBEDDABLE, which causes Walkdown to
+            // return to the loop below and signal that the loop should invoke the Walkdown again.
+            if (context->handlingBlockedBicomp)
+                return NONEMBEDDABLE;
 
-    		context->handlingBlockedBicomp = TRUE;
-    		do {
-    			// Detect whether bicomp can be used to find a K4 homeomorph.  It it does, then
-    			// it returns NONEMBEDDABLE so we break the search because we found the desired K4
-    			// If OK is returned, then the blockage was cleared and it is OK to Walkdown again.
-    			if ((RetVal = _SearchForK4InBicomp(theGraph, context, v, RootVertex)) != OK)
-    				break;
+            context->handlingBlockedBicomp = TRUE;
+            do
+            {
+                // Detect whether bicomp can be used to find a K4 homeomorph.  It it does, then
+                // it returns NONEMBEDDABLE so we break the search because we found the desired K4
+                // If OK is returned, then the blockage was cleared and it is OK to Walkdown again.
+                if ((RetVal = _SearchForK4InBicomp(theGraph, context, v, RootVertex)) != OK)
+                    break;
 
-    			// Walkdown again to embed more edges.  If Walkdown returns OK, then all remaining
-    			// edges to its descendants are embedded, so we'll get out of this loop. If Walkdown
-    			// detects that it still has not embedded all the edges to descendants of the bicomp's
-    			// root edge child, then Walkdown calls this routine again, and the above non-reentrancy
-    			// code returns NONEMBEDDABLE, causing this loop to search again for a K4.
-    			theGraph->IC.minorType = 0;
-    			RetVal = theGraph->functions.fpWalkDown(theGraph, v, RootVertex);
+                // Walkdown again to embed more edges.  If Walkdown returns OK, then all remaining
+                // edges to its descendants are embedded, so we'll get out of this loop. If Walkdown
+                // detects that it still has not embedded all the edges to descendants of the bicomp's
+                // root edge child, then Walkdown calls this routine again, and the above non-reentrancy
+                // code returns NONEMBEDDABLE, causing this loop to search again for a K4.
+                theGraph->IC.minorType = 0;
+                RetVal = theGraph->functions.fpWalkDown(theGraph, v, RootVertex);
 
-    			// Except if the Walkdown returns NONEMBEDDABLE due to finding a K4 homeomorph entangled
-    			// with a descendant bicomp (the R != RootVertex case above), then it was found
-    			// entangled with Minor A, so we can stop the search if minor A is detected
-    			if (theGraph->IC.minorType & MINORTYPE_A)
-    				break;
+                // Except if the Walkdown returns NONEMBEDDABLE due to finding a K4 homeomorph entangled
+                // with a descendant bicomp (the R != RootVertex case above), then it was found
+                // entangled with Minor A, so we can stop the search if minor A is detected
+                if (theGraph->IC.minorType & MINORTYPE_A)
+                    break;
 
-    		} while (RetVal == NONEMBEDDABLE);
-			context->handlingBlockedBicomp = FALSE;
-    	}
+            } while (RetVal == NONEMBEDDABLE);
+            context->handlingBlockedBicomp = FALSE;
+        }
 
-    	return RetVal;
+        return RetVal;
     }
     else
     {
-    	return context->functions.fpHandleBlockedBicomp(theGraph, v, RootVertex, R);
+        return context->functions.fpHandleBlockedBicomp(theGraph, v, RootVertex, R);
     }
 
     return NOTOK;
@@ -405,18 +406,18 @@ int  _K4Search_HandleBlockedBicomp(graphP theGraph, int v, int RootVertex, int R
 /********************************************************************
  ********************************************************************/
 
-int  _K4Search_EmbedPostprocess(graphP theGraph, int v, int edgeEmbeddingResult)
+int _K4Search_EmbedPostprocess(graphP theGraph, int v, int edgeEmbeddingResult)
 {
-     // For K4 search, we just return the edge embedding result because the
-     // search result has been obtained already.
-     if (theGraph->embedFlags == EMBEDFLAGS_SEARCHFORK4)
-     {
-         return edgeEmbeddingResult;
-     }
+    // For K4 search, we just return the edge embedding result because the
+    // search result has been obtained already.
+    if (theGraph->embedFlags == EMBEDFLAGS_SEARCHFORK4)
+    {
+        return edgeEmbeddingResult;
+    }
 
-     // When not searching for K4, we let the superclass do the work
-     else
-     {
+    // When not searching for K4, we let the superclass do the work
+    else
+    {
         K4SearchContext *context = NULL;
         gp_FindExtension(theGraph, K4SEARCH_ID, (void *)&context);
 
@@ -424,24 +425,24 @@ int  _K4Search_EmbedPostprocess(graphP theGraph, int v, int edgeEmbeddingResult)
         {
             return context->functions.fpEmbedPostprocess(theGraph, v, edgeEmbeddingResult);
         }
-     }
+    }
 
-     return NOTOK;
+    return NOTOK;
 }
 
 /********************************************************************
  ********************************************************************/
 
-int  _K4Search_CheckEmbeddingIntegrity(graphP theGraph, graphP origGraph)
+int _K4Search_CheckEmbeddingIntegrity(graphP theGraph, graphP origGraph)
 {
-     if (theGraph->embedFlags == EMBEDFLAGS_SEARCHFORK4)
-     {
-         return OK;
-     }
+    if (theGraph->embedFlags == EMBEDFLAGS_SEARCHFORK4)
+    {
+        return OK;
+    }
 
-     // When not searching for K4, we let the superclass do the work
-     else
-     {
+    // When not searching for K4, we let the superclass do the work
+    else
+    {
         K4SearchContext *context = NULL;
         gp_FindExtension(theGraph, K4SEARCH_ID, (void *)&context);
 
@@ -449,39 +450,39 @@ int  _K4Search_CheckEmbeddingIntegrity(graphP theGraph, graphP origGraph)
         {
             return context->functions.fpCheckEmbeddingIntegrity(theGraph, origGraph);
         }
-     }
+    }
 
-     return NOTOK;
+    return NOTOK;
 }
 
 /********************************************************************
  ********************************************************************/
 
-int  _K4Search_CheckObstructionIntegrity(graphP theGraph, graphP origGraph)
+int _K4Search_CheckObstructionIntegrity(graphP theGraph, graphP origGraph)
 {
-     // When searching for K4, we ensure that theGraph is a subgraph of
-     // the original graph and that it contains a K4 homeomorph
-     if (theGraph->embedFlags == EMBEDFLAGS_SEARCHFORK4)
-     {
-		int  degrees[4], imageVerts[4];
+    // When searching for K4, we ensure that theGraph is a subgraph of
+    // the original graph and that it contains a K4 homeomorph
+    if (theGraph->embedFlags == EMBEDFLAGS_SEARCHFORK4)
+    {
+        int degrees[4], imageVerts[4];
 
         if (_TestSubgraph(theGraph, origGraph) != TRUE)
             return NOTOK;
 
-		if (_getImageVertices(theGraph, degrees, 3, imageVerts, 4) != OK)
-			return NOTOK;
+        if (_getImageVertices(theGraph, degrees, 3, imageVerts, 4) != OK)
+            return NOTOK;
 
-		if (_TestForCompleteGraphObstruction(theGraph, 4, degrees, imageVerts) == TRUE)
-		{
-			return OK;
-		}
+        if (_TestForCompleteGraphObstruction(theGraph, 4, degrees, imageVerts) == TRUE)
+        {
+            return OK;
+        }
 
-		return NOTOK;
-     }
+        return NOTOK;
+    }
 
-     // When not searching for K4, we let the superclass do the work
-     else
-     {
+    // When not searching for K4, we let the superclass do the work
+    else
+    {
         K4SearchContext *context = NULL;
         gp_FindExtension(theGraph, K4SEARCH_ID, (void *)&context);
 
@@ -489,7 +490,7 @@ int  _K4Search_CheckObstructionIntegrity(graphP theGraph, graphP origGraph)
         {
             return context->functions.fpCheckObstructionIntegrity(theGraph, origGraph);
         }
-     }
+    }
 
-     return NOTOK;
+    return NOTOK;
 }

--- a/c/graphLib/io/g6-api-utilities.c
+++ b/c/graphLib/io/g6-api-utilities.c
@@ -8,31 +8,34 @@ See the LICENSE.TXT file for licensing information.
 
 int _getMaxEdgeCount(int graphOrder)
 {
-	return (graphOrder * (graphOrder - 1)) / 2;
+    return (graphOrder * (graphOrder - 1)) / 2;
 }
 
 int _getNumCharsForGraphEncoding(int graphOrder)
 {
-	int maxNumEdges = _getMaxEdgeCount(graphOrder);
+    int maxNumEdges = _getMaxEdgeCount(graphOrder);
 
-	return (maxNumEdges / 6) + (maxNumEdges % 6 ? 1 : 0);
+    return (maxNumEdges / 6) + (maxNumEdges % 6 ? 1 : 0);
 }
 
 int _getNumCharsForGraphOrder(int graphOrder)
 {
-	if (graphOrder > 0 && graphOrder < 63) {
-		return 1;
-	} else if (graphOrder >= 63 && graphOrder <= 100000) {
-		return 4;
-	}
+    if (graphOrder > 0 && graphOrder < 63)
+    {
+        return 1;
+    }
+    else if (graphOrder >= 63 && graphOrder <= 100000)
+    {
+        return 4;
+    }
 
-	return -1;
+    return -1;
 }
 
 int _getExpectedNumPaddingZeroes(const int graphOrder, const int numChars)
 {
-	int maxNumEdges = _getMaxEdgeCount(graphOrder);
-	int expectedNumPaddingZeroes = numChars * 6 - maxNumEdges;
+    int maxNumEdges = _getMaxEdgeCount(graphOrder);
+    int expectedNumPaddingZeroes = numChars * 6 - maxNumEdges;
 
-	return expectedNumPaddingZeroes;
+    return expectedNumPaddingZeroes;
 }

--- a/c/graphLib/io/g6-api-utilities.h
+++ b/c/graphLib/io/g6-api-utilities.h
@@ -8,13 +8,14 @@ See the LICENSE.TXT file for licensing information.
 #define G6_API_UTILITIES
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-int _getMaxEdgeCount(int);
-int _getNumCharsForGraphEncoding(int);
-int _getNumCharsForGraphOrder(int);
-int _getExpectedNumPaddingZeroes(const int, const int);
+    int _getMaxEdgeCount(int);
+    int _getNumCharsForGraphEncoding(int);
+    int _getNumCharsForGraphOrder(int);
+    int _getExpectedNumPaddingZeroes(const int, const int);
 
 #ifdef __cplusplus
 }

--- a/c/graphLib/io/g6-read-iterator.c
+++ b/c/graphLib/io/g6-read-iterator.c
@@ -10,601 +10,600 @@ See the LICENSE.TXT file for licensing information.
 #include "g6-read-iterator.h"
 #include "g6-api-utilities.h"
 
-
 int allocateG6ReadIterator(G6ReadIterator **ppG6ReadIterator, graphP pGraph)
 {
-	int exitCode = OK;
+    int exitCode = OK;
 
-	if (ppG6ReadIterator != NULL && (*ppG6ReadIterator) != NULL)
-	{
-		ErrorMessage("G6ReadIterator is not NULL and therefore can't be allocated.\n");
-		return NOTOK;
-	}
+    if (ppG6ReadIterator != NULL && (*ppG6ReadIterator) != NULL)
+    {
+        ErrorMessage("G6ReadIterator is not NULL and therefore can't be allocated.\n");
+        return NOTOK;
+    }
 
-	// numGraphsRead, graphOrder, numCharsForGraphOrder,
-	// numCharsForGraphEncoding, and currGraphBuffSize all set to 0
-	(*ppG6ReadIterator) = (G6ReadIterator *) calloc(1, sizeof(G6ReadIterator));
+    // numGraphsRead, graphOrder, numCharsForGraphOrder,
+    // numCharsForGraphEncoding, and currGraphBuffSize all set to 0
+    (*ppG6ReadIterator) = (G6ReadIterator *)calloc(1, sizeof(G6ReadIterator));
 
-	if ((*ppG6ReadIterator) == NULL)
-	{
-		ErrorMessage("Unable to allocate memory for G6ReadIterator.\n");
-		return NOTOK;
-	}
+    if ((*ppG6ReadIterator) == NULL)
+    {
+        ErrorMessage("Unable to allocate memory for G6ReadIterator.\n");
+        return NOTOK;
+    }
 
-	(*ppG6ReadIterator)->g6Input = NULL;
+    (*ppG6ReadIterator)->g6Input = NULL;
 
-	if (pGraph == NULL)
-	{
-		ErrorMessage("Must allocate graph to be used by G6ReadIterator.\n");
+    if (pGraph == NULL)
+    {
+        ErrorMessage("Must allocate graph to be used by G6ReadIterator.\n");
 
-		exitCode = freeG6ReadIterator(ppG6ReadIterator);
+        exitCode = freeG6ReadIterator(ppG6ReadIterator);
 
-		if (exitCode != OK)
-			ErrorMessage("Unable to free the G6ReadIterator.\n");
-	}
-	else
-	{
-		(*ppG6ReadIterator)->currGraph = pGraph;
-	}
+        if (exitCode != OK)
+            ErrorMessage("Unable to free the G6ReadIterator.\n");
+    }
+    else
+    {
+        (*ppG6ReadIterator)->currGraph = pGraph;
+    }
 
-	return exitCode;
+    return exitCode;
 }
 
 bool _isG6ReadIteratorAllocated(G6ReadIterator *pG6ReadIterator)
 {
-	bool g6ReadIteratorIsAllocated = true;
+    bool g6ReadIteratorIsAllocated = true;
 
-	if (pG6ReadIterator == NULL || pG6ReadIterator->currGraph == NULL)
-	{
-		g6ReadIteratorIsAllocated = false;
-	}
+    if (pG6ReadIterator == NULL || pG6ReadIterator->currGraph == NULL)
+    {
+        g6ReadIteratorIsAllocated = false;
+    }
 
-	return g6ReadIteratorIsAllocated;
+    return g6ReadIteratorIsAllocated;
 }
 
 int getNumGraphsRead(G6ReadIterator *pG6ReadIterator, int *pNumGraphsRead)
 {
-	if (pG6ReadIterator == NULL)
-	{
-		ErrorMessage("G6ReadIterator is not allocated.\n");
-		return NOTOK;
-	}
+    if (pG6ReadIterator == NULL)
+    {
+        ErrorMessage("G6ReadIterator is not allocated.\n");
+        return NOTOK;
+    }
 
-	(*pNumGraphsRead) = pG6ReadIterator->numGraphsRead;
+    (*pNumGraphsRead) = pG6ReadIterator->numGraphsRead;
 
-	return OK;
+    return OK;
 }
 
 int getOrderOfGraphToRead(G6ReadIterator *pG6ReadIterator, int *pGraphOrder)
 {
-	if (pG6ReadIterator == NULL)
-	{
-		ErrorMessage("G6ReadIterator is not allocated.\n");
-		return NOTOK;
-	}
+    if (pG6ReadIterator == NULL)
+    {
+        ErrorMessage("G6ReadIterator is not allocated.\n");
+        return NOTOK;
+    }
 
-	(*pGraphOrder) = pG6ReadIterator->graphOrder;
+    (*pGraphOrder) = pG6ReadIterator->graphOrder;
 
-	return OK;
+    return OK;
 }
 
 int getPointerToGraphReadIn(G6ReadIterator *pG6ReadIterator, graphP *ppGraph)
 {
-	if (pG6ReadIterator == NULL)
-	{
-		ErrorMessage("G6ReadIterator is not allocated.\n");
-		return NOTOK;
-	}
+    if (pG6ReadIterator == NULL)
+    {
+        ErrorMessage("G6ReadIterator is not allocated.\n");
+        return NOTOK;
+    }
 
-	(*ppGraph) = pG6ReadIterator->currGraph;
+    (*ppGraph) = pG6ReadIterator->currGraph;
 
-	return OK;
+    return OK;
 }
 
 int beginG6ReadIterationFromG6FilePath(G6ReadIterator *pG6ReadIterator, char *g6FilePath)
 {
-	int exitCode = OK;
+    int exitCode = OK;
 
-	if (!_isG6ReadIteratorAllocated(pG6ReadIterator))
-	{
-		ErrorMessage("G6ReadIterator is not allocated.\n");
-		return NOTOK;
-	}
+    if (!_isG6ReadIteratorAllocated(pG6ReadIterator))
+    {
+        ErrorMessage("G6ReadIterator is not allocated.\n");
+        return NOTOK;
+    }
 
-	if (g6FilePath == NULL || strlen(g6FilePath) == 0)
-	{
-		ErrorMessage("g6FilePath is null or has length 0.\n");
-		return NOTOK;
-	}
+    if (g6FilePath == NULL || strlen(g6FilePath) == 0)
+    {
+        ErrorMessage("g6FilePath is null or has length 0.\n");
+        return NOTOK;
+    }
 
-	g6FilePath[strcspn(g6FilePath, "\n\r")] = '\0';
+    g6FilePath[strcspn(g6FilePath, "\n\r")] = '\0';
 
-	FILE *g6Infile = fopen(g6FilePath, "r");
+    FILE *g6Infile = fopen(g6FilePath, "r");
 
-	if (g6Infile == NULL)
-	{
-		char * messageFormat = "Unable to open .g6 file with path \"%.*s\"\n";
-		char messageContents[MAXLINE + 1];
-		int charsAvailForFilename = (int) (MAXLINE - strlen(messageFormat));
-		sprintf(messageContents, messageFormat, charsAvailForFilename, g6FilePath);
-		ErrorMessage(messageContents);
-		return NOTOK;
-	}
+    if (g6Infile == NULL)
+    {
+        char *messageFormat = "Unable to open .g6 file with path \"%.*s\"\n";
+        char messageContents[MAXLINE + 1];
+        int charsAvailForFilename = (int)(MAXLINE - strlen(messageFormat));
+        sprintf(messageContents, messageFormat, charsAvailForFilename, g6FilePath);
+        ErrorMessage(messageContents);
+        return NOTOK;
+    }
 
-	exitCode = beginG6ReadIterationFromG6FilePointer(pG6ReadIterator, g6Infile);
+    exitCode = beginG6ReadIterationFromG6FilePointer(pG6ReadIterator, g6Infile);
 
-	return exitCode;
+    return exitCode;
 }
 
 int beginG6ReadIterationFromG6FilePointer(G6ReadIterator *pG6ReadIterator, FILE *g6Infile)
 {
-	int exitCode = OK;
+    int exitCode = OK;
 
-	if (g6Infile == NULL)
-	{
-		ErrorMessage(".g6 file pointer is NULL.\n");
-		return NOTOK;
-	}
+    if (g6Infile == NULL)
+    {
+        ErrorMessage(".g6 file pointer is NULL.\n");
+        return NOTOK;
+    }
 
-	strOrFileP g6Input = sf_New(g6Infile, NULL);
+    strOrFileP g6Input = sf_New(g6Infile, NULL);
 
-	if (g6Input == NULL)
-	{
-		ErrorMessage("Unable to allocate string-or-file container.\n");
-		return NOTOK;
-	}
+    if (g6Input == NULL)
+    {
+        ErrorMessage("Unable to allocate string-or-file container.\n");
+        return NOTOK;
+    }
 
-	pG6ReadIterator->g6Input = g6Input;
+    pG6ReadIterator->g6Input = g6Input;
 
-	exitCode = _beginG6ReadIteration(pG6ReadIterator);
+    exitCode = _beginG6ReadIteration(pG6ReadIterator);
 
-	return exitCode;
+    return exitCode;
 }
 
 int beginG6ReadIterationFromG6String(G6ReadIterator *pG6ReadIterator, char *g6InputStr)
 {
-	int exitCode = OK;
+    int exitCode = OK;
 
-	if (g6InputStr == NULL || strlen(g6InputStr) <= 0)
-	{
-		ErrorMessage("g6InputStr must not be null or empty string.\n");
-		return NOTOK;
-	}
+    if (g6InputStr == NULL || strlen(g6InputStr) <= 0)
+    {
+        ErrorMessage("g6InputStr must not be null or empty string.\n");
+        return NOTOK;
+    }
 
-	strOrFileP g6Input = sf_New(NULL, g6InputStr);
+    strOrFileP g6Input = sf_New(NULL, g6InputStr);
 
-	if (g6Input == NULL)
-	{
-		ErrorMessage("Unable to allocate string-or-file container.\n");
-		return NOTOK;
-	}
+    if (g6Input == NULL)
+    {
+        ErrorMessage("Unable to allocate string-or-file container.\n");
+        return NOTOK;
+    }
 
-	pG6ReadIterator->g6Input = g6Input;
+    pG6ReadIterator->g6Input = g6Input;
 
-	exitCode = _beginG6ReadIteration(pG6ReadIterator);
+    exitCode = _beginG6ReadIteration(pG6ReadIterator);
 
-	return exitCode;
+    return exitCode;
 }
 
 int _beginG6ReadIteration(G6ReadIterator *pG6ReadIterator)
 {
-	int exitCode = OK;
-	int charConfirmation = -1;
+    int exitCode = OK;
+    int charConfirmation = -1;
 
-	char messageContents[MAXLINE + 1];
+    char messageContents[MAXLINE + 1];
 
-	strOrFileP g6Input = pG6ReadIterator->g6Input;
+    strOrFileP g6Input = pG6ReadIterator->g6Input;
 
-	int firstChar = sf_getc(g6Input);
-	if (firstChar == EOF)
-	{
-		ErrorMessage(".g6 infile is empty.\n");
-		return NOTOK;
-	}
-	else
-	{
-		charConfirmation = sf_ungetc(firstChar, g6Input);
+    int firstChar = sf_getc(g6Input);
+    if (firstChar == EOF)
+    {
+        ErrorMessage(".g6 infile is empty.\n");
+        return NOTOK;
+    }
+    else
+    {
+        charConfirmation = sf_ungetc(firstChar, g6Input);
 
-		if (charConfirmation != firstChar)
-		{
-			ErrorMessage("Unable to ungetc first character.\n");
-			return NOTOK;
-		}
+        if (charConfirmation != firstChar)
+        {
+            ErrorMessage("Unable to ungetc first character.\n");
+            return NOTOK;
+        }
 
-		if (firstChar == '>')
-		{
-			exitCode = _processAndCheckHeader(g6Input);
-			if (exitCode != OK)
-			{
-				ErrorMessage("Unable to process and check .g6 infile header.\n");
-				return exitCode;
-			}
-		}
-	}
+        if (firstChar == '>')
+        {
+            exitCode = _processAndCheckHeader(g6Input);
+            if (exitCode != OK)
+            {
+                ErrorMessage("Unable to process and check .g6 infile header.\n");
+                return exitCode;
+            }
+        }
+    }
 
-	int lineNum = 1;
-	firstChar = sf_getc(g6Input);
-	charConfirmation = sf_ungetc(firstChar, g6Input);
+    int lineNum = 1;
+    firstChar = sf_getc(g6Input);
+    charConfirmation = sf_ungetc(firstChar, g6Input);
 
-	if (charConfirmation != firstChar)
-	{
-		ErrorMessage("Unable to ungetc first character.\n");
-		return NOTOK;
-	}
+    if (charConfirmation != firstChar)
+    {
+        ErrorMessage("Unable to ungetc first character.\n");
+        return NOTOK;
+    }
 
-	if (!_firstCharIsValid(firstChar, lineNum))
-		return NOTOK;
+    if (!_firstCharIsValid(firstChar, lineNum))
+        return NOTOK;
 
-	// Despite the general specification indicating that n \in [0, 68,719,476,735],
-	// in practice n will be limited such that an integer will suffice in storing it.
-	int graphOrder = -1;
-	exitCode = _getGraphOrder(g6Input, &graphOrder);
+    // Despite the general specification indicating that n \in [0, 68,719,476,735],
+    // in practice n will be limited such that an integer will suffice in storing it.
+    int graphOrder = -1;
+    exitCode = _getGraphOrder(g6Input, &graphOrder);
 
-	if (exitCode != OK)
-	{
-		sprintf(messageContents, "Invalid graph order on line %d of .g6 file.\n", lineNum);
-		ErrorMessage(messageContents);
-		return exitCode;
-	}
+    if (exitCode != OK)
+    {
+        sprintf(messageContents, "Invalid graph order on line %d of .g6 file.\n", lineNum);
+        ErrorMessage(messageContents);
+        return exitCode;
+    }
 
-	if (pG6ReadIterator->currGraph->N == 0)
-	{
-		exitCode = gp_InitGraph(pG6ReadIterator->currGraph, graphOrder);
+    if (pG6ReadIterator->currGraph->N == 0)
+    {
+        exitCode = gp_InitGraph(pG6ReadIterator->currGraph, graphOrder);
 
-		if (exitCode != OK)
-		{
-			sprintf(messageContents, "Unable to initialize graph datastructure with order %d for graph on line %d of the .g6 file.\n", graphOrder, lineNum);
-			ErrorMessage(messageContents);
-			return exitCode;
-		}
+        if (exitCode != OK)
+        {
+            sprintf(messageContents, "Unable to initialize graph datastructure with order %d for graph on line %d of the .g6 file.\n", graphOrder, lineNum);
+            ErrorMessage(messageContents);
+            return exitCode;
+        }
 
-		pG6ReadIterator->graphOrder = graphOrder;
-	}
-	else
-	{
-		if (pG6ReadIterator->currGraph->N != graphOrder)
-		{
-			sprintf(messageContents, "Graph datastructure passed to G6ReadIterator already initialized with graph order %d,\n", pG6ReadIterator->currGraph->N);
-			ErrorMessage(messageContents);
-			sprintf(messageContents, "\twhich doesn't match the graph order %d specified in the file.\n", graphOrder);
-			ErrorMessage(messageContents);
-			return NOTOK;
-		}
-		else
-		{
-			gp_ReinitializeGraph(pG6ReadIterator->currGraph);
-			pG6ReadIterator->graphOrder = graphOrder;
-		}
-	}
+        pG6ReadIterator->graphOrder = graphOrder;
+    }
+    else
+    {
+        if (pG6ReadIterator->currGraph->N != graphOrder)
+        {
+            sprintf(messageContents, "Graph datastructure passed to G6ReadIterator already initialized with graph order %d,\n", pG6ReadIterator->currGraph->N);
+            ErrorMessage(messageContents);
+            sprintf(messageContents, "\twhich doesn't match the graph order %d specified in the file.\n", graphOrder);
+            ErrorMessage(messageContents);
+            return NOTOK;
+        }
+        else
+        {
+            gp_ReinitializeGraph(pG6ReadIterator->currGraph);
+            pG6ReadIterator->graphOrder = graphOrder;
+        }
+    }
 
-	// Ensures zero-based flag is set regardless of whether the graph was initialized or reinitialized.
-	pG6ReadIterator->currGraph->internalFlags |= FLAGS_ZEROBASEDIO;
+    // Ensures zero-based flag is set regardless of whether the graph was initialized or reinitialized.
+    pG6ReadIterator->currGraph->internalFlags |= FLAGS_ZEROBASEDIO;
 
-	pG6ReadIterator->numCharsForGraphOrder = _getNumCharsForGraphOrder(graphOrder);
-	pG6ReadIterator->numCharsForGraphEncoding = _getNumCharsForGraphEncoding(graphOrder);
-	// Must add 3 bytes for newline, possible carriage return, and null terminator
-	pG6ReadIterator->currGraphBuffSize = pG6ReadIterator->numCharsForGraphOrder + pG6ReadIterator->numCharsForGraphEncoding + 3;
-	pG6ReadIterator->currGraphBuff = (char *) calloc(pG6ReadIterator->currGraphBuffSize, sizeof(char));
+    pG6ReadIterator->numCharsForGraphOrder = _getNumCharsForGraphOrder(graphOrder);
+    pG6ReadIterator->numCharsForGraphEncoding = _getNumCharsForGraphEncoding(graphOrder);
+    // Must add 3 bytes for newline, possible carriage return, and null terminator
+    pG6ReadIterator->currGraphBuffSize = pG6ReadIterator->numCharsForGraphOrder + pG6ReadIterator->numCharsForGraphEncoding + 3;
+    pG6ReadIterator->currGraphBuff = (char *)calloc(pG6ReadIterator->currGraphBuffSize, sizeof(char));
 
-	if (pG6ReadIterator->currGraphBuff == NULL)
-	{
-		ErrorMessage("Unable to allocate memory for currGraphBuff.\n");
-		exitCode = NOTOK;
-	}
+    if (pG6ReadIterator->currGraphBuff == NULL)
+    {
+        ErrorMessage("Unable to allocate memory for currGraphBuff.\n");
+        exitCode = NOTOK;
+    }
 
-	return exitCode;
+    return exitCode;
 }
 
 int _processAndCheckHeader(strOrFileP g6Input)
 {
-	int exitCode = OK;
+    int exitCode = OK;
 
-	if (g6Input == NULL)
-	{
-		ErrorMessage("Invalid .g6 string-or-file container.\n");
-		return NOTOK;
-	}
+    if (g6Input == NULL)
+    {
+        ErrorMessage("Invalid .g6 string-or-file container.\n");
+        return NOTOK;
+    }
 
-	char *correctG6Header = ">>graph6<<";
-	char *sparse6Header = ">>sparse6<";
-	char *digraph6Header = ">>digraph6";
+    char *correctG6Header = ">>graph6<<";
+    char *sparse6Header = ">>sparse6<";
+    char *digraph6Header = ">>digraph6";
 
-	char headerCandidateChars[11];
-	headerCandidateChars[0] = '\0';
+    char headerCandidateChars[11];
+    headerCandidateChars[0] = '\0';
 
-	for (int i = 0; i < 10; i++)
-	{
-		headerCandidateChars[i] = sf_getc(g6Input);
-	}
+    for (int i = 0; i < 10; i++)
+    {
+        headerCandidateChars[i] = sf_getc(g6Input);
+    }
 
-	headerCandidateChars[10] = '\0';
+    headerCandidateChars[10] = '\0';
 
-	if (strcmp(correctG6Header, headerCandidateChars) != 0)
-	{
-		if (strcmp(sparse6Header, headerCandidateChars) == 0)
-			ErrorMessage("Graph file is sparse6 format, which is not supported.\n");
-		else if (strcmp(digraph6Header, headerCandidateChars) == 0)
-			ErrorMessage("Graph file is digraph6 format, which is not supported.\n");
-		else
-			ErrorMessage("Invalid header for .g6 file.\n"); 
+    if (strcmp(correctG6Header, headerCandidateChars) != 0)
+    {
+        if (strcmp(sparse6Header, headerCandidateChars) == 0)
+            ErrorMessage("Graph file is sparse6 format, which is not supported.\n");
+        else if (strcmp(digraph6Header, headerCandidateChars) == 0)
+            ErrorMessage("Graph file is digraph6 format, which is not supported.\n");
+        else
+            ErrorMessage("Invalid header for .g6 file.\n");
 
-		 exitCode = NOTOK;
-	}
+        exitCode = NOTOK;
+    }
 
-	return exitCode;
+    return exitCode;
 }
 
 bool _firstCharIsValid(char c, const int lineNum)
 {
-	bool isValidFirstChar = false;
+    bool isValidFirstChar = false;
 
-	if (strchr(":;&", c) != NULL)
-	{
-		char messageContents[MAXLINE + 1];
-		sprintf(messageContents, "Invalid first character on line %d, i.e. one of ':', ';', or '&'; aborting.\n", lineNum);
-		ErrorMessage(messageContents);
-	}
-	else
-		isValidFirstChar = true;
+    if (strchr(":;&", c) != NULL)
+    {
+        char messageContents[MAXLINE + 1];
+        sprintf(messageContents, "Invalid first character on line %d, i.e. one of ':', ';', or '&'; aborting.\n", lineNum);
+        ErrorMessage(messageContents);
+    }
+    else
+        isValidFirstChar = true;
 
-	return isValidFirstChar;
+    return isValidFirstChar;
 }
 
 int _getGraphOrder(strOrFileP g6Input, int *graphOrder)
 {
-	int exitCode = OK;
+    int exitCode = OK;
 
-	if (g6Input == NULL)
-	{
-		ErrorMessage("Invalid string-or-file container for .g6 input.\n");
-		return NOTOK;
-	}
+    if (g6Input == NULL)
+    {
+        ErrorMessage("Invalid string-or-file container for .g6 input.\n");
+        return NOTOK;
+    }
 
-	// Since geng: n must be in the range 1..32, and since edge-addition-planarity-suite
-	// processing of random graphs may only handle up to n = 100,000, we will only check
-	// if 1 or 4 bytes are necessary
-	int n = 0;
-	int graphChar = sf_getc(g6Input);
-	if (graphChar == 126)
-	{
-		if ((graphChar = sf_getc(g6Input)) == 126)
-		{
-			ErrorMessage("Graph order is too large; format suggests that 258048 <= n <= 68719476735, but we only support n <= 100000.\n");
-			return NOTOK;
-		}
+    // Since geng: n must be in the range 1..32, and since edge-addition-planarity-suite
+    // processing of random graphs may only handle up to n = 100,000, we will only check
+    // if 1 or 4 bytes are necessary
+    int n = 0;
+    int graphChar = sf_getc(g6Input);
+    if (graphChar == 126)
+    {
+        if ((graphChar = sf_getc(g6Input)) == 126)
+        {
+            ErrorMessage("Graph order is too large; format suggests that 258048 <= n <= 68719476735, but we only support n <= 100000.\n");
+            return NOTOK;
+        }
 
-		sf_ungetc(graphChar, g6Input);
+        sf_ungetc(graphChar, g6Input);
 
-		for (int i = 2; i >= 0; i--)
-		{
-			graphChar = sf_getc(g6Input) - 63;
-			n |= graphChar << (6 * i);
-		}
+        for (int i = 2; i >= 0; i--)
+        {
+            graphChar = sf_getc(g6Input) - 63;
+            n |= graphChar << (6 * i);
+        }
 
-		if (n > 100000)
-		{
-			ErrorMessage("Graph order is too large; we only support n <= 100000.\n");
-			return NOTOK;
-		}
-	}
-	else if (graphChar > 62 && graphChar < 126)
-		n = graphChar - 63;
-	else
-	{
-		ErrorMessage("Graph order is too small; character doesn't correspond to a printable ASCII character.\n");
-		return NOTOK;
-	}
+        if (n > 100000)
+        {
+            ErrorMessage("Graph order is too large; we only support n <= 100000.\n");
+            return NOTOK;
+        }
+    }
+    else if (graphChar > 62 && graphChar < 126)
+        n = graphChar - 63;
+    else
+    {
+        ErrorMessage("Graph order is too small; character doesn't correspond to a printable ASCII character.\n");
+        return NOTOK;
+    }
 
-	(*graphOrder) = n;
+    (*graphOrder) = n;
 
-	return exitCode;
+    return exitCode;
 }
 
 int readGraphUsingG6ReadIterator(G6ReadIterator *pG6ReadIterator)
 {
-	int exitCode = OK;
+    int exitCode = OK;
 
-	char messageContents[MAXLINE + 1];
+    char messageContents[MAXLINE + 1];
 
-	if (!_isG6ReadIteratorAllocated(pG6ReadIterator))
-	{
-		ErrorMessage("G6ReadIterator is not allocated.\n");
-		return NOTOK;
-	}
+    if (!_isG6ReadIteratorAllocated(pG6ReadIterator))
+    {
+        ErrorMessage("G6ReadIterator is not allocated.\n");
+        return NOTOK;
+    }
 
-	strOrFileP g6Input = pG6ReadIterator->g6Input;
+    strOrFileP g6Input = pG6ReadIterator->g6Input;
 
-	if (g6Input == NULL)
-	{
-		ErrorMessage("Pointer to .g6 string-or-file container is NULL.\n");
-		return NOTOK;
-	}
+    if (g6Input == NULL)
+    {
+        ErrorMessage("Pointer to .g6 string-or-file container is NULL.\n");
+        return NOTOK;
+    }
 
-	int numGraphsRead = pG6ReadIterator->numGraphsRead;
+    int numGraphsRead = pG6ReadIterator->numGraphsRead;
 
-	char *currGraphBuff = pG6ReadIterator->currGraphBuff;
+    char *currGraphBuff = pG6ReadIterator->currGraphBuff;
 
-	if (currGraphBuff == NULL)
-	{
-		ErrorMessage("currGraphBuff string is null.\n");
-		return NOTOK;
-	}
+    if (currGraphBuff == NULL)
+    {
+        ErrorMessage("currGraphBuff string is null.\n");
+        return NOTOK;
+    }
 
-	const int graphOrder = pG6ReadIterator->graphOrder;
-	const int numCharsForGraphOrder = pG6ReadIterator->numCharsForGraphOrder;
-	const int numCharsForGraphEncoding = pG6ReadIterator->numCharsForGraphEncoding;
-	const int currGraphBuffSize = pG6ReadIterator->currGraphBuffSize;
+    const int graphOrder = pG6ReadIterator->graphOrder;
+    const int numCharsForGraphOrder = pG6ReadIterator->numCharsForGraphOrder;
+    const int numCharsForGraphEncoding = pG6ReadIterator->numCharsForGraphEncoding;
+    const int currGraphBuffSize = pG6ReadIterator->currGraphBuffSize;
 
-	graphP currGraph = pG6ReadIterator->currGraph;
+    graphP currGraph = pG6ReadIterator->currGraph;
 
-	char firstChar = '\0';
-	char *graphEncodingChars = NULL;
-	if (sf_fgets(currGraphBuff, currGraphBuffSize, g6Input) != NULL)
-	{
-		numGraphsRead++;
-		firstChar = currGraphBuff[0];
+    char firstChar = '\0';
+    char *graphEncodingChars = NULL;
+    if (sf_fgets(currGraphBuff, currGraphBuffSize, g6Input) != NULL)
+    {
+        numGraphsRead++;
+        firstChar = currGraphBuff[0];
 
-		if (!_firstCharIsValid(firstChar, numGraphsRead))
-			return NOTOK;
+        if (!_firstCharIsValid(firstChar, numGraphsRead))
+            return NOTOK;
 
-		// From https://stackoverflow.com/a/28462221, strcspn finds the index of the first
-		// char in charset; this way, I replace the char at that index with the null-terminator
-		currGraphBuff[strcspn(currGraphBuff, "\n\r")] = '\0'; // works for LF, CR, CRLF, LFCR, ...
+        // From https://stackoverflow.com/a/28462221, strcspn finds the index of the first
+        // char in charset; this way, I replace the char at that index with the null-terminator
+        currGraphBuff[strcspn(currGraphBuff, "\n\r")] = '\0'; // works for LF, CR, CRLF, LFCR, ...
 
-		// If the line was too long, then we would have placed the null terminator at the final
-		// index (where it already was; see strcpn docs), and the length of the string will be 
-		// longer than the line should have been, i.e. orderOffset + numCharsForGraphRepr
-		if (strlen(currGraphBuff) != (((numGraphsRead == 1) ? 0 : numCharsForGraphOrder) + numCharsForGraphEncoding))
-		{
-			sprintf(messageContents, "Invalid line length read on line %d\n", numGraphsRead);
-			ErrorMessage(messageContents);
-			return NOTOK;
-		}
+        // If the line was too long, then we would have placed the null terminator at the final
+        // index (where it already was; see strcpn docs), and the length of the string will be
+        // longer than the line should have been, i.e. orderOffset + numCharsForGraphRepr
+        if (strlen(currGraphBuff) != (((numGraphsRead == 1) ? 0 : numCharsForGraphOrder) + numCharsForGraphEncoding))
+        {
+            sprintf(messageContents, "Invalid line length read on line %d\n", numGraphsRead);
+            ErrorMessage(messageContents);
+            return NOTOK;
+        }
 
-		if (numGraphsRead > 1)
-		{
-			exitCode = _checkGraphOrder(currGraphBuff, graphOrder);
+        if (numGraphsRead > 1)
+        {
+            exitCode = _checkGraphOrder(currGraphBuff, graphOrder);
 
-			if (exitCode != OK)
-			{
-				sprintf(messageContents, "Order of graph on line %d is incorrect.\n", numGraphsRead);
-				ErrorMessage(messageContents);
-				return exitCode;
-			}
-		}
+            if (exitCode != OK)
+            {
+                sprintf(messageContents, "Order of graph on line %d is incorrect.\n", numGraphsRead);
+                ErrorMessage(messageContents);
+                return exitCode;
+            }
+        }
 
-		// On first line, we have already processed the characters corresponding to the graph
-		// order, so there's no need to apply the offset. On subsequent lines, the orderOffset
-		// must be applied so that we are only starting validation on the byte corresponding to
-		// the encoding of the adjacency matrix.
-		graphEncodingChars = (numGraphsRead == 1) ? currGraphBuff : currGraphBuff + numCharsForGraphOrder;
-		
-		exitCode = _validateGraphEncoding(graphEncodingChars, graphOrder, numCharsForGraphEncoding);
+        // On first line, we have already processed the characters corresponding to the graph
+        // order, so there's no need to apply the offset. On subsequent lines, the orderOffset
+        // must be applied so that we are only starting validation on the byte corresponding to
+        // the encoding of the adjacency matrix.
+        graphEncodingChars = (numGraphsRead == 1) ? currGraphBuff : currGraphBuff + numCharsForGraphOrder;
 
-		if (exitCode != OK)
-		{
-			sprintf(messageContents, "Graph on line %d is invalid.", numGraphsRead);
-			ErrorMessage(messageContents);
-			return exitCode;
-		}
+        exitCode = _validateGraphEncoding(graphEncodingChars, graphOrder, numCharsForGraphEncoding);
 
-		if (numGraphsRead > 1)
-		{
-			gp_ReinitializeGraph(currGraph);
-			// Ensures zero-based flag is set after reinitializing graph.
-			currGraph->internalFlags |= FLAGS_ZEROBASEDIO;
-		}
+        if (exitCode != OK)
+        {
+            sprintf(messageContents, "Graph on line %d is invalid.", numGraphsRead);
+            ErrorMessage(messageContents);
+            return exitCode;
+        }
 
-		exitCode = _decodeGraph(graphEncodingChars, graphOrder, numCharsForGraphEncoding, currGraph);
+        if (numGraphsRead > 1)
+        {
+            gp_ReinitializeGraph(currGraph);
+            // Ensures zero-based flag is set after reinitializing graph.
+            currGraph->internalFlags |= FLAGS_ZEROBASEDIO;
+        }
 
-		if (exitCode != OK)
-		{
-			sprintf(messageContents, "Unable to interpret bits on line %d to populate adjacency matrix.\n", numGraphsRead);
-			ErrorMessage(messageContents);
-			return exitCode;
-		}
-		
-		pG6ReadIterator->numGraphsRead = numGraphsRead;
-	}
-	else
-		pG6ReadIterator->currGraph = NULL;
+        exitCode = _decodeGraph(graphEncodingChars, graphOrder, numCharsForGraphEncoding, currGraph);
 
-	return exitCode;
+        if (exitCode != OK)
+        {
+            sprintf(messageContents, "Unable to interpret bits on line %d to populate adjacency matrix.\n", numGraphsRead);
+            ErrorMessage(messageContents);
+            return exitCode;
+        }
+
+        pG6ReadIterator->numGraphsRead = numGraphsRead;
+    }
+    else
+        pG6ReadIterator->currGraph = NULL;
+
+    return exitCode;
 }
 
 int _checkGraphOrder(char *graphBuff, int graphOrder)
 {
-	int exitCode = OK;
-	
-	int n = 0;
-	char currChar = graphBuff[0];
-	if (currChar == 126)
-	{
-		if (graphBuff[1] == 126)
-		{
-			ErrorMessage("Can only handle graphs of order <= 100,000.\n");
-			return NOTOK;
-		}
-		else if (graphBuff[1] > 126)
-		{
-			ErrorMessage("Invalid graph order signifier.\n");
-			return NOTOK;
-		}
+    int exitCode = OK;
 
-		int orderCharIndex = 2;
+    int n = 0;
+    char currChar = graphBuff[0];
+    if (currChar == 126)
+    {
+        if (graphBuff[1] == 126)
+        {
+            ErrorMessage("Can only handle graphs of order <= 100,000.\n");
+            return NOTOK;
+        }
+        else if (graphBuff[1] > 126)
+        {
+            ErrorMessage("Invalid graph order signifier.\n");
+            return NOTOK;
+        }
 
-		for (int i = 1; i < 4; i++)
-			n |= (graphBuff[i] - 63) << (6 * orderCharIndex--);
-	}
-	else if (currChar > 62 && currChar < 126)
-		n = currChar - 63;
-	else
-	{
-		ErrorMessage("Character doesn't correspond to a printable ASCII character.\n");
-		return NOTOK;
-	}
+        int orderCharIndex = 2;
 
-	if (n != graphOrder)
-	{
-		char messageContents[MAXLINE + 1];
-		sprintf(messageContents, "Graph order %d doesn't match expected graph order %d", n, graphOrder);
-		ErrorMessage(messageContents);
-		exitCode = NOTOK;
-	}
+        for (int i = 1; i < 4; i++)
+            n |= (graphBuff[i] - 63) << (6 * orderCharIndex--);
+    }
+    else if (currChar > 62 && currChar < 126)
+        n = currChar - 63;
+    else
+    {
+        ErrorMessage("Character doesn't correspond to a printable ASCII character.\n");
+        return NOTOK;
+    }
 
-	return exitCode;
+    if (n != graphOrder)
+    {
+        char messageContents[MAXLINE + 1];
+        sprintf(messageContents, "Graph order %d doesn't match expected graph order %d", n, graphOrder);
+        ErrorMessage(messageContents);
+        exitCode = NOTOK;
+    }
+
+    return exitCode;
 }
 
 int _validateGraphEncoding(char *graphBuff, const int graphOrder, const int numChars)
 {
-	int exitCode = OK;
+    int exitCode = OK;
 
-	char messageContents[MAXLINE + 1];
+    char messageContents[MAXLINE + 1];
 
-	// Num edges of the graph (and therefore the number of bits) is (n * (n-1))/2, and
-	// since each resulting byte needs to correspond to an ascii character between 63 and 126,
-	// each group is only comprised of 6 bits (to which we add 63 for the final byte value)
-	int expectedNumChars = _getNumCharsForGraphEncoding(graphOrder);
-	int numCharsForGraphEncoding = strlen(graphBuff);
-	if (expectedNumChars != numCharsForGraphEncoding)
-	{
-		sprintf(messageContents, "Invalid number of bytes for graph of order %d; got %d but expected %d\n", graphOrder, numCharsForGraphEncoding, expectedNumChars);
-		ErrorMessage(messageContents);
-		return NOTOK;
-	}
+    // Num edges of the graph (and therefore the number of bits) is (n * (n-1))/2, and
+    // since each resulting byte needs to correspond to an ascii character between 63 and 126,
+    // each group is only comprised of 6 bits (to which we add 63 for the final byte value)
+    int expectedNumChars = _getNumCharsForGraphEncoding(graphOrder);
+    int numCharsForGraphEncoding = strlen(graphBuff);
+    if (expectedNumChars != numCharsForGraphEncoding)
+    {
+        sprintf(messageContents, "Invalid number of bytes for graph of order %d; got %d but expected %d\n", graphOrder, numCharsForGraphEncoding, expectedNumChars);
+        ErrorMessage(messageContents);
+        return NOTOK;
+    }
 
-	// Check that characters are valid ASCII characters between 62 and 126
-	for (int i = 0; i < numChars; i++)
-	{
-		if (graphBuff[i] < 63 || graphBuff[i] > 126)
-		{
-			sprintf(messageContents, "Invalid character at index %d: \"%c\"\n", i, graphBuff[i]);
-			ErrorMessage(messageContents);
-			return NOTOK;
-		}
-	}
+    // Check that characters are valid ASCII characters between 62 and 126
+    for (int i = 0; i < numChars; i++)
+    {
+        if (graphBuff[i] < 63 || graphBuff[i] > 126)
+        {
+            sprintf(messageContents, "Invalid character at index %d: \"%c\"\n", i, graphBuff[i]);
+            ErrorMessage(messageContents);
+            return NOTOK;
+        }
+    }
 
-	// Check that there are no extraneous bits in representation (since we pad out to a
-	// multiple of 6 before splitting into bytes and adding 63 to each byte)
-	int expectedNumPaddingZeroes = _getExpectedNumPaddingZeroes(graphOrder, numChars);
-	char finalByte = graphBuff[numChars - 1] - 63;
-	int numPaddingZeroes = 0;
-	for (int i = 0; i < expectedNumPaddingZeroes; i++)
-	{
-		if (finalByte & (1 << i))
-			break;
-		
-		numPaddingZeroes++;
-	}
+    // Check that there are no extraneous bits in representation (since we pad out to a
+    // multiple of 6 before splitting into bytes and adding 63 to each byte)
+    int expectedNumPaddingZeroes = _getExpectedNumPaddingZeroes(graphOrder, numChars);
+    char finalByte = graphBuff[numChars - 1] - 63;
+    int numPaddingZeroes = 0;
+    for (int i = 0; i < expectedNumPaddingZeroes; i++)
+    {
+        if (finalByte & (1 << i))
+            break;
 
-	if (numPaddingZeroes != expectedNumPaddingZeroes)
-	{
-		sprintf(messageContents, "Expected %d padding zeroes, but got %d.\n", expectedNumPaddingZeroes, numPaddingZeroes);
-		ErrorMessage(messageContents);
-		exitCode = NOTOK;
-	}
+        numPaddingZeroes++;
+    }
 
-	return exitCode;
+    if (numPaddingZeroes != expectedNumPaddingZeroes)
+    {
+        sprintf(messageContents, "Expected %d padding zeroes, but got %d.\n", expectedNumPaddingZeroes, numPaddingZeroes);
+        ErrorMessage(messageContents);
+        exitCode = NOTOK;
+    }
+
+    return exitCode;
 }
 
 // Takes the character array graphBuff, the derived number of vertices graphOrder,
@@ -616,110 +615,110 @@ int _validateGraphEncoding(char *graphBuff, const int graphOrder, const int numC
 // are incremented such that row ranges from 0 to one less than the column index.
 int _decodeGraph(char *graphBuff, const int graphOrder, const int numChars, graphP pGraph)
 {
-	int exitCode = OK;
+    int exitCode = OK;
 
-	if (pGraph == NULL)
-	{
-		ErrorMessage("Must initialize graph datastructure before invoking _decodeGraph.\n");
-		return NOTOK;
-	}
+    if (pGraph == NULL)
+    {
+        ErrorMessage("Must initialize graph datastructure before invoking _decodeGraph.\n");
+        return NOTOK;
+    }
 
-	int numPaddingZeroes = _getExpectedNumPaddingZeroes(graphOrder, numChars);
+    int numPaddingZeroes = _getExpectedNumPaddingZeroes(graphOrder, numChars);
 
-	char currByte = '\0';
-	int bitValue = 0;
-	int row = 0;
-	int col = 1;
-	for (int i = 0; i < numChars; i++)
-	{
-		currByte = graphBuff[i] - 63;
-		// j corresponds to the number of places one must bitshift the byte by to read
-		// the next bit in the byte
-		for (int j = sizeof(char) * 5; j >= 0; j--)
-		{
-			// If we are on the final byte, we know that the final numPaddingZeroes bits
-			// can be ignored, so we break out of the loop
-			if ((i == numChars) && j == numPaddingZeroes - 1)
-				break;
+    char currByte = '\0';
+    int bitValue = 0;
+    int row = 0;
+    int col = 1;
+    for (int i = 0; i < numChars; i++)
+    {
+        currByte = graphBuff[i] - 63;
+        // j corresponds to the number of places one must bitshift the byte by to read
+        // the next bit in the byte
+        for (int j = sizeof(char) * 5; j >= 0; j--)
+        {
+            // If we are on the final byte, we know that the final numPaddingZeroes bits
+            // can be ignored, so we break out of the loop
+            if ((i == numChars) && j == numPaddingZeroes - 1)
+                break;
 
-			if (row == col)
-			{
-				row = 0;
-				col++;
-			}
+            if (row == col)
+            {
+                row = 0;
+                col++;
+            }
 
-			bitValue = ((currByte >> j) & 1u) ? 1 : 0;
-			if (bitValue == 1)
-			{
-				// Add gp_GetFirstVertex(pGraph), which is 1 if NIL == 0 (i.e. internal 1-based labelling) and 0 if NIL == -1 (internally 0-based)
-				exitCode = gp_DynamicAddEdge(pGraph, row+gp_GetFirstVertex(pGraph), 0, col+gp_GetFirstVertex(pGraph), 0);
-				if (exitCode != OK)
-					return exitCode;
-			}
+            bitValue = ((currByte >> j) & 1u) ? 1 : 0;
+            if (bitValue == 1)
+            {
+                // Add gp_GetFirstVertex(pGraph), which is 1 if NIL == 0 (i.e. internal 1-based labelling) and 0 if NIL == -1 (internally 0-based)
+                exitCode = gp_DynamicAddEdge(pGraph, row + gp_GetFirstVertex(pGraph), 0, col + gp_GetFirstVertex(pGraph), 0);
+                if (exitCode != OK)
+                    return exitCode;
+            }
 
-			row++;
-		}
-	}
+            row++;
+        }
+    }
 
-	return exitCode;
+    return exitCode;
 }
 
 int endG6ReadIteration(G6ReadIterator *pG6ReadIterator)
 {
-	int exitCode = OK;
+    int exitCode = OK;
 
-	if (pG6ReadIterator != NULL)
-	{
-		if (pG6ReadIterator->g6Input != NULL)
-		{
-			exitCode = sf_closeFile(pG6ReadIterator->g6Input);
-			if (exitCode != OK)
-				ErrorMessage("Unable to close g6Input file pointer.\n");
-		
-			sf_Free(&(pG6ReadIterator->g6Input));
-		}
+    if (pG6ReadIterator != NULL)
+    {
+        if (pG6ReadIterator->g6Input != NULL)
+        {
+            exitCode = sf_closeFile(pG6ReadIterator->g6Input);
+            if (exitCode != OK)
+                ErrorMessage("Unable to close g6Input file pointer.\n");
 
-		if (pG6ReadIterator->currGraphBuff != NULL)
-		{
-			free(pG6ReadIterator->currGraphBuff);
-			pG6ReadIterator->currGraphBuff = NULL;
-		}
-	}
+            sf_Free(&(pG6ReadIterator->g6Input));
+        }
 
-	return exitCode;
+        if (pG6ReadIterator->currGraphBuff != NULL)
+        {
+            free(pG6ReadIterator->currGraphBuff);
+            pG6ReadIterator->currGraphBuff = NULL;
+        }
+    }
+
+    return exitCode;
 }
 
 int freeG6ReadIterator(G6ReadIterator **ppG6ReadIterator)
 {
-	int exitCode = OK;
+    int exitCode = OK;
 
-	if (ppG6ReadIterator != NULL && (*ppG6ReadIterator) != NULL)
-	{
-		if ((*ppG6ReadIterator)->g6Input != NULL)
-		{
-			exitCode = sf_closeFile((*ppG6ReadIterator)->g6Input);
-			if (exitCode != OK)
-				ErrorMessage("Unable to close g6Input file pointer.\n");
+    if (ppG6ReadIterator != NULL && (*ppG6ReadIterator) != NULL)
+    {
+        if ((*ppG6ReadIterator)->g6Input != NULL)
+        {
+            exitCode = sf_closeFile((*ppG6ReadIterator)->g6Input);
+            if (exitCode != OK)
+                ErrorMessage("Unable to close g6Input file pointer.\n");
 
-			sf_Free(&((*ppG6ReadIterator)->g6Input));
-		}
+            sf_Free(&((*ppG6ReadIterator)->g6Input));
+        }
 
-		(*ppG6ReadIterator)->numGraphsRead = 0;
-		(*ppG6ReadIterator)->graphOrder = 0;
+        (*ppG6ReadIterator)->numGraphsRead = 0;
+        (*ppG6ReadIterator)->graphOrder = 0;
 
-		if ((*ppG6ReadIterator)->currGraphBuff != NULL)
-		{
-			free((*ppG6ReadIterator)->currGraphBuff);
-			(*ppG6ReadIterator)->currGraphBuff = NULL;
-		}
+        if ((*ppG6ReadIterator)->currGraphBuff != NULL)
+        {
+            free((*ppG6ReadIterator)->currGraphBuff);
+            (*ppG6ReadIterator)->currGraphBuff = NULL;
+        }
 
-		(*ppG6ReadIterator)->currGraph = NULL;
+        (*ppG6ReadIterator)->currGraph = NULL;
 
-		free((*ppG6ReadIterator));
-		(*ppG6ReadIterator) = NULL;
-	}
+        free((*ppG6ReadIterator));
+        (*ppG6ReadIterator) = NULL;
+    }
 
-	return exitCode;
+    return exitCode;
 }
 
 // Although _ReadGraphFromG6FilePath is almost identical to _ReadGraphFromG6FilePointer,
@@ -727,45 +726,45 @@ int freeG6ReadIterator(G6ReadIterator **ppG6ReadIterator)
 // to change. If you do modify this function, be sure to modify _ReadGraphFromG6FilePointer.
 int _ReadGraphFromG6FilePath(graphP pGraphToRead, char *pathToG6File)
 {
-	int exitCode = OK;
+    int exitCode = OK;
 
-	G6ReadIterator *pG6ReadIterator = NULL;
-	exitCode = allocateG6ReadIterator(&pG6ReadIterator, pGraphToRead);
+    G6ReadIterator *pG6ReadIterator = NULL;
+    exitCode = allocateG6ReadIterator(&pG6ReadIterator, pGraphToRead);
 
-	if (exitCode != OK)
-	{
-		ErrorMessage("Unable to allocate G6ReadIterator.\n");
-		return exitCode;
-	}
+    if (exitCode != OK)
+    {
+        ErrorMessage("Unable to allocate G6ReadIterator.\n");
+        return exitCode;
+    }
 
-	exitCode = beginG6ReadIterationFromG6FilePath(pG6ReadIterator, pathToG6File);
+    exitCode = beginG6ReadIterationFromG6FilePath(pG6ReadIterator, pathToG6File);
 
-	if (exitCode != OK)
-	{
-		ErrorMessage("Unable to begin .g6 read iteration.\n");
+    if (exitCode != OK)
+    {
+        ErrorMessage("Unable to begin .g6 read iteration.\n");
 
-		exitCode = freeG6ReadIterator(&pG6ReadIterator);
+        exitCode = freeG6ReadIterator(&pG6ReadIterator);
 
-		if (exitCode != OK)
-			ErrorMessage("Unable to free G6ReadIterator.\n");
+        if (exitCode != OK)
+            ErrorMessage("Unable to free G6ReadIterator.\n");
 
-		return exitCode;
-	}
+        return exitCode;
+    }
 
-	exitCode = readGraphUsingG6ReadIterator(pG6ReadIterator);
-	if (exitCode != OK)
-		ErrorMessage("Unable to read graph from .g6 read iterator.\n");
+    exitCode = readGraphUsingG6ReadIterator(pG6ReadIterator);
+    if (exitCode != OK)
+        ErrorMessage("Unable to read graph from .g6 read iterator.\n");
 
-	exitCode = endG6ReadIteration(pG6ReadIterator);
-	if (exitCode != OK)
-		ErrorMessage("Unable to end G6ReadIterator.\n");
-	
-	exitCode = freeG6ReadIterator(&pG6ReadIterator);
+    exitCode = endG6ReadIteration(pG6ReadIterator);
+    if (exitCode != OK)
+        ErrorMessage("Unable to end G6ReadIterator.\n");
 
-	if (exitCode != OK)
-		ErrorMessage("Unable to free G6ReadIterator.\n");
+    exitCode = freeG6ReadIterator(&pG6ReadIterator);
 
-	return exitCode;
+    if (exitCode != OK)
+        ErrorMessage("Unable to free G6ReadIterator.\n");
+
+    return exitCode;
 }
 
 // Although _ReadGraphFromG6FilePointer is almost identical to _ReadGraphFromG6FilePath,
@@ -773,92 +772,92 @@ int _ReadGraphFromG6FilePath(graphP pGraphToRead, char *pathToG6File)
 // to change. If you do change this function, be sure to modify _ReadGraphFromG6FilePath.
 int _ReadGraphFromG6FilePointer(graphP pGraphToRead, FILE *g6Infile)
 {
-	int exitCode = OK;
+    int exitCode = OK;
 
-	G6ReadIterator *pG6ReadIterator = NULL;
-	exitCode = allocateG6ReadIterator(&pG6ReadIterator, pGraphToRead);
+    G6ReadIterator *pG6ReadIterator = NULL;
+    exitCode = allocateG6ReadIterator(&pG6ReadIterator, pGraphToRead);
 
-	if (exitCode != OK)
-	{
-		ErrorMessage("Unable to allocate G6ReadIterator.\n");
-		return exitCode;
-	}
+    if (exitCode != OK)
+    {
+        ErrorMessage("Unable to allocate G6ReadIterator.\n");
+        return exitCode;
+    }
 
-	exitCode = beginG6ReadIterationFromG6FilePointer(pG6ReadIterator, g6Infile);
+    exitCode = beginG6ReadIterationFromG6FilePointer(pG6ReadIterator, g6Infile);
 
-	if (exitCode != OK)
-	{
-		ErrorMessage("Unable to begin .g6 read iteration.\n");
+    if (exitCode != OK)
+    {
+        ErrorMessage("Unable to begin .g6 read iteration.\n");
 
-		exitCode = freeG6ReadIterator(&pG6ReadIterator);
+        exitCode = freeG6ReadIterator(&pG6ReadIterator);
 
-		if (exitCode != OK)
-			ErrorMessage("Unable to free G6ReadIterator.\n");
+        if (exitCode != OK)
+            ErrorMessage("Unable to free G6ReadIterator.\n");
 
-		return exitCode;
-	}
+        return exitCode;
+    }
 
-	exitCode = readGraphUsingG6ReadIterator(pG6ReadIterator);
-	if (exitCode != OK)
-		ErrorMessage("Unable to read graph from .g6 read iterator.\n");
+    exitCode = readGraphUsingG6ReadIterator(pG6ReadIterator);
+    if (exitCode != OK)
+        ErrorMessage("Unable to read graph from .g6 read iterator.\n");
 
-	exitCode = endG6ReadIteration(pG6ReadIterator);
-	if (exitCode != OK)
-		ErrorMessage("Unable to end G6ReadIterator.\n");
-	
-	exitCode = freeG6ReadIterator(&pG6ReadIterator);
+    exitCode = endG6ReadIteration(pG6ReadIterator);
+    if (exitCode != OK)
+        ErrorMessage("Unable to end G6ReadIterator.\n");
 
-	if (exitCode != OK)
-		ErrorMessage("Unable to free G6ReadIterator.\n");
+    exitCode = freeG6ReadIterator(&pG6ReadIterator);
 
-	return exitCode;
+    if (exitCode != OK)
+        ErrorMessage("Unable to free G6ReadIterator.\n");
+
+    return exitCode;
 }
 
 int _ReadGraphFromG6String(graphP pGraphToRead, char *g6EncodedString)
 {
-	int exitCode = OK;
+    int exitCode = OK;
 
-	if (g6EncodedString == NULL || strlen(g6EncodedString) == 0)
-	{
-		ErrorMessage("Input string is empty.\n");
-		return NOTOK;
-	}
+    if (g6EncodedString == NULL || strlen(g6EncodedString) == 0)
+    {
+        ErrorMessage("Input string is empty.\n");
+        return NOTOK;
+    }
 
-	G6ReadIterator *pG6ReadIterator = NULL;
-	exitCode = allocateG6ReadIterator(&pG6ReadIterator, pGraphToRead);
+    G6ReadIterator *pG6ReadIterator = NULL;
+    exitCode = allocateG6ReadIterator(&pG6ReadIterator, pGraphToRead);
 
-	if (exitCode != OK)
-	{
-		ErrorMessage("Unable to allocate G6ReadIterator.\n");
-		return exitCode;
-	}
+    if (exitCode != OK)
+    {
+        ErrorMessage("Unable to allocate G6ReadIterator.\n");
+        return exitCode;
+    }
 
-	exitCode = beginG6ReadIterationFromG6String(pG6ReadIterator, g6EncodedString);
+    exitCode = beginG6ReadIterationFromG6String(pG6ReadIterator, g6EncodedString);
 
-	if (exitCode != OK)
-	{
-		ErrorMessage("Unable to begin .g6 read iteration.\n");
+    if (exitCode != OK)
+    {
+        ErrorMessage("Unable to begin .g6 read iteration.\n");
 
-		exitCode = freeG6ReadIterator(&pG6ReadIterator);
+        exitCode = freeG6ReadIterator(&pG6ReadIterator);
 
-		if (exitCode != OK)
-			ErrorMessage("Unable to free G6ReadIterator.\n");
+        if (exitCode != OK)
+            ErrorMessage("Unable to free G6ReadIterator.\n");
 
-		return exitCode;
-	}
+        return exitCode;
+    }
 
-	exitCode = readGraphUsingG6ReadIterator(pG6ReadIterator);
-	if (exitCode != OK)
-		ErrorMessage("Unable to read graph from .g6 read iterator.\n");
+    exitCode = readGraphUsingG6ReadIterator(pG6ReadIterator);
+    if (exitCode != OK)
+        ErrorMessage("Unable to read graph from .g6 read iterator.\n");
 
-	exitCode = endG6ReadIteration(pG6ReadIterator);
-	if (exitCode != OK)
-		ErrorMessage("Unable to end G6ReadIterator.\n");
-	
-	exitCode = freeG6ReadIterator(&pG6ReadIterator);
+    exitCode = endG6ReadIteration(pG6ReadIterator);
+    if (exitCode != OK)
+        ErrorMessage("Unable to end G6ReadIterator.\n");
 
-	if (exitCode != OK)
-		ErrorMessage("Unable to free G6ReadIterator.\n");
+    exitCode = freeG6ReadIterator(&pG6ReadIterator);
 
-	return exitCode;
+    if (exitCode != OK)
+        ErrorMessage("Unable to free G6ReadIterator.\n");
+
+    return exitCode;
 }

--- a/c/graphLib/io/g6-read-iterator.h
+++ b/c/graphLib/io/g6-read-iterator.h
@@ -18,47 +18,47 @@ extern "C"
 #include "../graph.h"
 #include "strOrFile.h"
 
-	typedef struct
-	{
-		strOrFileP g6Input;
-		int numGraphsRead;
+    typedef struct
+    {
+        strOrFileP g6Input;
+        int numGraphsRead;
 
-		int graphOrder;
-		int numCharsForGraphOrder;
-		int numCharsForGraphEncoding;
-		int currGraphBuffSize;
-		char *currGraphBuff;
+        int graphOrder;
+        int numCharsForGraphOrder;
+        int numCharsForGraphEncoding;
+        int currGraphBuffSize;
+        char *currGraphBuff;
 
-		graphP currGraph;
-	} G6ReadIterator;
+        graphP currGraph;
+    } G6ReadIterator;
 
-	int allocateG6ReadIterator(G6ReadIterator **, graphP);
-	bool _isG6ReadIteratorAllocated(G6ReadIterator *pG6ReadIterator);
+    int allocateG6ReadIterator(G6ReadIterator **, graphP);
+    bool _isG6ReadIteratorAllocated(G6ReadIterator *pG6ReadIterator);
 
-	int getNumGraphsRead(G6ReadIterator *, int *);
-	int getOrderOfGraphToRead(G6ReadIterator *, int *);
-	int getPointerToGraphReadIn(G6ReadIterator *, graphP *);
+    int getNumGraphsRead(G6ReadIterator *, int *);
+    int getOrderOfGraphToRead(G6ReadIterator *, int *);
+    int getPointerToGraphReadIn(G6ReadIterator *, graphP *);
 
-	int beginG6ReadIterationFromG6FilePath(G6ReadIterator *, char *);
-	int beginG6ReadIterationFromG6FilePointer(G6ReadIterator *, FILE *);
-	int beginG6ReadIterationFromG6String(G6ReadIterator *pG6ReadIterator, char *g6InputStr);
-	int _beginG6ReadIteration(G6ReadIterator *pG6ReadIterator);
-	int _processAndCheckHeader(strOrFileP g6Input);
-	bool _firstCharIsValid(char, const int);
-	int _getGraphOrder(strOrFileP g6Input, int *);
+    int beginG6ReadIterationFromG6FilePath(G6ReadIterator *, char *);
+    int beginG6ReadIterationFromG6FilePointer(G6ReadIterator *, FILE *);
+    int beginG6ReadIterationFromG6String(G6ReadIterator *pG6ReadIterator, char *g6InputStr);
+    int _beginG6ReadIteration(G6ReadIterator *pG6ReadIterator);
+    int _processAndCheckHeader(strOrFileP g6Input);
+    bool _firstCharIsValid(char, const int);
+    int _getGraphOrder(strOrFileP g6Input, int *);
 
-	int readGraphUsingG6ReadIterator(G6ReadIterator *);
-	int _checkGraphOrder(char *, int);
-	int _validateGraphEncoding(char *, const int, const int);
-	int _decodeGraph(char *, const int, const int, graphP);
+    int readGraphUsingG6ReadIterator(G6ReadIterator *);
+    int _checkGraphOrder(char *, int);
+    int _validateGraphEncoding(char *, const int, const int);
+    int _decodeGraph(char *, const int, const int, graphP);
 
-	int endG6ReadIteration(G6ReadIterator *);
+    int endG6ReadIteration(G6ReadIterator *);
 
-	int freeG6ReadIterator(G6ReadIterator **);
+    int freeG6ReadIterator(G6ReadIterator **);
 
-	int _ReadGraphFromG6FilePath(graphP, char *);
-	int _ReadGraphFromG6FilePointer(graphP pGraphToRead, FILE *g6Infile);
-	int _ReadGraphFromG6String(graphP, char *);
+    int _ReadGraphFromG6FilePath(graphP, char *);
+    int _ReadGraphFromG6FilePointer(graphP pGraphToRead, FILE *g6Infile);
+    int _ReadGraphFromG6String(graphP, char *);
 
 #ifdef __cplusplus
 }

--- a/c/graphLib/io/g6-write-iterator.c
+++ b/c/graphLib/io/g6-write-iterator.c
@@ -12,688 +12,688 @@ See the LICENSE.TXT file for licensing information.
 
 int allocateG6WriteIterator(G6WriteIterator **ppG6WriteIterator, graphP pGraph)
 {
-	int exitCode = OK;
+    int exitCode = OK;
 
-	if (ppG6WriteIterator != NULL && (*ppG6WriteIterator) != NULL)
-	{
-		ErrorMessage("G6WriteIterator is not NULL and therefore can't be allocated.\n");
-		return NOTOK;
-	}
+    if (ppG6WriteIterator != NULL && (*ppG6WriteIterator) != NULL)
+    {
+        ErrorMessage("G6WriteIterator is not NULL and therefore can't be allocated.\n");
+        return NOTOK;
+    }
 
-	// numGraphsWritten, graphOrder, numCharsForGraphOrder,
-	// numCharsForGraphEncoding, and currGraphBuffSize all set to 0
-	(*ppG6WriteIterator) = (G6WriteIterator *)calloc(1, sizeof(G6WriteIterator));
+    // numGraphsWritten, graphOrder, numCharsForGraphOrder,
+    // numCharsForGraphEncoding, and currGraphBuffSize all set to 0
+    (*ppG6WriteIterator) = (G6WriteIterator *)calloc(1, sizeof(G6WriteIterator));
 
-	if ((*ppG6WriteIterator) == NULL)
-	{
-		ErrorMessage("Unable to allocate memory for G6WriteIterator.\n");
-		return NOTOK;
-	}
+    if ((*ppG6WriteIterator) == NULL)
+    {
+        ErrorMessage("Unable to allocate memory for G6WriteIterator.\n");
+        return NOTOK;
+    }
 
-	(*ppG6WriteIterator)->g6Output = NULL;
-	(*ppG6WriteIterator)->currGraphBuff = NULL;
-	(*ppG6WriteIterator)->columnOffsets = NULL;
+    (*ppG6WriteIterator)->g6Output = NULL;
+    (*ppG6WriteIterator)->currGraphBuff = NULL;
+    (*ppG6WriteIterator)->columnOffsets = NULL;
 
-	if (pGraph == NULL || pGraph->N <= 0)
-	{
-		ErrorMessage("[ERROR] Must allocate and initialize graph with an order greater than 0 to use the G6WriteIterator.\n");
+    if (pGraph == NULL || pGraph->N <= 0)
+    {
+        ErrorMessage("[ERROR] Must allocate and initialize graph with an order greater than 0 to use the G6WriteIterator.\n");
 
-		exitCode = freeG6WriteIterator(ppG6WriteIterator);
+        exitCode = freeG6WriteIterator(ppG6WriteIterator);
 
-		if (exitCode != OK)
-			ErrorMessage("Unable to free the G6WriteIterator.\n");
-	}
-	else
-		(*ppG6WriteIterator)->currGraph = pGraph;
+        if (exitCode != OK)
+            ErrorMessage("Unable to free the G6WriteIterator.\n");
+    }
+    else
+        (*ppG6WriteIterator)->currGraph = pGraph;
 
-	return exitCode;
+    return exitCode;
 }
 
 bool _isG6WriteIteratorAllocated(G6WriteIterator *pG6WriteIterator)
 {
-	bool G6WriteIteratorIsAllocated = true;
+    bool G6WriteIteratorIsAllocated = true;
 
-	if (pG6WriteIterator == NULL || pG6WriteIterator->currGraph == NULL)
-		G6WriteIteratorIsAllocated = false;
+    if (pG6WriteIterator == NULL || pG6WriteIterator->currGraph == NULL)
+        G6WriteIteratorIsAllocated = false;
 
-	return G6WriteIteratorIsAllocated;
+    return G6WriteIteratorIsAllocated;
 }
 
 int getNumGraphsWritten(G6WriteIterator *pG6WriteIterator, int *pNumGraphsRead)
 {
-	if (pG6WriteIterator == NULL)
-	{
-		ErrorMessage("G6WriteIterator is not allocated.\n");
-		return NOTOK;
-	}
+    if (pG6WriteIterator == NULL)
+    {
+        ErrorMessage("G6WriteIterator is not allocated.\n");
+        return NOTOK;
+    }
 
-	(*pNumGraphsRead) = pG6WriteIterator->numGraphsWritten;
+    (*pNumGraphsRead) = pG6WriteIterator->numGraphsWritten;
 
-	return OK;
+    return OK;
 }
 
 int getOrderOfGraphToWrite(G6WriteIterator *pG6WriteIterator, int *pGraphOrder)
 {
-	if (pG6WriteIterator == NULL)
-	{
-		ErrorMessage("G6WriteIterator is not allocated.\n");
-		return NOTOK;
-	}
+    if (pG6WriteIterator == NULL)
+    {
+        ErrorMessage("G6WriteIterator is not allocated.\n");
+        return NOTOK;
+    }
 
-	(*pGraphOrder) = pG6WriteIterator->graphOrder;
+    (*pGraphOrder) = pG6WriteIterator->graphOrder;
 
-	return OK;
+    return OK;
 }
 
 int getPointerToGraphToWrite(G6WriteIterator *pG6WriteIterator, graphP *ppGraph)
 {
-	if (pG6WriteIterator == NULL)
-	{
-		ErrorMessage("[ERROR] G6WriteIterator is not allocated.\n");
-		return NOTOK;
-	}
+    if (pG6WriteIterator == NULL)
+    {
+        ErrorMessage("[ERROR] G6WriteIterator is not allocated.\n");
+        return NOTOK;
+    }
 
-	(*ppGraph) = pG6WriteIterator->currGraph;
+    (*ppGraph) = pG6WriteIterator->currGraph;
 
-	return OK;
+    return OK;
 }
 
 int getGraphBuff(G6WriteIterator *pG6WriteIterator, char **ppCurrGraphBuff)
 {
-	if (pG6WriteIterator == NULL)
-	{
-		ErrorMessage("G6WriteIterator is not allocated.\n");
-		return NOTOK;
-	}
+    if (pG6WriteIterator == NULL)
+    {
+        ErrorMessage("G6WriteIterator is not allocated.\n");
+        return NOTOK;
+    }
 
-	(*ppCurrGraphBuff) = pG6WriteIterator->currGraphBuff;
+    (*ppCurrGraphBuff) = pG6WriteIterator->currGraphBuff;
 
-	return OK;
+    return OK;
 }
 
 int beginG6WriteIterationToG6FilePath(G6WriteIterator *pG6WriteIterator, char *g6FilePath)
 {
-	int exitCode = OK;
+    int exitCode = OK;
 
-	if (!_isG6WriteIteratorAllocated(pG6WriteIterator))
-	{
-		ErrorMessage("G6WriteIterator is not allocated.\n");
-		return NOTOK;
-	}
+    if (!_isG6WriteIteratorAllocated(pG6WriteIterator))
+    {
+        ErrorMessage("G6WriteIterator is not allocated.\n");
+        return NOTOK;
+    }
 
-	if (g6FilePath == NULL || strlen(g6FilePath) == 0)
-	{
-		ErrorMessage("g6FilePath is null or has length 0.\n");
-		return NOTOK;
-	}
+    if (g6FilePath == NULL || strlen(g6FilePath) == 0)
+    {
+        ErrorMessage("g6FilePath is null or has length 0.\n");
+        return NOTOK;
+    }
 
-	g6FilePath[strcspn(g6FilePath, "\n\r")] = '\0';
+    g6FilePath[strcspn(g6FilePath, "\n\r")] = '\0';
 
-	FILE *g6Outfile = fopen(g6FilePath, "w");
+    FILE *g6Outfile = fopen(g6FilePath, "w");
 
-	if (g6Outfile == NULL)
-	{
-		char *messageFormat = "Unable to open \"%.*s\" for writing.\n";
-		char messageContents[MAXLINE + 1];
-		int charsAvailForStr = (int)(MAXLINE - strlen(messageFormat));
-		sprintf(messageContents, messageFormat, charsAvailForStr, g6FilePath);
-		ErrorMessage(messageContents);
-		return NOTOK;
-	}
+    if (g6Outfile == NULL)
+    {
+        char *messageFormat = "Unable to open \"%.*s\" for writing.\n";
+        char messageContents[MAXLINE + 1];
+        int charsAvailForStr = (int)(MAXLINE - strlen(messageFormat));
+        sprintf(messageContents, messageFormat, charsAvailForStr, g6FilePath);
+        ErrorMessage(messageContents);
+        return NOTOK;
+    }
 
-	exitCode = beginG6WriteIterationToG6FilePointer(pG6WriteIterator, g6Outfile);
+    exitCode = beginG6WriteIterationToG6FilePointer(pG6WriteIterator, g6Outfile);
 
-	if (exitCode != OK)
-		ErrorMessage("Unable to begin write iteration from .g6 file pointer corresponding to given file path.\n");
+    if (exitCode != OK)
+        ErrorMessage("Unable to begin write iteration from .g6 file pointer corresponding to given file path.\n");
 
-	return exitCode;
+    return exitCode;
 }
 
 int beginG6WriteIterationToG6FilePointer(G6WriteIterator *pG6WriteIterator, FILE *g6Outfile)
 {
-	int exitCode = OK;
+    int exitCode = OK;
 
-	if (g6Outfile == NULL)
-	{
-		ErrorMessage(".g6 outfile pointer is NULL.\n");
-		return NOTOK;
-	}
+    if (g6Outfile == NULL)
+    {
+        ErrorMessage(".g6 outfile pointer is NULL.\n");
+        return NOTOK;
+    }
 
-	pG6WriteIterator->g6Output = sf_New(g6Outfile, NULL);
+    pG6WriteIterator->g6Output = sf_New(g6Outfile, NULL);
 
-	exitCode = _beginG6WriteIteration(pG6WriteIterator);
+    exitCode = _beginG6WriteIteration(pG6WriteIterator);
 
-	if (exitCode != OK)
-		ErrorMessage("Unable to begin .g6 write iteration from given file pointer.\n");
+    if (exitCode != OK)
+        ErrorMessage("Unable to begin .g6 write iteration from given file pointer.\n");
 
-	return exitCode;
+    return exitCode;
 }
 
 int beginG6WriteIterationToG6String(G6WriteIterator *pG6WriteIterator, char **g6OutputStr)
 {
-	int exitCode = OK;
+    int exitCode = OK;
 
-	if (g6OutputStr == NULL)
-	{
-		ErrorMessage("No .g6 output string pointer provided.\n");
-		return NOTOK;
-	}
+    if (g6OutputStr == NULL)
+    {
+        ErrorMessage("No .g6 output string pointer provided.\n");
+        return NOTOK;
+    }
 
-	if ((*g6OutputStr) == NULL)
-	{
-		(*g6OutputStr) = (char *)malloc(1 * sizeof(char));
-		(*g6OutputStr)[0] = '\0';
-	}
+    if ((*g6OutputStr) == NULL)
+    {
+        (*g6OutputStr) = (char *)malloc(1 * sizeof(char));
+        (*g6OutputStr)[0] = '\0';
+    }
 
-	pG6WriteIterator->g6Output = sf_New(NULL, (*g6OutputStr));
+    pG6WriteIterator->g6Output = sf_New(NULL, (*g6OutputStr));
 
-	exitCode = _beginG6WriteIteration(pG6WriteIterator);
+    exitCode = _beginG6WriteIteration(pG6WriteIterator);
 
-	if (exitCode != OK)
-		ErrorMessage("Unable to begin .g6 write iteration from given file pointer.\n");
+    if (exitCode != OK)
+        ErrorMessage("Unable to begin .g6 write iteration from given file pointer.\n");
 
-	return exitCode;
+    return exitCode;
 }
 
 int _beginG6WriteIteration(G6WriteIterator *pG6WriteIterator)
 {
-	int exitCode = OK;
+    int exitCode = OK;
 
-	char *g6Header = ">>graph6<<";
-	if (sf_fputs(g6Header, pG6WriteIterator->g6Output) < 0)
-	{
-		ErrorMessage("Unable to fputs header to g6Output.\n");
-		return NOTOK;
-	}
+    char *g6Header = ">>graph6<<";
+    if (sf_fputs(g6Header, pG6WriteIterator->g6Output) < 0)
+    {
+        ErrorMessage("Unable to fputs header to g6Output.\n");
+        return NOTOK;
+    }
 
-	pG6WriteIterator->graphOrder = pG6WriteIterator->currGraph->N;
+    pG6WriteIterator->graphOrder = pG6WriteIterator->currGraph->N;
 
-	pG6WriteIterator->columnOffsets = (int *)calloc(pG6WriteIterator->graphOrder + 1, sizeof(int));
+    pG6WriteIterator->columnOffsets = (int *)calloc(pG6WriteIterator->graphOrder + 1, sizeof(int));
 
-	if (pG6WriteIterator->columnOffsets == NULL)
-	{
-		ErrorMessage("Unable to allocate memory for column offsets.\n");
-		return NOTOK;
-	}
+    if (pG6WriteIterator->columnOffsets == NULL)
+    {
+        ErrorMessage("Unable to allocate memory for column offsets.\n");
+        return NOTOK;
+    }
 
-	_precomputeColumnOffsets(pG6WriteIterator->columnOffsets, pG6WriteIterator->graphOrder);
+    _precomputeColumnOffsets(pG6WriteIterator->columnOffsets, pG6WriteIterator->graphOrder);
 
-	pG6WriteIterator->numCharsForGraphOrder = _getNumCharsForGraphOrder(pG6WriteIterator->graphOrder);
-	pG6WriteIterator->numCharsForGraphEncoding = _getNumCharsForGraphEncoding(pG6WriteIterator->graphOrder);
-	// Must add 3 bytes for newline, possible carriage return, and null terminator
-	pG6WriteIterator->currGraphBuffSize = pG6WriteIterator->numCharsForGraphOrder + pG6WriteIterator->numCharsForGraphEncoding + 3;
-	pG6WriteIterator->currGraphBuff = (char *)calloc(pG6WriteIterator->currGraphBuffSize, sizeof(char));
+    pG6WriteIterator->numCharsForGraphOrder = _getNumCharsForGraphOrder(pG6WriteIterator->graphOrder);
+    pG6WriteIterator->numCharsForGraphEncoding = _getNumCharsForGraphEncoding(pG6WriteIterator->graphOrder);
+    // Must add 3 bytes for newline, possible carriage return, and null terminator
+    pG6WriteIterator->currGraphBuffSize = pG6WriteIterator->numCharsForGraphOrder + pG6WriteIterator->numCharsForGraphEncoding + 3;
+    pG6WriteIterator->currGraphBuff = (char *)calloc(pG6WriteIterator->currGraphBuffSize, sizeof(char));
 
-	if (pG6WriteIterator->currGraphBuff == NULL)
-	{
-		ErrorMessage("Unable to allocate memory for currGraphBuff.\n");
-		exitCode = NOTOK;
-	}
+    if (pG6WriteIterator->currGraphBuff == NULL)
+    {
+        ErrorMessage("Unable to allocate memory for currGraphBuff.\n");
+        exitCode = NOTOK;
+    }
 
-	return exitCode;
+    return exitCode;
 }
 
 void _precomputeColumnOffsets(int *columnOffsets, int graphOrder)
 {
-	if (columnOffsets == NULL)
-	{
-		ErrorMessage("Must allocate columnOffsets memory before precomputation.\n");
-		return;
-	}
+    if (columnOffsets == NULL)
+    {
+        ErrorMessage("Must allocate columnOffsets memory before precomputation.\n");
+        return;
+    }
 
-	columnOffsets[0] = 0;
-	columnOffsets[1] = 0;
-	for (int i = 2; i <= graphOrder; i++)
-		columnOffsets[i] = columnOffsets[i - 1] + (i - 1);
+    columnOffsets[0] = 0;
+    columnOffsets[1] = 0;
+    for (int i = 2; i <= graphOrder; i++)
+        columnOffsets[i] = columnOffsets[i - 1] + (i - 1);
 }
 
 int writeGraphUsingG6WriteIterator(G6WriteIterator *pG6WriteIterator)
 {
-	int exitCode = OK;
+    int exitCode = OK;
 
-	if (!_isG6WriteIteratorAllocated(pG6WriteIterator))
-	{
-		ErrorMessage("Unable to write graph, as G6WriteIterator is not allocated.\n");
-		return NOTOK;
-	}
+    if (!_isG6WriteIteratorAllocated(pG6WriteIterator))
+    {
+        ErrorMessage("Unable to write graph, as G6WriteIterator is not allocated.\n");
+        return NOTOK;
+    }
 
-	exitCode = _encodeAdjMatAsG6(pG6WriteIterator);
+    exitCode = _encodeAdjMatAsG6(pG6WriteIterator);
 
-	if (exitCode != OK)
-	{
-		ErrorMessage("Error converting adjacency matrix to g6 format.\n");
-		return exitCode;
-	}
+    if (exitCode != OK)
+    {
+        ErrorMessage("Error converting adjacency matrix to g6 format.\n");
+        return exitCode;
+    }
 
-	exitCode = _printEncodedGraph(pG6WriteIterator);
-	if (exitCode != OK)
-		ErrorMessage("Unable to output g6 encoded graph to string-or-file container.\n");
+    exitCode = _printEncodedGraph(pG6WriteIterator);
+    if (exitCode != OK)
+        ErrorMessage("Unable to output g6 encoded graph to string-or-file container.\n");
 
-	return exitCode;
+    return exitCode;
 }
 
 int _encodeAdjMatAsG6(G6WriteIterator *pG6WriteIterator)
 {
-	int exitCode = OK;
+    int exitCode = OK;
 
-	if (!_isG6WriteIteratorAllocated(pG6WriteIterator))
-	{
-		ErrorMessage("Unable to encode graph, as G6WriteIterator is not allocated.\n");
-		return NOTOK;
-	}
+    if (!_isG6WriteIteratorAllocated(pG6WriteIterator))
+    {
+        ErrorMessage("Unable to encode graph, as G6WriteIterator is not allocated.\n");
+        return NOTOK;
+    }
 
-	char *g6Encoding = pG6WriteIterator->currGraphBuff;
+    char *g6Encoding = pG6WriteIterator->currGraphBuff;
 
-	if (g6Encoding == NULL)
-	{
-		ErrorMessage("[ERROR] Graph buffer is not allocated.\n");
-		return NOTOK;
-	}
+    if (g6Encoding == NULL)
+    {
+        ErrorMessage("[ERROR] Graph buffer is not allocated.\n");
+        return NOTOK;
+    }
 
-	int *columnOffsets = pG6WriteIterator->columnOffsets;
-	if (columnOffsets == NULL)
-	{
-		ErrorMessage("Column offsets array is not allocated.\n");
-		return NOTOK;
-	}
+    int *columnOffsets = pG6WriteIterator->columnOffsets;
+    if (columnOffsets == NULL)
+    {
+        ErrorMessage("Column offsets array is not allocated.\n");
+        return NOTOK;
+    }
 
-	graphP pGraph = pG6WriteIterator->currGraph;
+    graphP pGraph = pG6WriteIterator->currGraph;
 
-	if (pGraph == NULL || pGraph->N == 0)
-	{
-		ErrorMessage("Graph is not allocated.\n");
-		return NOTOK;
-	}
+    if (pGraph == NULL || pGraph->N == 0)
+    {
+        ErrorMessage("Graph is not allocated.\n");
+        return NOTOK;
+    }
 
-	// memset ensures all bits are zero, which means we only need to set the bits
-	// that correspond to an edge; this also takes care of padding zeroes for us
-	memset(pG6WriteIterator->currGraphBuff, 0, (pG6WriteIterator->currGraphBuffSize) * sizeof(char));
+    // memset ensures all bits are zero, which means we only need to set the bits
+    // that correspond to an edge; this also takes care of padding zeroes for us
+    memset(pG6WriteIterator->currGraphBuff, 0, (pG6WriteIterator->currGraphBuffSize) * sizeof(char));
 
-	int graphOrder = pG6WriteIterator->graphOrder;
-	int numCharsForGraphOrder = pG6WriteIterator->numCharsForGraphOrder;
-	int numCharsForGraphEncoding = pG6WriteIterator->numCharsForGraphEncoding;
-	int totalNumCharsForOrderAndGraph = numCharsForGraphOrder + numCharsForGraphEncoding;
+    int graphOrder = pG6WriteIterator->graphOrder;
+    int numCharsForGraphOrder = pG6WriteIterator->numCharsForGraphOrder;
+    int numCharsForGraphEncoding = pG6WriteIterator->numCharsForGraphEncoding;
+    int totalNumCharsForOrderAndGraph = numCharsForGraphOrder + numCharsForGraphEncoding;
 
-	if (graphOrder > 62)
-	{
-		g6Encoding[0] = 126;
-		// bytes 1 through 3 will be populated with the 18-bit representation of the graph order
-		int intermediate = -1;
-		for (int i = 0; i < 3; i++)
-		{
-			intermediate = graphOrder >> (6 * i);
-			g6Encoding[3 - i] = intermediate & 63;
-			g6Encoding[3 - i] += 63;
-		}
-	}
-	else if (graphOrder > 1 && graphOrder < 63)
-	{
-		g6Encoding[0] = graphOrder + 63;
-	}
+    if (graphOrder > 62)
+    {
+        g6Encoding[0] = 126;
+        // bytes 1 through 3 will be populated with the 18-bit representation of the graph order
+        int intermediate = -1;
+        for (int i = 0; i < 3; i++)
+        {
+            intermediate = graphOrder >> (6 * i);
+            g6Encoding[3 - i] = intermediate & 63;
+            g6Encoding[3 - i] += 63;
+        }
+    }
+    else if (graphOrder > 1 && graphOrder < 63)
+    {
+        g6Encoding[0] = graphOrder + 63;
+    }
 
-	int u = NIL, v = NIL, e = NIL;
-	exitCode = _getFirstEdge(pGraph, &e, &u, &v);
+    int u = NIL, v = NIL, e = NIL;
+    exitCode = _getFirstEdge(pGraph, &e, &u, &v);
 
-	if (exitCode != OK)
-	{
-		ErrorMessage("Unable to fetch first edge in graph.\n");
-		return exitCode;
-	}
+    if (exitCode != OK)
+    {
+        ErrorMessage("Unable to fetch first edge in graph.\n");
+        return exitCode;
+    }
 
-	int charOffset = 0;
-	int bitPositionPower = 0;
-	while (u != NIL && v != NIL)
-	{
-		// The internal graph representation is usually 1-based, but may be 0-based, so
-		// one must subtract the index of the first vertex (i.e. result of gp_GetFirstVertex)
-		// because the .g6 format is 0-based
-		u -= gp_GetFirstVertex(theGraph);
-		v -= gp_GetFirstVertex(theGraph);
+    int charOffset = 0;
+    int bitPositionPower = 0;
+    while (u != NIL && v != NIL)
+    {
+        // The internal graph representation is usually 1-based, but may be 0-based, so
+        // one must subtract the index of the first vertex (i.e. result of gp_GetFirstVertex)
+        // because the .g6 format is 0-based
+        u -= gp_GetFirstVertex(theGraph);
+        v -= gp_GetFirstVertex(theGraph);
 
-		// The columnOffset machinery assumes that we are traversing the edges represented in
-		// the upper-triangular matrix. Since we are dealing with simple graphs, if (v, u)
-		// exists, then (u, v) exists, and so the edge is indicated by a 1 in row = min(u, v)
-		// and col = max(u, v) in the upper-triangular adjacency matrix.
-		if (v < u)
-		{
-			int tempVert = v;
-			v = u;
-			u = tempVert;
-		}
+        // The columnOffset machinery assumes that we are traversing the edges represented in
+        // the upper-triangular matrix. Since we are dealing with simple graphs, if (v, u)
+        // exists, then (u, v) exists, and so the edge is indicated by a 1 in row = min(u, v)
+        // and col = max(u, v) in the upper-triangular adjacency matrix.
+        if (v < u)
+        {
+            int tempVert = v;
+            v = u;
+            u = tempVert;
+        }
 
-		// (columnOffsets[v] + u) describes the bit index of the current edge
-		// given the column and row in the adjacency matrix representation;
-		// the byte is floor((columnOffsets[v] + u) / 6) and the we determine which
-		// bit to set in that byte by left-shifting 1 by (5 - ((columnOffsets[v] + u) % 6))
-		// (transforming the ((columnOffsets[v] + u) % 6)th bit from the left to the
-		// (5 - ((columnOffsets[v] + u) % 6))th bit from the right)
-		charOffset = numCharsForGraphOrder + ((columnOffsets[v] + u) / 6);
-		bitPositionPower = 5 - ((columnOffsets[v] + u) % 6);
+        // (columnOffsets[v] + u) describes the bit index of the current edge
+        // given the column and row in the adjacency matrix representation;
+        // the byte is floor((columnOffsets[v] + u) / 6) and the we determine which
+        // bit to set in that byte by left-shifting 1 by (5 - ((columnOffsets[v] + u) % 6))
+        // (transforming the ((columnOffsets[v] + u) % 6)th bit from the left to the
+        // (5 - ((columnOffsets[v] + u) % 6))th bit from the right)
+        charOffset = numCharsForGraphOrder + ((columnOffsets[v] + u) / 6);
+        bitPositionPower = 5 - ((columnOffsets[v] + u) % 6);
 
-		g6Encoding[charOffset] |= (1u << bitPositionPower);
+        g6Encoding[charOffset] |= (1u << bitPositionPower);
 
-		exitCode = _getNextEdge(pGraph, &e, &u, &v);
+        exitCode = _getNextEdge(pGraph, &e, &u, &v);
 
-		if (exitCode != OK)
-		{
-			ErrorMessage("Unable to fetch next edge in graph.\n");
-			free(columnOffsets);
-			free(g6Encoding);
-			return exitCode;
-		}
-	}
+        if (exitCode != OK)
+        {
+            ErrorMessage("Unable to fetch next edge in graph.\n");
+            free(columnOffsets);
+            free(g6Encoding);
+            return exitCode;
+        }
+    }
 
-	// Bytes corresponding to graph order have already been modified to
-	// correspond to printable ascii character (i.e. by adding 63); must
-	// now do the same for bytes corresponding to edge lists
-	for (int i = numCharsForGraphOrder; i < totalNumCharsForOrderAndGraph; i++)
-		g6Encoding[i] += 63;
+    // Bytes corresponding to graph order have already been modified to
+    // correspond to printable ascii character (i.e. by adding 63); must
+    // now do the same for bytes corresponding to edge lists
+    for (int i = numCharsForGraphOrder; i < totalNumCharsForOrderAndGraph; i++)
+        g6Encoding[i] += 63;
 
-	return exitCode;
+    return exitCode;
 }
 
 int _getFirstEdge(graphP theGraph, int *e, int *u, int *v)
 {
-	if (theGraph == NULL)
-		return NOTOK;
+    if (theGraph == NULL)
+        return NOTOK;
 
-	if ((*e) >= gp_EdgeInUseIndexBound(theGraph))
-	{
-		ErrorMessage("First edge is outside bounds.");
-		return NOTOK;
-	}
+    if ((*e) >= gp_EdgeInUseIndexBound(theGraph))
+    {
+        ErrorMessage("First edge is outside bounds.");
+        return NOTOK;
+    }
 
-	(*e) = gp_GetFirstEdge(theGraph);
+    (*e) = gp_GetFirstEdge(theGraph);
 
-	return _getNextInUseEdge(theGraph, e, u, v);
+    return _getNextInUseEdge(theGraph, e, u, v);
 }
 
 int _getNextEdge(graphP theGraph, int *e, int *u, int *v)
 {
-	if (theGraph == NULL)
-		return NOTOK;
+    if (theGraph == NULL)
+        return NOTOK;
 
-	(*e) += 2;
+    (*e) += 2;
 
-	return _getNextInUseEdge(theGraph, e, u, v);
+    return _getNextInUseEdge(theGraph, e, u, v);
 }
 
 int _getNextInUseEdge(graphP theGraph, int *e, int *u, int *v)
 {
-	int exitCode = OK;
-	int EsizeOccupied = gp_EdgeInUseIndexBound(theGraph);
+    int exitCode = OK;
+    int EsizeOccupied = gp_EdgeInUseIndexBound(theGraph);
 
-	(*u) = NIL;
-	(*v) = NIL;
+    (*u) = NIL;
+    (*v) = NIL;
 
-	if ((*e) < EsizeOccupied)
-	{
-		while (!gp_EdgeInUse(theGraph, (*e)))
-		{
-			(*e) += 2;
-			if ((*e) >= EsizeOccupied)
-				break;
-		}
+    if ((*e) < EsizeOccupied)
+    {
+        while (!gp_EdgeInUse(theGraph, (*e)))
+        {
+            (*e) += 2;
+            if ((*e) >= EsizeOccupied)
+                break;
+        }
 
-		if ((*e) < EsizeOccupied && gp_EdgeInUse(theGraph, (*e)))
-		{
-			(*u) = gp_GetNeighbor(theGraph, (*e));
-			(*v) = gp_GetNeighbor(theGraph, gp_GetTwinArc(theGraph, (*e)));
-		}
-	}
+        if ((*e) < EsizeOccupied && gp_EdgeInUse(theGraph, (*e)))
+        {
+            (*u) = gp_GetNeighbor(theGraph, (*e));
+            (*v) = gp_GetNeighbor(theGraph, gp_GetTwinArc(theGraph, (*e)));
+        }
+    }
 
-	return exitCode;
+    return exitCode;
 }
 
 int _printEncodedGraph(G6WriteIterator *pG6WriteIterator)
 {
-	int exitCode = OK;
+    int exitCode = OK;
 
-	if (pG6WriteIterator->g6Output == NULL)
-	{
-		ErrorMessage("Unable to print to NULL string-or-file container.\n");
-		return NOTOK;
-	}
+    if (pG6WriteIterator->g6Output == NULL)
+    {
+        ErrorMessage("Unable to print to NULL string-or-file container.\n");
+        return NOTOK;
+    }
 
-	if (pG6WriteIterator->currGraphBuff == NULL || strlen(pG6WriteIterator->currGraphBuff) == 0)
-	{
-		ErrorMessage("Unable to print; g6 encoding is empty.\n");
-		return NOTOK;
-	}
+    if (pG6WriteIterator->currGraphBuff == NULL || strlen(pG6WriteIterator->currGraphBuff) == 0)
+    {
+        ErrorMessage("Unable to print; g6 encoding is empty.\n");
+        return NOTOK;
+    }
 
-	if (sf_fputs(pG6WriteIterator->currGraphBuff, pG6WriteIterator->g6Output) < 0)
-	{
-		ErrorMessage("Failed to output all characters of g6 encoding.\n");
-		exitCode = NOTOK;
-	}
+    if (sf_fputs(pG6WriteIterator->currGraphBuff, pG6WriteIterator->g6Output) < 0)
+    {
+        ErrorMessage("Failed to output all characters of g6 encoding.\n");
+        exitCode = NOTOK;
+    }
 
-	if (sf_fputs("\n", pG6WriteIterator->g6Output) < 0)
-	{
-		ErrorMessage("Failed to put line terminator after g6 encoding.\n");
-		exitCode = NOTOK;
-	}
+    if (sf_fputs("\n", pG6WriteIterator->g6Output) < 0)
+    {
+        ErrorMessage("Failed to put line terminator after g6 encoding.\n");
+        exitCode = NOTOK;
+    }
 
-	return exitCode;
+    return exitCode;
 }
 
 int endG6WriteIteration(G6WriteIterator *pG6WriteIterator)
 {
-	int exitCode = OK;
+    int exitCode = OK;
 
-	if (pG6WriteIterator != NULL)
-	{
-		if (pG6WriteIterator->g6Output != NULL)
-		{
-			exitCode = sf_closeFile(pG6WriteIterator->g6Output);
+    if (pG6WriteIterator != NULL)
+    {
+        if (pG6WriteIterator->g6Output != NULL)
+        {
+            exitCode = sf_closeFile(pG6WriteIterator->g6Output);
 
-			if (exitCode != OK)
-				ErrorMessage("Unable to close g6Output file pointer.\n");
+            if (exitCode != OK)
+                ErrorMessage("Unable to close g6Output file pointer.\n");
 
-			sf_Free(&(pG6WriteIterator->g6Output));
-		}
+            sf_Free(&(pG6WriteIterator->g6Output));
+        }
 
-		if (pG6WriteIterator->currGraphBuff != NULL)
-		{
-			free(pG6WriteIterator->currGraphBuff);
-			pG6WriteIterator->currGraphBuff = NULL;
-		}
+        if (pG6WriteIterator->currGraphBuff != NULL)
+        {
+            free(pG6WriteIterator->currGraphBuff);
+            pG6WriteIterator->currGraphBuff = NULL;
+        }
 
-		if (pG6WriteIterator->columnOffsets != NULL)
-		{
-			free((pG6WriteIterator->columnOffsets));
-			pG6WriteIterator->columnOffsets = NULL;
-		}
-	}
+        if (pG6WriteIterator->columnOffsets != NULL)
+        {
+            free((pG6WriteIterator->columnOffsets));
+            pG6WriteIterator->columnOffsets = NULL;
+        }
+    }
 
-	return exitCode;
+    return exitCode;
 }
 
 int freeG6WriteIterator(G6WriteIterator **ppG6WriteIterator)
 {
-	int exitCode = OK;
+    int exitCode = OK;
 
-	if (ppG6WriteIterator != NULL && (*ppG6WriteIterator) != NULL)
-	{
-		if ((*ppG6WriteIterator)->g6Output != NULL)
-			sf_Free(&((*ppG6WriteIterator)->g6Output));
+    if (ppG6WriteIterator != NULL && (*ppG6WriteIterator) != NULL)
+    {
+        if ((*ppG6WriteIterator)->g6Output != NULL)
+            sf_Free(&((*ppG6WriteIterator)->g6Output));
 
-		(*ppG6WriteIterator)->numGraphsWritten = 0;
-		(*ppG6WriteIterator)->graphOrder = 0;
+        (*ppG6WriteIterator)->numGraphsWritten = 0;
+        (*ppG6WriteIterator)->graphOrder = 0;
 
-		if ((*ppG6WriteIterator)->currGraphBuff != NULL)
-		{
-			free((*ppG6WriteIterator)->currGraphBuff);
-			(*ppG6WriteIterator)->currGraphBuff = NULL;
-		}
+        if ((*ppG6WriteIterator)->currGraphBuff != NULL)
+        {
+            free((*ppG6WriteIterator)->currGraphBuff);
+            (*ppG6WriteIterator)->currGraphBuff = NULL;
+        }
 
-		if ((*ppG6WriteIterator)->columnOffsets != NULL)
-		{
-			free(((*ppG6WriteIterator)->columnOffsets));
-			(*ppG6WriteIterator)->columnOffsets = NULL;
-		}
+        if ((*ppG6WriteIterator)->columnOffsets != NULL)
+        {
+            free(((*ppG6WriteIterator)->columnOffsets));
+            (*ppG6WriteIterator)->columnOffsets = NULL;
+        }
 
-		// N.B. The G6WriteIterator doesn't "own" the graph, so we don't free it.
-		(*ppG6WriteIterator)->currGraph = NULL;
+        // N.B. The G6WriteIterator doesn't "own" the graph, so we don't free it.
+        (*ppG6WriteIterator)->currGraph = NULL;
 
-		free((*ppG6WriteIterator));
-		(*ppG6WriteIterator) = NULL;
-	}
+        free((*ppG6WriteIterator));
+        (*ppG6WriteIterator) = NULL;
+    }
 
-	return exitCode;
+    return exitCode;
 }
 
 int _WriteGraphToG6FilePath(graphP pGraph, char *g6OutputFilename)
 {
-	int exitCode = OK;
+    int exitCode = OK;
 
-	G6WriteIterator *pG6WriteIterator = NULL;
+    G6WriteIterator *pG6WriteIterator = NULL;
 
-	exitCode = allocateG6WriteIterator(&pG6WriteIterator, pGraph);
+    exitCode = allocateG6WriteIterator(&pG6WriteIterator, pGraph);
 
-	if (exitCode != OK)
-	{
-		ErrorMessage("Unable to allocate G6WriteIterator.\n");
-		freeG6WriteIterator(&pG6WriteIterator);
-		return exitCode;
-	}
+    if (exitCode != OK)
+    {
+        ErrorMessage("Unable to allocate G6WriteIterator.\n");
+        freeG6WriteIterator(&pG6WriteIterator);
+        return exitCode;
+    }
 
-	exitCode = beginG6WriteIterationToG6FilePath(pG6WriteIterator, g6OutputFilename);
+    exitCode = beginG6WriteIterationToG6FilePath(pG6WriteIterator, g6OutputFilename);
 
-	if (exitCode != OK)
-	{
-		ErrorMessage("Unable to begin G6 write iteration.\n");
-		freeG6WriteIterator(&pG6WriteIterator);
-		return exitCode;
-	}
+    if (exitCode != OK)
+    {
+        ErrorMessage("Unable to begin G6 write iteration.\n");
+        freeG6WriteIterator(&pG6WriteIterator);
+        return exitCode;
+    }
 
-	exitCode = writeGraphUsingG6WriteIterator(pG6WriteIterator);
+    exitCode = writeGraphUsingG6WriteIterator(pG6WriteIterator);
 
-	if (exitCode != OK)
-	{
-		ErrorMessage("Unable to write graph using G6WriteIterator.\n");
-	}
-	else
-	{
-		int endG6WriteIterationCode = endG6WriteIteration(pG6WriteIterator);
+    if (exitCode != OK)
+    {
+        ErrorMessage("Unable to write graph using G6WriteIterator.\n");
+    }
+    else
+    {
+        int endG6WriteIterationCode = endG6WriteIteration(pG6WriteIterator);
 
-		if (endG6WriteIterationCode != OK)
-		{
-			ErrorMessage("Unable to end G6 write iteration.\n");
-			exitCode = endG6WriteIterationCode;
-		}
-	}
+        if (endG6WriteIterationCode != OK)
+        {
+            ErrorMessage("Unable to end G6 write iteration.\n");
+            exitCode = endG6WriteIterationCode;
+        }
+    }
 
-	int freeG6WriteIteratorCode = freeG6WriteIterator(&pG6WriteIterator);
+    int freeG6WriteIteratorCode = freeG6WriteIterator(&pG6WriteIterator);
 
-	if (freeG6WriteIteratorCode != OK)
-	{
-		ErrorMessage("Unable to free G6Writer.\n");
-		exitCode = freeG6WriteIteratorCode;
-	}
+    if (freeG6WriteIteratorCode != OK)
+    {
+        ErrorMessage("Unable to free G6Writer.\n");
+        exitCode = freeG6WriteIteratorCode;
+    }
 
-	return exitCode;
+    return exitCode;
 }
 
 int _WriteGraphToG6FilePointer(graphP pGraph, FILE *g6Outfile)
 {
-	int exitCode = OK;
+    int exitCode = OK;
 
-	G6WriteIterator *pG6WriteIterator = NULL;
+    G6WriteIterator *pG6WriteIterator = NULL;
 
-	exitCode = allocateG6WriteIterator(&pG6WriteIterator, pGraph);
+    exitCode = allocateG6WriteIterator(&pG6WriteIterator, pGraph);
 
-	if (exitCode != OK)
-	{
-		ErrorMessage("Unable to allocate G6WriteIterator.\n");
-		freeG6WriteIterator(&pG6WriteIterator);
-		return exitCode;
-	}
+    if (exitCode != OK)
+    {
+        ErrorMessage("Unable to allocate G6WriteIterator.\n");
+        freeG6WriteIterator(&pG6WriteIterator);
+        return exitCode;
+    }
 
-	exitCode = beginG6WriteIterationToG6FilePointer(pG6WriteIterator, g6Outfile);
+    exitCode = beginG6WriteIterationToG6FilePointer(pG6WriteIterator, g6Outfile);
 
-	if (exitCode != OK)
-	{
-		ErrorMessage("Unable to begin G6 write iteration.\n");
-		freeG6WriteIterator(&pG6WriteIterator);
-		return exitCode;
-	}
+    if (exitCode != OK)
+    {
+        ErrorMessage("Unable to begin G6 write iteration.\n");
+        freeG6WriteIterator(&pG6WriteIterator);
+        return exitCode;
+    }
 
-	exitCode = writeGraphUsingG6WriteIterator(pG6WriteIterator);
+    exitCode = writeGraphUsingG6WriteIterator(pG6WriteIterator);
 
-	if (exitCode != OK)
-	{
-		ErrorMessage("Unable to write graph using G6WriteIterator.\n");
-	}
-	else
-	{
-		int endG6WriteIterationCode = endG6WriteIteration(pG6WriteIterator);
+    if (exitCode != OK)
+    {
+        ErrorMessage("Unable to write graph using G6WriteIterator.\n");
+    }
+    else
+    {
+        int endG6WriteIterationCode = endG6WriteIteration(pG6WriteIterator);
 
-		if (endG6WriteIterationCode != OK)
-		{
-			ErrorMessage("Unable to end G6 write iteration.\n");
-			exitCode = endG6WriteIterationCode;
-		}
-	}
+        if (endG6WriteIterationCode != OK)
+        {
+            ErrorMessage("Unable to end G6 write iteration.\n");
+            exitCode = endG6WriteIterationCode;
+        }
+    }
 
-	int freeG6WriteIteratorCode = freeG6WriteIterator(&pG6WriteIterator);
+    int freeG6WriteIteratorCode = freeG6WriteIterator(&pG6WriteIterator);
 
-	if (freeG6WriteIteratorCode != OK)
-	{
-		ErrorMessage("Unable to free G6Writer.\n");
-		exitCode = freeG6WriteIteratorCode;
-	}
+    if (freeG6WriteIteratorCode != OK)
+    {
+        ErrorMessage("Unable to free G6Writer.\n");
+        exitCode = freeG6WriteIteratorCode;
+    }
 
-	return exitCode;
+    return exitCode;
 }
 
 int _WriteGraphToG6String(graphP pGraph, char **g6OutputStr)
 {
-	int exitCode = OK;
+    int exitCode = OK;
 
-	G6WriteIterator *pG6WriteIterator = NULL;
+    G6WriteIterator *pG6WriteIterator = NULL;
 
-	exitCode = allocateG6WriteIterator(&pG6WriteIterator, pGraph);
+    exitCode = allocateG6WriteIterator(&pG6WriteIterator, pGraph);
 
-	if (exitCode != OK)
-	{
-		ErrorMessage("Unable to allocate G6WriteIterator.\n");
-		freeG6WriteIterator(&pG6WriteIterator);
-		return exitCode;
-	}
+    if (exitCode != OK)
+    {
+        ErrorMessage("Unable to allocate G6WriteIterator.\n");
+        freeG6WriteIterator(&pG6WriteIterator);
+        return exitCode;
+    }
 
-	exitCode = beginG6WriteIterationToG6String(pG6WriteIterator, g6OutputStr);
+    exitCode = beginG6WriteIterationToG6String(pG6WriteIterator, g6OutputStr);
 
-	if (exitCode != OK)
-	{
-		ErrorMessage("Unable to begin G6 write iteration.\n");
-		freeG6WriteIterator(&pG6WriteIterator);
-		return exitCode;
-	}
+    if (exitCode != OK)
+    {
+        ErrorMessage("Unable to begin G6 write iteration.\n");
+        freeG6WriteIterator(&pG6WriteIterator);
+        return exitCode;
+    }
 
-	exitCode = writeGraphUsingG6WriteIterator(pG6WriteIterator);
+    exitCode = writeGraphUsingG6WriteIterator(pG6WriteIterator);
 
-	if (exitCode != OK)
-		ErrorMessage("Unable to write graph using G6WriteIterator.\n");
-	else
-	{
-		(*g6OutputStr) = sf_takeTheStr(pG6WriteIterator->g6Output);
+    if (exitCode != OK)
+        ErrorMessage("Unable to write graph using G6WriteIterator.\n");
+    else
+    {
+        (*g6OutputStr) = sf_takeTheStr(pG6WriteIterator->g6Output);
 
-		int endG6WriteIterationCode = endG6WriteIteration(pG6WriteIterator);
+        int endG6WriteIterationCode = endG6WriteIteration(pG6WriteIterator);
 
-		if (endG6WriteIterationCode != OK)
-		{
-			ErrorMessage("Unable to end G6 write iteration.\n");
-			exitCode = endG6WriteIterationCode;
-		}
-	}
+        if (endG6WriteIterationCode != OK)
+        {
+            ErrorMessage("Unable to end G6 write iteration.\n");
+            exitCode = endG6WriteIterationCode;
+        }
+    }
 
-	int freeG6WriteIteratorCode = freeG6WriteIterator(&pG6WriteIterator);
+    int freeG6WriteIteratorCode = freeG6WriteIterator(&pG6WriteIterator);
 
-	if (freeG6WriteIteratorCode != OK)
-	{
-		ErrorMessage("Unable to free G6Writer.\n");
-		exitCode = freeG6WriteIteratorCode;
-	}
+    if (freeG6WriteIteratorCode != OK)
+    {
+        ErrorMessage("Unable to free G6Writer.\n");
+        exitCode = freeG6WriteIteratorCode;
+    }
 
-	return exitCode;
+    return exitCode;
 }

--- a/c/graphLib/io/g6-write-iterator.h
+++ b/c/graphLib/io/g6-write-iterator.h
@@ -18,51 +18,51 @@ extern "C"
 #include "../graph.h"
 #include "strOrFile.h"
 
-	typedef struct
-	{
-		strOrFileP g6Output;
-		int numGraphsWritten;
+    typedef struct
+    {
+        strOrFileP g6Output;
+        int numGraphsWritten;
 
-		int graphOrder;
-		int numCharsForGraphOrder;
-		int numCharsForGraphEncoding;
-		int currGraphBuffSize;
-		char *currGraphBuff;
+        int graphOrder;
+        int numCharsForGraphOrder;
+        int numCharsForGraphEncoding;
+        int currGraphBuffSize;
+        char *currGraphBuff;
 
-		int *columnOffsets;
+        int *columnOffsets;
 
-		graphP currGraph;
-	} G6WriteIterator;
+        graphP currGraph;
+    } G6WriteIterator;
 
-	int allocateG6WriteIterator(G6WriteIterator **, graphP);
-	bool _isG6WriteIteratorAllocated(G6WriteIterator *);
+    int allocateG6WriteIterator(G6WriteIterator **, graphP);
+    bool _isG6WriteIteratorAllocated(G6WriteIterator *);
 
-	int getNumGraphsWritten(G6WriteIterator *, int *);
-	int getOrderOfGraphToWrite(G6WriteIterator *, int *);
-	int getPointerToGraphToWrite(G6WriteIterator *, graphP *);
+    int getNumGraphsWritten(G6WriteIterator *, int *);
+    int getOrderOfGraphToWrite(G6WriteIterator *, int *);
+    int getPointerToGraphToWrite(G6WriteIterator *, graphP *);
 
-	int beginG6WriteIterationToG6FilePath(G6WriteIterator *pG6WriteIterator, char *g6FilePath);
-	int beginG6WriteIterationToG6FilePointer(G6WriteIterator *pG6WriteIterator, FILE *g6Outfile);
-	int beginG6WriteIterationToG6String(G6WriteIterator *pG6WriteIterator, char **g6OutputStr);
-	int _beginG6WriteIteration(G6WriteIterator *pG6WriteIterator);
-	void _precomputeColumnOffsets(int *, int);
+    int beginG6WriteIterationToG6FilePath(G6WriteIterator *pG6WriteIterator, char *g6FilePath);
+    int beginG6WriteIterationToG6FilePointer(G6WriteIterator *pG6WriteIterator, FILE *g6Outfile);
+    int beginG6WriteIterationToG6String(G6WriteIterator *pG6WriteIterator, char **g6OutputStr);
+    int _beginG6WriteIteration(G6WriteIterator *pG6WriteIterator);
+    void _precomputeColumnOffsets(int *, int);
 
-	int writeGraphUsingG6WriteIterator(G6WriteIterator *);
+    int writeGraphUsingG6WriteIterator(G6WriteIterator *);
 
-	int _encodeAdjMatAsG6(G6WriteIterator *);
-	int _getFirstEdge(graphP, int *, int *, int *);
-	int _getNextEdge(graphP, int *, int *, int *);
-	int _getNextInUseEdge(graphP theGraph, int *e, int *u, int *v);
+    int _encodeAdjMatAsG6(G6WriteIterator *);
+    int _getFirstEdge(graphP, int *, int *, int *);
+    int _getNextEdge(graphP, int *, int *, int *);
+    int _getNextInUseEdge(graphP theGraph, int *e, int *u, int *v);
 
-	int _printEncodedGraph(G6WriteIterator *);
+    int _printEncodedGraph(G6WriteIterator *);
 
-	int endG6WriteIteration(G6WriteIterator *);
+    int endG6WriteIteration(G6WriteIterator *);
 
-	int freeG6WriteIterator(G6WriteIterator **);
+    int freeG6WriteIterator(G6WriteIterator **);
 
-	int _WriteGraphToG6FilePath(graphP pGraph, char *g6OutputFilename);
-	int _WriteGraphToG6FilePointer(graphP pGraph, FILE *g6Outfile);
-	int _WriteGraphToG6String(graphP pGraph, char **g6OutputStr);
+    int _WriteGraphToG6FilePath(graphP pGraph, char *g6OutputFilename);
+    int _WriteGraphToG6FilePointer(graphP pGraph, FILE *g6Outfile);
+    int _WriteGraphToG6String(graphP pGraph, char **g6OutputStr);
 
 #ifdef __cplusplus
 }

--- a/c/graphLib/io/strOrFile.c
+++ b/c/graphLib/io/strOrFile.c
@@ -19,23 +19,23 @@ See the LICENSE.TXT file for licensing information.
 // TODO: (#56) add char fileMode to differentiate between read and write modes
 strOrFileP sf_New(FILE *pFile, char *theStr)
 {
-	strOrFileP theStrOrFile;
-	if (((pFile == NULL) && (theStr == NULL)) || ((pFile != NULL) && (theStr != NULL)))
-		return NULL;
+    strOrFileP theStrOrFile;
+    if (((pFile == NULL) && (theStr == NULL)) || ((pFile != NULL) && (theStr != NULL)))
+        return NULL;
 
-	theStrOrFile = (strOrFileP)calloc(sizeof(strOrFile), 1);
-	if (theStrOrFile != NULL)
-	{
-		if (pFile != NULL)
-			theStrOrFile->pFile = pFile;
-		else if ((theStr != NULL))
-		{
-			theStrOrFile->theStr = theStr;
-			theStrOrFile->theStrPos = 0;
-		}
-	}
+    theStrOrFile = (strOrFileP)calloc(sizeof(strOrFile), 1);
+    if (theStrOrFile != NULL)
+    {
+        if (pFile != NULL)
+            theStrOrFile->pFile = pFile;
+        else if ((theStr != NULL))
+        {
+            theStrOrFile->theStr = theStr;
+            theStrOrFile->theStrPos = 0;
+        }
+    }
 
-	return theStrOrFile;
+    return theStrOrFile;
 }
 
 /********************************************************************
@@ -46,22 +46,22 @@ strOrFileP sf_New(FILE *pFile, char *theStr)
  ********************************************************************/
 char sf_getc(strOrFileP theStrOrFile)
 {
-	char theChar = '\0';
+    char theChar = '\0';
 
-	if (theStrOrFile != NULL)
-	{
-		if (theStrOrFile->pFile != NULL)
-			theChar = getc(theStrOrFile->pFile);
-		else if (theStrOrFile->theStr != NULL)
-		{
-			if ((theStrOrFile->theStr + theStrOrFile->theStrPos)[0] == '\0')
-				return EOF;
+    if (theStrOrFile != NULL)
+    {
+        if (theStrOrFile->pFile != NULL)
+            theChar = getc(theStrOrFile->pFile);
+        else if (theStrOrFile->theStr != NULL)
+        {
+            if ((theStrOrFile->theStr + theStrOrFile->theStrPos)[0] == '\0')
+                return EOF;
 
-			theChar = theStrOrFile->theStr[theStrOrFile->theStrPos++];
-		}
-	}
+            theChar = theStrOrFile->theStr[theStrOrFile->theStrPos++];
+        }
+    }
 
-	return theChar;
+    return theChar;
 }
 
 /********************************************************************
@@ -77,24 +77,24 @@ char sf_getc(strOrFileP theStrOrFile)
  ********************************************************************/
 char sf_ungetc(char theChar, strOrFileP theStrOrFile)
 {
-	char charToReturn = EOF;
+    char charToReturn = EOF;
 
-	if (theStrOrFile != NULL)
-	{
-		if (theStrOrFile->pFile != NULL)
-			charToReturn = ungetc(theChar, theStrOrFile->pFile);
-		// Don't want to ungetc to an index before theStrOrFile->theStr start
-		else if (theStrOrFile->theStr != NULL)
-		{
-			if (theStrOrFile->theStrPos <= 0)
-				return EOF;
+    if (theStrOrFile != NULL)
+    {
+        if (theStrOrFile->pFile != NULL)
+            charToReturn = ungetc(theChar, theStrOrFile->pFile);
+        // Don't want to ungetc to an index before theStrOrFile->theStr start
+        else if (theStrOrFile->theStr != NULL)
+        {
+            if (theStrOrFile->theStrPos <= 0)
+                return EOF;
 
-			// Decrement theStrPos, then replace the character in theStr at that position with theChar
-			charToReturn = theStrOrFile->theStr[--(theStrOrFile->theStrPos)] = theChar;
-		}
-	}
+            // Decrement theStrPos, then replace the character in theStr at that position with theChar
+            charToReturn = theStrOrFile->theStr[--(theStrOrFile->theStrPos)] = theChar;
+        }
+    }
 
-	return charToReturn;
+    return charToReturn;
 }
 
 /********************************************************************
@@ -113,35 +113,35 @@ char sf_ungetc(char theChar, strOrFileP theStrOrFile)
  ********************************************************************/
 char *sf_fgets(char *str, int count, strOrFileP theStrOrFile)
 {
-	if (str == NULL || count < 0 || theStrOrFile == NULL)
-		return NULL;
+    if (str == NULL || count < 0 || theStrOrFile == NULL)
+        return NULL;
 
-	if (theStrOrFile->pFile != NULL)
-	{
-		return fgets(str, count, theStrOrFile->pFile);
-	}
-	else if (theStrOrFile->theStr != NULL && theStrOrFile->theStr[theStrOrFile->theStrPos] != '\0')
-	{
-		strncpy(str, theStrOrFile->theStr + theStrOrFile->theStrPos, count);
-		str[count - 1] = '\0';
-		// Handles \n and \r\n
-		char *findDelim = strchr(str, '\n');
-		if (findDelim != NULL)
-			findDelim[1] = '\0';
-		// Handles \r
-		else
-		{
-			findDelim = strchr(str, '\r');
-			if (findDelim != NULL)
-				findDelim[1] = '\0';
-		}
+    if (theStrOrFile->pFile != NULL)
+    {
+        return fgets(str, count, theStrOrFile->pFile);
+    }
+    else if (theStrOrFile->theStr != NULL && theStrOrFile->theStr[theStrOrFile->theStrPos] != '\0')
+    {
+        strncpy(str, theStrOrFile->theStr + theStrOrFile->theStrPos, count);
+        str[count - 1] = '\0';
+        // Handles \n and \r\n
+        char *findDelim = strchr(str, '\n');
+        if (findDelim != NULL)
+            findDelim[1] = '\0';
+        // Handles \r
+        else
+        {
+            findDelim = strchr(str, '\r');
+            if (findDelim != NULL)
+                findDelim[1] = '\0';
+        }
 
-		theStrOrFile->theStrPos += strlen(str);
+        theStrOrFile->theStrPos += strlen(str);
 
-		return str;
-	}
+        return str;
+    }
 
-	return NULL;
+    return NULL;
 }
 
 /********************************************************************
@@ -156,30 +156,30 @@ char *sf_fgets(char *str, int count, strOrFileP theStrOrFile)
  ********************************************************************/
 int sf_fputs(char *strToWrite, strOrFileP theStrOrFile)
 {
-	int outputLen = EOF;
+    int outputLen = EOF;
 
-	if (strToWrite == NULL || theStrOrFile == NULL)
-		return outputLen;
+    if (strToWrite == NULL || theStrOrFile == NULL)
+        return outputLen;
 
-	int lenOfStringToPuts = strlen(strToWrite);
-	if (theStrOrFile->pFile != NULL)
-		outputLen = fputs(strToWrite, theStrOrFile->pFile);
-	else if (theStrOrFile->theStr != NULL)
-	{
-		// Want to be able to contain the original theStr contents, the strToWrite, and a null terminator (added by strcat)
-		char *newStr = realloc(theStrOrFile->theStr, (strlen(theStrOrFile->theStr) + lenOfStringToPuts + 1) * sizeof(char));
-		// If realloc failed, pointer returned will be NULL; error will be handled by eventually freeing iterator, which will
-		// clean up the old memory for theStrOrFile->theStr
-		if (newStr == NULL)
-			return outputLen;
-		else
-			theStrOrFile->theStr = newStr;
-		strcat(theStrOrFile->theStr, strToWrite);
-		theStrOrFile->theStrPos += lenOfStringToPuts;
-		outputLen = lenOfStringToPuts;
-	}
+    int lenOfStringToPuts = strlen(strToWrite);
+    if (theStrOrFile->pFile != NULL)
+        outputLen = fputs(strToWrite, theStrOrFile->pFile);
+    else if (theStrOrFile->theStr != NULL)
+    {
+        // Want to be able to contain the original theStr contents, the strToWrite, and a null terminator (added by strcat)
+        char *newStr = realloc(theStrOrFile->theStr, (strlen(theStrOrFile->theStr) + lenOfStringToPuts + 1) * sizeof(char));
+        // If realloc failed, pointer returned will be NULL; error will be handled by eventually freeing iterator, which will
+        // clean up the old memory for theStrOrFile->theStr
+        if (newStr == NULL)
+            return outputLen;
+        else
+            theStrOrFile->theStr = newStr;
+        strcat(theStrOrFile->theStr, strToWrite);
+        theStrOrFile->theStrPos += lenOfStringToPuts;
+        outputLen = lenOfStringToPuts;
+    }
 
-	return outputLen;
+    return outputLen;
 }
 
 /********************************************************************
@@ -192,9 +192,9 @@ int sf_fputs(char *strToWrite, strOrFileP theStrOrFile)
  ********************************************************************/
 char *sf_takeTheStr(strOrFileP theStrOrFile)
 {
-	char *theStr = theStrOrFile->theStr;
-	theStrOrFile->theStr = NULL;
-	return theStr;
+    char *theStr = theStrOrFile->theStr;
+    theStrOrFile->theStr = NULL;
+    return theStr;
 }
 
 /********************************************************************
@@ -210,22 +210,22 @@ char *sf_takeTheStr(strOrFileP theStrOrFile)
  ********************************************************************/
 int sf_closeFile(strOrFileP theStrOrFile)
 {
-	FILE *pFile = theStrOrFile->pFile;
-	theStrOrFile->pFile = NULL;
-	if (pFile != NULL)
-	{
-		int errorCode = 0;
+    FILE *pFile = theStrOrFile->pFile;
+    theStrOrFile->pFile = NULL;
+    if (pFile != NULL)
+    {
+        int errorCode = 0;
 
-		if (pFile == stdin || pFile == stdout || pFile == stderr)
-			errorCode = fflush(pFile);
-		else
-			errorCode = fclose(pFile);
+        if (pFile == stdin || pFile == stdout || pFile == stderr)
+            errorCode = fflush(pFile);
+        else
+            errorCode = fclose(pFile);
 
-		if (errorCode < 0)
-			return NOTOK;
-	}
+        if (errorCode < 0)
+            return NOTOK;
+    }
 
-	return OK;
+    return OK;
 }
 
 /********************************************************************
@@ -247,24 +247,24 @@ int sf_closeFile(strOrFileP theStrOrFile)
  ********************************************************************/
 void sf_Free(strOrFileP *pStrOrFile)
 {
-	if (pStrOrFile != NULL && (*pStrOrFile) != NULL)
-	{
-		if ((*pStrOrFile)->theStr != NULL)
-			free((*pStrOrFile)->theStr);
-		(*pStrOrFile)->theStr = NULL;
-		(*pStrOrFile)->theStrPos = 0;
+    if (pStrOrFile != NULL && (*pStrOrFile) != NULL)
+    {
+        if ((*pStrOrFile)->theStr != NULL)
+            free((*pStrOrFile)->theStr);
+        (*pStrOrFile)->theStr = NULL;
+        (*pStrOrFile)->theStrPos = 0;
 
-		if ((*pStrOrFile)->pFile != NULL)
-		{
-			// If sf_closeFile() has not previously been called, we must be in an error state
-			sf_closeFile((*pStrOrFile));
-			// TODO: (#56) if the strOrFile container's FILE pointer corresponds to an output file,
-			// i.e. fileMode is 'w', we should try to remove the file since the error state means
-			// the contents are invalid
-		}
-		(*pStrOrFile)->pFile = NULL;
+        if ((*pStrOrFile)->pFile != NULL)
+        {
+            // If sf_closeFile() has not previously been called, we must be in an error state
+            sf_closeFile((*pStrOrFile));
+            // TODO: (#56) if the strOrFile container's FILE pointer corresponds to an output file,
+            // i.e. fileMode is 'w', we should try to remove the file since the error state means
+            // the contents are invalid
+        }
+        (*pStrOrFile)->pFile = NULL;
 
-		free(*pStrOrFile);
-		(*pStrOrFile) = NULL;
-	}
+        free(*pStrOrFile);
+        (*pStrOrFile) = NULL;
+    }
 }

--- a/c/graphLib/io/strOrFile.h
+++ b/c/graphLib/io/strOrFile.h
@@ -8,33 +8,35 @@ See the LICENSE.TXT file for licensing information.
 #define STR_OR_FILE_H
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 #include <stdio.h>
 
-typedef struct {
-    char fileMode;
-    FILE *pFile;
-    char *theStr;
-    int theStrPos;
-} strOrFile;
+    typedef struct
+    {
+        char fileMode;
+        FILE *pFile;
+        char *theStr;
+        int theStrPos;
+    } strOrFile;
 
-typedef strOrFile *strOrFileP;
+    typedef strOrFile *strOrFileP;
 
-strOrFileP sf_New(FILE * pFile, char *theStr);
+    strOrFileP sf_New(FILE *pFile, char *theStr);
 
-char sf_getc(strOrFileP theStrOrFile);
-char sf_ungetc(char theChar, strOrFileP theStrOrFile);
-char * sf_fgets(char *str, int count, strOrFileP theStrOrFile);
+    char sf_getc(strOrFileP theStrOrFile);
+    char sf_ungetc(char theChar, strOrFileP theStrOrFile);
+    char *sf_fgets(char *str, int count, strOrFileP theStrOrFile);
 
-int sf_fputs(char *strToWrite, strOrFileP theStrOrFile);
+    int sf_fputs(char *strToWrite, strOrFileP theStrOrFile);
 
-char * sf_takeTheStr(strOrFileP theStrOrFile);
+    char *sf_takeTheStr(strOrFileP theStrOrFile);
 
-int sf_closeFile(strOrFileP theStrOrFile);
+    int sf_closeFile(strOrFileP theStrOrFile);
 
-void sf_Free(strOrFileP *pStrOrFile);
+    void sf_Free(strOrFileP *pStrOrFile);
 
 #ifdef __cplusplus
 }

--- a/c/graphLib/io/strbuf.h
+++ b/c/graphLib/io/strbuf.h
@@ -8,43 +8,50 @@ See the LICENSE.TXT file for licensing information.
 #define STRBUF_H
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 // includes mem functions like memcpy
 #include <string.h>
 
-typedef struct
-{
-        char *buf;
-        int size, capacity, readPos;
-} strBuf;
+        typedef struct
+        {
+                char *buf;
+                int size, capacity, readPos;
+        } strBuf;
 
-typedef strBuf * strBufP;
+        typedef strBuf *strBufP;
 
-strBufP sb_New(int);
-void sb_Free(strBufP *);
+        strBufP sb_New(int);
+        void sb_Free(strBufP *);
 
-void sb_ClearBuf(strBufP);
-int  sb_Copy(strBufP, strBufP);
-strBufP sb_Duplicate(strBufP);
+        void sb_ClearBuf(strBufP);
+        int sb_Copy(strBufP, strBufP);
+        strBufP sb_Duplicate(strBufP);
 
 #define sb_GetFullString(theStrBuf) (theStrBuf->buf)
 #define sb_GetSize(theStrBuf) (theStrBuf->size)
 #define sb_GetCapacity(theStrBuf) (theStrBuf->capacity)
-#define sb_GetReadString(theStrBuf) ( (theStrBuf!=NULL && theStrBuf->buf!=NULL) ? (theStrBuf->buf + theStrBuf->readPos) : NULL)
+#define sb_GetReadString(theStrBuf) ((theStrBuf != NULL && theStrBuf->buf != NULL) ? (theStrBuf->buf + theStrBuf->readPos) : NULL)
 
 #define sb_GetReadPos(theStrBuf) (theStrBuf->readPos)
-#define sb_SetReadPos(theStrBuf, theReadPos) { theStrBuf->readPos = theReadPos; }
+#define sb_SetReadPos(theStrBuf, theReadPos)     \
+        {                                        \
+                theStrBuf->readPos = theReadPos; \
+        }
 
-void sb_ReadSkipWhitespace(strBufP);
-void sb_ReadSkipInteger(strBufP);
-#define sb_ReadSkipChar(theStrBuf) { theStrBuf->readPos++; }
+        void sb_ReadSkipWhitespace(strBufP);
+        void sb_ReadSkipInteger(strBufP);
+#define sb_ReadSkipChar(theStrBuf)    \
+        {                             \
+                theStrBuf->readPos++; \
+        }
 
-int sb_ConcatString(strBufP, char *);
-int sb_ConcatChar(strBufP, char);
+        int sb_ConcatString(strBufP, char *);
+        int sb_ConcatChar(strBufP, char);
 
-char *sb_TakeString(strBufP);
+        char *sb_TakeString(strBufP);
 
 #ifndef SPEED_MACROS
 // Optimized SPEED_MACROS versions of larger methods are not used in this module

--- a/c/graphLib/lowLevelUtils/apiutils.c
+++ b/c/graphLib/lowLevelUtils/apiutils.c
@@ -13,28 +13,28 @@ int quietMode = FALSE;
 
 int getQuietModeSetting(void)
 {
-	return quietMode;
+    return quietMode;
 }
 
 void setQuietModeSetting(int newQuietModeSetting)
 {
-	quietMode = newQuietModeSetting;
+    quietMode = newQuietModeSetting;
 }
 
 void Message(char *message)
 {
-	if (!getQuietModeSetting())
-	{
-		fprintf(stdout, "%s", message);
-		fflush(stdout);
-	}
+    if (!getQuietModeSetting())
+    {
+        fprintf(stdout, "%s", message);
+        fflush(stdout);
+    }
 }
 
 void ErrorMessage(char *message)
 {
-	if (!getQuietModeSetting())
-	{
-		fprintf(stderr, "%s", message);
-		fflush(stderr);
-	}
+    if (!getQuietModeSetting())
+    {
+        fprintf(stderr, "%s", message);
+        fflush(stderr);
+    }
 }

--- a/c/graphLib/lowLevelUtils/appconst.h
+++ b/c/graphLib/lowLevelUtils/appconst.h
@@ -80,8 +80,8 @@ extern int debugNOTOK(void);
 #define NIL_CHAR 0x00
 
 // This definition is used in combination with 0-based array indexing
-// #define NIL		-1
-// #define NIL_CHAR	0xFF
+// #define NIL      -1
+// #define NIL_CHAR 0xFF
 
 /********************************************************************
  A few simple integer selection macros

--- a/c/graphLib/lowLevelUtils/listcoll.h
+++ b/c/graphLib/lowLevelUtils/listcoll.h
@@ -8,109 +8,110 @@ See the LICENSE.TXT file for licensing information.
 #define _LISTCOLL_H
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 /* This include is needed for memset and memcpy */
 #include <string.h>
 
-typedef struct
-{
-        int prev, next;
-} lcnode;
+        typedef struct
+        {
+                int prev, next;
+        } lcnode;
 
-typedef struct
-{
-        int N;
-        lcnode *List;
-} listCollectionRec;
+        typedef struct
+        {
+                int N;
+                lcnode *List;
+        } listCollectionRec;
 
-typedef listCollectionRec * listCollectionP;
+        typedef listCollectionRec *listCollectionP;
 
-listCollectionP LCNew(int N);
-void LCFree(listCollectionP *pListColl);
+        listCollectionP LCNew(int N);
+        void LCFree(listCollectionP *pListColl);
 
-void LCInsertAfter(listCollectionP listColl, int theAnchor, int theNewNode);
-void LCInsertBefore(listCollectionP listColl, int theAnchor, int theNewNode);
+        void LCInsertAfter(listCollectionP listColl, int theAnchor, int theNewNode);
+        void LCInsertBefore(listCollectionP listColl, int theAnchor, int theNewNode);
 
 #ifndef SPEED_MACROS
 
-void LCReset(listCollectionP listColl);
-void LCCopy(listCollectionP dst, listCollectionP src);
+        void LCReset(listCollectionP listColl);
+        void LCCopy(listCollectionP dst, listCollectionP src);
 
-int  LCGetNext(listCollectionP listColl, int theList, int theNode);
-int  LCGetPrev(listCollectionP listColl, int theList, int theNode);
+        int LCGetNext(listCollectionP listColl, int theList, int theNode);
+        int LCGetPrev(listCollectionP listColl, int theList, int theNode);
 
-int  LCPrepend(listCollectionP listColl, int theList, int theNode);
-int  LCAppend(listCollectionP listColl, int theList, int theNode);
-int  LCDelete(listCollectionP listColl, int theList, int theNode);
+        int LCPrepend(listCollectionP listColl, int theList, int theNode);
+        int LCAppend(listCollectionP listColl, int theList, int theNode);
+        int LCDelete(listCollectionP listColl, int theList, int theNode);
 
 #else
 
 /* void LCReset(listCollectionP listColl); */
 
-#define LCReset(listColl) memset(listColl->List, NIL_CHAR, listColl->N*sizeof(lcnode))
+#define LCReset(listColl) memset(listColl->List, NIL_CHAR, listColl->N * sizeof(lcnode))
 
 /* void LCCopy(listCollectionP dst, listCollectionP src) */
 
-#define LCCopy(dst, src) memcpy(dst->List, src->List, src->N*sizeof(lcnode))
+#define LCCopy(dst, src) memcpy(dst->List, src->List, src->N * sizeof(lcnode))
 
 /* int  LCGetNext(listCollectionP listColl, int theList, int theNode);
-	Return theNode's successor, unless it is theList head pointer */
+        Return theNode's successor, unless it is theList head pointer */
 
-#define LCGetNext(listColl, theList, theNode) listColl->List[theNode].next==theList ? NIL : listColl->List[theNode].next
+#define LCGetNext(listColl, theList, theNode) listColl->List[theNode].next == theList ? NIL : listColl->List[theNode].next
 
 /* int  LCGetPrev(listCollectionP listColl, int theList, int theNode);
-	Return theNode's predecessor unless theNode is theList head.
-	To start going backwards, use NIL for theNode, which returns theList head's predecessor
-	Usage: Obtain last node, loop while NIL not returned, process node then get predecessor.
-		After theList head processed, get predecessor returns NIL because we started with
-		theList head's predecessor. */
+        Return theNode's predecessor unless theNode is theList head.
+        To start going backwards, use NIL for theNode, which returns theList head's predecessor
+        Usage: Obtain last node, loop while NIL not returned, process node then get predecessor.
+                After theList head processed, get predecessor returns NIL because we started with
+                theList head's predecessor. */
 
 #define LCGetPrev(listColl, theList, theNode) \
-        (theNode==NIL \
-	 ? listColl->List[theList].prev \
-         : theNode==theList ? NIL : listColl->List[theNode].prev)
+        (theNode == NIL                       \
+             ? listColl->List[theList].prev   \
+         : theNode == theList ? NIL           \
+                              : listColl->List[theNode].prev)
 
 /* int  LCPrepend(listCollectionP listColl, int theList, int theNode);
-	If theList is empty, then theNode becomes its only member and is returned.
-	Otherwise, theNode is placed before theList head, and theNode is returned as the new head. */
+        If theList is empty, then theNode becomes its only member and is returned.
+        Otherwise, theNode is placed before theList head, and theNode is returned as the new head. */
 
-#define LCPrepend(listColl, theList, theNode) \
-        (theList==NIL \
-         ? (listColl->List[theNode].prev = listColl->List[theNode].next = theNode) \
-         : (listColl->List[theNode].next = theList, \
-            listColl->List[theNode].prev = listColl->List[theList].prev, \
-            listColl->List[listColl->List[theNode].prev].next = theNode, \
-            listColl->List[theList].prev = theNode, \
-			listColl->List[theList].prev))
+#define LCPrepend(listColl, theList, theNode)                                          \
+        (theList == NIL                                                                \
+             ? (listColl->List[theNode].prev = listColl->List[theNode].next = theNode) \
+             : (listColl->List[theNode].next = theList,                                \
+                listColl->List[theNode].prev = listColl->List[theList].prev,           \
+                listColl->List[listColl->List[theNode].prev].next = theNode,           \
+                listColl->List[theList].prev = theNode,                                \
+                listColl->List[theList].prev))
 
 /* int  LCAppend(listCollectionP listColl, int theList, int theNode);
-	If theList is empty, then theNode becomes its only member and is returned.
-	Otherwise, theNode is placed before theList head, and then theList head is returned. */
+        If theList is empty, then theNode becomes its only member and is returned.
+        Otherwise, theNode is placed before theList head, and then theList head is returned. */
 
-#define LCAppend(listColl, theList, theNode) \
-        (theList==NIL \
-         ? (listColl->List[theNode].prev = listColl->List[theNode].next = theNode) \
-         : (listColl->List[theNode].next = theList, \
-            listColl->List[theNode].prev = listColl->List[theList].prev, \
-            listColl->List[listColl->List[theNode].prev].next = theNode, \
-            listColl->List[theList].prev = theNode, \
-			theList))
+#define LCAppend(listColl, theList, theNode)                                           \
+        (theList == NIL                                                                \
+             ? (listColl->List[theNode].prev = listColl->List[theNode].next = theNode) \
+             : (listColl->List[theNode].next = theList,                                \
+                listColl->List[theNode].prev = listColl->List[theList].prev,           \
+                listColl->List[listColl->List[theNode].prev].next = theNode,           \
+                listColl->List[theList].prev = theNode,                                \
+                theList))
 
 /* int  LCDelete(listCollectionP listColl, int theList, int theNode);
-	If theList contains only one node, then NIL it out and return NIL meaning empty list
-	Otherwise, join the predecessor and successor, then
-	return either the list head or its successor if the deleted node is the list head
-	(in that case, the caller makes the successor become the new list head).*/
+        If theList contains only one node, then NIL it out and return NIL meaning empty list
+        Otherwise, join the predecessor and successor, then
+        return either the list head or its successor if the deleted node is the list head
+        (in that case, the caller makes the successor become the new list head).*/
 
-
-#define LCDelete(listColl, theList, theNode) \
-        listColl->List[theList].next == theList \
-	? (listColl->List[theList].prev = listColl->List[theList].next = NIL) \
-        : (listColl->List[listColl->List[theNode].prev].next = listColl->List[theNode].next, \
-           listColl->List[listColl->List[theNode].next].prev = listColl->List[theNode].prev, \
-	   (theList==theNode ? listColl->List[theNode].next : theList))
+#define LCDelete(listColl, theList, theNode)                                                     \
+        listColl->List[theList].next == theList                                                  \
+            ? (listColl->List[theList].prev = listColl->List[theList].next = NIL)                \
+            : (listColl->List[listColl->List[theNode].prev].next = listColl->List[theNode].next, \
+               listColl->List[listColl->List[theNode].next].prev = listColl->List[theNode].prev, \
+               (theList == theNode ? listColl->List[theNode].next : theList))
 
 #endif
 

--- a/c/graphLib/lowLevelUtils/platformTime.h
+++ b/c/graphLib/lowLevelUtils/platformTime.h
@@ -24,8 +24,8 @@ See the LICENSE.TXT file for licensing information.
 
 typedef struct
 {
-	clock_t hiresTime;
-	time_t lowresTime;
+    clock_t hiresTime;
+    time_t lowresTime;
 } platform_time;
 
 #define platform_GetTime(timeVar) (timeVar.hiresTime = clock(), timeVar.lowresTime = time(NULL))
@@ -35,7 +35,7 @@ typedef struct
 // If we're getting a duration longer than that, then we fall back to the coarser time() measure
 
 #define platform_GetDuration(startTime, endTime) ( \
-	((double)(endTime.lowresTime - startTime.lowresTime)) > 2000 ? ((double)(endTime.lowresTime - startTime.lowresTime)) : ((double)(endTime.hiresTime - startTime.hiresTime)) / CLOCKS_PER_SEC)
+    ((double)(endTime.lowresTime - startTime.lowresTime)) > 2000 ? ((double)(endTime.lowresTime - startTime.lowresTime)) : ((double)(endTime.hiresTime - startTime.hiresTime)) / CLOCKS_PER_SEC)
 
 /*
 #define platform_time clock_t

--- a/c/graphLib/lowLevelUtils/stack.c
+++ b/c/graphLib/lowLevelUtils/stack.c
@@ -10,89 +10,90 @@ See the LICENSE.TXT file for licensing information.
 
 stackP sp_New(int capacity)
 {
-stackP theStack;
+    stackP theStack;
 
-     theStack = (stackP) malloc(sizeof(stack));
+    theStack = (stackP)malloc(sizeof(stack));
 
-     if (theStack != NULL)
-     {
-         theStack->S = (int *) malloc(capacity*sizeof(int));
-         if (theStack->S == NULL)
-         {
-             free(theStack);
-             theStack = NULL;
-         }
-     }
+    if (theStack != NULL)
+    {
+        theStack->S = (int *)malloc(capacity * sizeof(int));
+        if (theStack->S == NULL)
+        {
+            free(theStack);
+            theStack = NULL;
+        }
+    }
 
-     if (theStack != NULL)
-     {
-         theStack->capacity = capacity;
-         sp_ClearStack(theStack);
-     }
+    if (theStack != NULL)
+    {
+        theStack->capacity = capacity;
+        sp_ClearStack(theStack);
+    }
 
-     return theStack;
+    return theStack;
 }
 
 void sp_Free(stackP *pStack)
 {
-     if (pStack == NULL || *pStack == NULL) return;
+    if (pStack == NULL || *pStack == NULL)
+        return;
 
-     (*pStack)->capacity = (*pStack)->size = 0;
+    (*pStack)->capacity = (*pStack)->size = 0;
 
-     if ((*pStack)->S != NULL)
-          free((*pStack)->S);
-     (*pStack)->S = NULL;
-     free(*pStack);
+    if ((*pStack)->S != NULL)
+        free((*pStack)->S);
+    (*pStack)->S = NULL;
+    free(*pStack);
 
-     *pStack = NULL;
+    *pStack = NULL;
 }
 
-int  sp_CopyContent(stackP stackDst, stackP stackSrc)
+int sp_CopyContent(stackP stackDst, stackP stackSrc)
 {
-     if (stackDst->capacity < stackSrc->size)
-         return NOTOK;
+    if (stackDst->capacity < stackSrc->size)
+        return NOTOK;
 
-     if (stackSrc->size > 0)
-         memcpy(stackDst->S, stackSrc->S, stackSrc->size*sizeof(int));
+    if (stackSrc->size > 0)
+        memcpy(stackDst->S, stackSrc->S, stackSrc->size * sizeof(int));
 
-     stackDst->size = stackSrc->size;
-     return OK;
+    stackDst->size = stackSrc->size;
+    return OK;
 }
 
 stackP sp_Duplicate(stackP theStack)
 {
-stackP newStack = sp_New(theStack->capacity);
+    stackP newStack = sp_New(theStack->capacity);
 
     if (newStack == NULL)
         return NULL;
 
     if (theStack->size > 0)
     {
-        memcpy(newStack->S, theStack->S, theStack->size*sizeof(int));
+        memcpy(newStack->S, theStack->S, theStack->size * sizeof(int));
         newStack->size = theStack->size;
     }
 
     return newStack;
 }
 
-int  sp_Copy(stackP stackDst, stackP stackSrc)
+int sp_Copy(stackP stackDst, stackP stackSrc)
 {
     if (sp_CopyContent(stackDst, stackSrc) != OK)
     {
-    stackP newStack = sp_Duplicate(stackSrc);
-    int  *p;
+        stackP newStack = sp_Duplicate(stackSrc);
+        int *p;
 
-         if (newStack == NULL)
-             return NOTOK;
+        if (newStack == NULL)
+            return NOTOK;
 
-         p = stackDst->S;
-         stackDst->S = newStack->S;
-         newStack->S = p;
-         newStack->capacity = stackDst->capacity;
-         sp_Free(&newStack);
+        p = stackDst->S;
+        stackDst->S = newStack->S;
+        newStack->S = p;
+        newStack->capacity = stackDst->capacity;
+        sp_Free(&newStack);
 
-         stackDst->size = stackSrc->size;
-         stackDst->capacity = stackSrc->capacity;
+        stackDst->size = stackSrc->size;
+        stackDst->capacity = stackSrc->capacity;
     }
 
     return OK;
@@ -100,124 +101,124 @@ int  sp_Copy(stackP stackDst, stackP stackSrc)
 
 #ifndef SPEED_MACROS
 
-int  sp_ClearStack(stackP theStack)
+int sp_ClearStack(stackP theStack)
 {
-     theStack->size = 0;
-     return OK;
+    theStack->size = 0;
+    return OK;
 }
 
-int  sp_GetCurrentSize(stackP theStack)
+int sp_GetCurrentSize(stackP theStack)
 {
-     return theStack->size;
+    return theStack->size;
 }
 
-int  sp_SetCurrentSize(stackP theStack, int size)
+int sp_SetCurrentSize(stackP theStack, int size)
 {
-	 return size > theStack->capacity ? NOTOK : (theStack->size = size, OK);
+    return size > theStack->capacity ? NOTOK : (theStack->size = size, OK);
 }
 
-int  sp_IsEmpty(stackP theStack)
+int sp_IsEmpty(stackP theStack)
 {
-     return !theStack->size;
+    return !theStack->size;
 }
 
-int  sp_NonEmpty(stackP theStack)
+int sp_NonEmpty(stackP theStack)
 {
-     return theStack->size;
+    return theStack->size;
 }
 
-int  sp__Push(stackP theStack, int a)
+int sp__Push(stackP theStack, int a)
 {
-     if (theStack->size >= theStack->capacity)
-         return NOTOK;
+    if (theStack->size >= theStack->capacity)
+        return NOTOK;
 
-     theStack->S[theStack->size++] = a;
-     return OK;
+    theStack->S[theStack->size++] = a;
+    return OK;
 }
 
-int  sp__Push2(stackP theStack, int a, int b)
+int sp__Push2(stackP theStack, int a, int b)
 {
-     if (theStack->size + 1 >= theStack->capacity)
-         return NOTOK;
+    if (theStack->size + 1 >= theStack->capacity)
+        return NOTOK;
 
-     theStack->S[theStack->size++] = a;
-     theStack->S[theStack->size++] = b;
-     return OK;
+    theStack->S[theStack->size++] = a;
+    theStack->S[theStack->size++] = b;
+    return OK;
 }
 
-int  sp__Pop(stackP theStack, int *pA)
+int sp__Pop(stackP theStack, int *pA)
 {
-     if (theStack->size <= 0)
-         return NOTOK;
+    if (theStack->size <= 0)
+        return NOTOK;
 
-     *pA = theStack->S[--theStack->size];
-     return OK;
+    *pA = theStack->S[--theStack->size];
+    return OK;
 }
 
-int  sp__Pop_Discard(stackP theStack)
+int sp__Pop_Discard(stackP theStack)
 {
-     if (theStack->size <= 0)
-         return NOTOK;
+    if (theStack->size <= 0)
+        return NOTOK;
 
-     --theStack->size;
-     return OK;
+    --theStack->size;
+    return OK;
 }
 
-int  sp__Pop2(stackP theStack, int *pA, int *pB)
+int sp__Pop2(stackP theStack, int *pA, int *pB)
 {
-     if (theStack->size <= 1)
-         return NOTOK;
+    if (theStack->size <= 1)
+        return NOTOK;
 
-     *pB = theStack->S[--theStack->size];
-     *pA = theStack->S[--theStack->size];
+    *pB = theStack->S[--theStack->size];
+    *pA = theStack->S[--theStack->size];
 
-     return OK;
+    return OK;
 }
 
-int  sp__Pop2_Discard1(stackP theStack, int *pA)
+int sp__Pop2_Discard1(stackP theStack, int *pA)
 {
-     if (theStack->size <= 1)
-         return NOTOK;
+    if (theStack->size <= 1)
+        return NOTOK;
 
-     // When a pair of the form (main, secondary) are pushed in order,
-     // it is sometimes necessary to pop the secondary and discard,
-     // then pop and store the main datum.
-     --theStack->size;
-     *pA = theStack->S[--theStack->size];
+    // When a pair of the form (main, secondary) are pushed in order,
+    // it is sometimes necessary to pop the secondary and discard,
+    // then pop and store the main datum.
+    --theStack->size;
+    *pA = theStack->S[--theStack->size];
 
-     return OK;
+    return OK;
 }
 
-int  sp__Pop2_Discard(stackP theStack)
+int sp__Pop2_Discard(stackP theStack)
 {
-     if (theStack->size <= 1)
-         return NOTOK;
+    if (theStack->size <= 1)
+        return NOTOK;
 
-     --theStack->size;
-     --theStack->size;
+    --theStack->size;
+    --theStack->size;
 
-     return OK;
+    return OK;
 }
 
-int  sp_Top(stackP theStack)
+int sp_Top(stackP theStack)
 {
-    return theStack->size ? theStack->S[theStack->size-1] : NIL;
+    return theStack->size ? theStack->S[theStack->size - 1] : NIL;
 }
 
-int  sp_Get(stackP theStack, int pos)
+int sp_Get(stackP theStack, int pos)
 {
-	 if (theStack == NULL || pos < 0 || pos >= theStack->size)
-		 return NOTOK;
+    if (theStack == NULL || pos < 0 || pos >= theStack->size)
+        return NOTOK;
 
-     return (theStack->S[pos]);
+    return (theStack->S[pos]);
 }
 
-int  sp_Set(stackP theStack, int pos, int val)
+int sp_Set(stackP theStack, int pos, int val)
 {
-	 if (theStack == NULL || pos < 0 || pos >= theStack->size)
-		 return NOTOK;
+    if (theStack == NULL || pos < 0 || pos >= theStack->size)
+        return NOTOK;
 
-	 return (theStack->S[pos] = val);
+    return (theStack->S[pos] = val);
 }
 
 #endif // not defined SPEED_MACROS

--- a/c/graphLib/lowLevelUtils/stack.h
+++ b/c/graphLib/lowLevelUtils/stack.h
@@ -8,66 +8,95 @@ See the LICENSE.TXT file for licensing information.
 #define STACK_H
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 // includes mem functions like memcpy
 #include <string.h>
 
-typedef struct
-{
-        int *S;
-        int size, capacity;
-} stack;
+        typedef struct
+        {
+                int *S;
+                int size, capacity;
+        } stack;
 
-typedef stack * stackP;
+        typedef stack *stackP;
 
-stackP sp_New(int);
-void sp_Free(stackP *);
+        stackP sp_New(int);
+        void sp_Free(stackP *);
 
-int  sp_Copy(stackP, stackP);
+        int sp_Copy(stackP, stackP);
 
-int  sp_CopyContent(stackP stackDst, stackP stackSrc);
-stackP sp_Duplicate(stackP theStack);
+        int sp_CopyContent(stackP stackDst, stackP stackSrc);
+        stackP sp_Duplicate(stackP theStack);
 
 #define sp_GetCapacity(theStack) (theStack->capacity)
 
 #ifndef SPEED_MACROS
 
-int  sp_ClearStack(stackP);
-int  sp_GetCurrentSize(stackP theStack);
-int  sp_SetCurrentSize(stackP theStack, int top);
+        int sp_ClearStack(stackP);
+        int sp_GetCurrentSize(stackP theStack);
+        int sp_SetCurrentSize(stackP theStack, int top);
 
-int  sp_IsEmpty(stackP);
-int  sp_NonEmpty(stackP);
+        int sp_IsEmpty(stackP);
+        int sp_NonEmpty(stackP);
 
-#define sp_Push(theStack, a) { if (sp__Push(theStack, (a)) != OK) return NOTOK; }
-#define sp_Push2(theStack, a, b) { if (sp__Push2(theStack, (a), (b)) != OK) return NOTOK; }
+#define sp_Push(theStack, a)                       \
+        {                                          \
+                if (sp__Push(theStack, (a)) != OK) \
+                        return NOTOK;              \
+        }
+#define sp_Push2(theStack, a, b)                         \
+        {                                                \
+                if (sp__Push2(theStack, (a), (b)) != OK) \
+                        return NOTOK;                    \
+        }
 
-int  sp__Push(stackP, int);
-int  sp__Push2(stackP, int, int);
+        int sp__Push(stackP, int);
+        int sp__Push2(stackP, int, int);
 
-#define sp_Pop(theStack, a) { if (sp__Pop(theStack, &(a)) != OK) return NOTOK; }
-#define sp_Pop_Discard(theStack) { if (sp__Pop_Discard(theStack) != OK) return NOTOK; }
+#define sp_Pop(theStack, a)                        \
+        {                                          \
+                if (sp__Pop(theStack, &(a)) != OK) \
+                        return NOTOK;              \
+        }
+#define sp_Pop_Discard(theStack)                     \
+        {                                            \
+                if (sp__Pop_Discard(theStack) != OK) \
+                        return NOTOK;                \
+        }
 
-#define sp_Pop2(theStack, a, b) { if (sp__Pop2(theStack, &(a), &(b)) != OK) return NOTOK; }
-#define sp_Pop2_Discard1(theStack, a) { if (sp__Pop2_Discard1(theStack, &(a)) != OK) return NOTOK; }
-#define sp_Pop2_Discard(theStack) { if (sp__Pop2_Discard(theStack) != OK) return NOTOK; }
+#define sp_Pop2(theStack, a, b)                           \
+        {                                                 \
+                if (sp__Pop2(theStack, &(a), &(b)) != OK) \
+                        return NOTOK;                     \
+        }
+#define sp_Pop2_Discard1(theStack, a)                        \
+        {                                                    \
+                if (sp__Pop2_Discard1(theStack, &(a)) != OK) \
+                        return NOTOK;                        \
+        }
+#define sp_Pop2_Discard(theStack)                     \
+        {                                             \
+                if (sp__Pop2_Discard(theStack) != OK) \
+                        return NOTOK;                 \
+        }
 
-int  sp__Pop(stackP, int *);
-int  sp__Pop_Discard(stackP theStack);
+        int sp__Pop(stackP, int *);
+        int sp__Pop_Discard(stackP theStack);
 
-int  sp__Pop2(stackP, int *, int *);
-int  sp__Pop2_Discard1(stackP theStack, int *pA);
-int  sp__Pop2_Discard(stackP theStack);
+        int sp__Pop2(stackP, int *, int *);
+        int sp__Pop2_Discard1(stackP theStack, int *pA);
+        int sp__Pop2_Discard(stackP theStack);
 
-int  sp_Top(stackP);
-int  sp_Get(stackP, int);
-int  sp_Set(stackP, int, int);
+        int sp_Top(stackP);
+        int sp_Get(stackP, int);
+        int sp_Set(stackP, int, int);
 
 #else
 
-#define sp_ClearStack(theStack) theStack->size=0
+#define sp_ClearStack(theStack) theStack->size = 0
 #define sp_GetCurrentSize(theStack) (theStack->size)
 #define sp_SetCurrentSize(theStack, Size) ((Size) > theStack->capacity ? NOTOK : (theStack->size = (Size), OK))
 
@@ -75,16 +104,32 @@ int  sp_Set(stackP, int, int);
 #define sp_NonEmpty(theStack) theStack->size
 
 #define sp_Push(theStack, a) theStack->S[theStack->size++] = a
-#define sp_Push2(theStack, a, b) {sp_Push(theStack, a); sp_Push(theStack, b);}
+#define sp_Push2(theStack, a, b)      \
+        {                             \
+                sp_Push(theStack, a); \
+                sp_Push(theStack, b); \
+        }
 
-#define sp_Pop(theStack, a) a=theStack->S[--theStack->size]
+#define sp_Pop(theStack, a) a = theStack->S[--theStack->size]
 #define sp_Pop_Discard(theStack) --theStack->size
 
-#define sp_Pop2(theStack, a, b) {sp_Pop(theStack, b);sp_Pop(theStack, a);}
-#define sp_Pop2_Discard1(theStack, a) {sp_Pop_Discard(theStack);sp_Pop(theStack, a);}
-#define sp_Pop2_Discard(theStack) {sp_Pop_Discard(theStack);sp_Pop_Discard(theStack);}
+#define sp_Pop2(theStack, a, b)      \
+        {                            \
+                sp_Pop(theStack, b); \
+                sp_Pop(theStack, a); \
+        }
+#define sp_Pop2_Discard1(theStack, a)     \
+        {                                 \
+                sp_Pop_Discard(theStack); \
+                sp_Pop(theStack, a);      \
+        }
+#define sp_Pop2_Discard(theStack)         \
+        {                                 \
+                sp_Pop_Discard(theStack); \
+                sp_Pop_Discard(theStack); \
+        }
 
-#define sp_Top(theStack) (theStack->size ? theStack->S[theStack->size-1] : NIL)
+#define sp_Top(theStack) (theStack->size ? theStack->S[theStack->size - 1] : NIL)
 #define sp_Get(theStack, pos) (theStack->S[pos])
 #define sp_Set(theStack, pos, val) (theStack->S[pos] = val)
 

--- a/c/graphLib/planarityRelated/graphDrawPlanar_Extensions.c
+++ b/c/graphLib/planarityRelated/graphDrawPlanar_Extensions.c
@@ -12,35 +12,35 @@ See the LICENSE.TXT file for licensing information.
 extern void _ClearVertexVisitedFlags(graphP theGraph, int);
 
 extern void _CollectDrawingData(DrawPlanarContext *context, int RootVertex, int W, int WPrevLink);
-extern int  _BreakTie(DrawPlanarContext *context, int BicompRoot, int W, int WPrevLink);
+extern int _BreakTie(DrawPlanarContext *context, int BicompRoot, int W, int WPrevLink);
 
-extern int  _ComputeVisibilityRepresentation(DrawPlanarContext *context);
-extern int  _CheckVisibilityRepresentationIntegrity(DrawPlanarContext *context);
+extern int _ComputeVisibilityRepresentation(DrawPlanarContext *context);
+extern int _CheckVisibilityRepresentationIntegrity(DrawPlanarContext *context);
 
 /* Forward declarations of local functions */
 
 void _DrawPlanar_ClearStructures(DrawPlanarContext *context);
-int  _DrawPlanar_CreateStructures(DrawPlanarContext *context);
-int  _DrawPlanar_InitStructures(DrawPlanarContext *context);
+int _DrawPlanar_CreateStructures(DrawPlanarContext *context);
+int _DrawPlanar_InitStructures(DrawPlanarContext *context);
 
 void _DrawPlanar_InitEdgeRec(DrawPlanarContext *context, int v);
 void _DrawPlanar_InitVertexInfo(DrawPlanarContext *context, int v);
 
 /* Forward declarations of overloading functions */
 
-int  _DrawPlanar_MergeBicomps(graphP theGraph, int v, int RootVertex, int W, int WPrevLink);
-int  _DrawPlanar_HandleInactiveVertex(graphP theGraph, int BicompRoot, int *pW, int *pWPrevLink);
-int  _DrawPlanar_EmbedPostprocess(graphP theGraph, int v, int edgeEmbeddingResult);
-int  _DrawPlanar_CheckEmbeddingIntegrity(graphP theGraph, graphP origGraph);
-int  _DrawPlanar_CheckObstructionIntegrity(graphP theGraph, graphP origGraph);
+int _DrawPlanar_MergeBicomps(graphP theGraph, int v, int RootVertex, int W, int WPrevLink);
+int _DrawPlanar_HandleInactiveVertex(graphP theGraph, int BicompRoot, int *pW, int *pWPrevLink);
+int _DrawPlanar_EmbedPostprocess(graphP theGraph, int v, int edgeEmbeddingResult);
+int _DrawPlanar_CheckEmbeddingIntegrity(graphP theGraph, graphP origGraph);
+int _DrawPlanar_CheckObstructionIntegrity(graphP theGraph, graphP origGraph);
 
-int  _DrawPlanar_InitGraph(graphP theGraph, int N);
+int _DrawPlanar_InitGraph(graphP theGraph, int N);
 void _DrawPlanar_ReinitializeGraph(graphP theGraph);
-int  _DrawPlanar_EnsureArcCapacity(graphP theGraph, int requiredArcCapacity);
-int  _DrawPlanar_SortVertices(graphP theGraph);
+int _DrawPlanar_EnsureArcCapacity(graphP theGraph, int requiredArcCapacity);
+int _DrawPlanar_SortVertices(graphP theGraph);
 
-int  _DrawPlanar_ReadPostprocess(graphP theGraph, void *extraData, long extraDataSize);
-int  _DrawPlanar_WritePostprocess(graphP theGraph, void **pExtraData, long *pExtraDataSize);
+int _DrawPlanar_ReadPostprocess(graphP theGraph, void *extraData, long extraDataSize);
+int _DrawPlanar_WritePostprocess(graphP theGraph, void **pExtraData, long *pExtraDataSize);
 
 /* Forward declarations of functions used by the extension system */
 
@@ -74,81 +74,81 @@ int DRAWPLANAR_ID = 0;
  Returns OK for success, NOTOK for failure.
  ****************************************************************************/
 
-int  gp_AttachDrawPlanar(graphP theGraph)
+int gp_AttachDrawPlanar(graphP theGraph)
 {
-     DrawPlanarContext *context = NULL;
+    DrawPlanarContext *context = NULL;
 
-     // If the drawing feature has already been attached to the graph,
-     // then there is no need to attach it again
-     gp_FindExtension(theGraph, DRAWPLANAR_ID, (void *)&context);
-     if (context != NULL)
-     {
-         return OK;
-     }
+    // If the drawing feature has already been attached to the graph,
+    // then there is no need to attach it again
+    gp_FindExtension(theGraph, DRAWPLANAR_ID, (void *)&context);
+    if (context != NULL)
+    {
+        return OK;
+    }
 
-     // Allocate a new extension context
-     context = (DrawPlanarContext *) malloc(sizeof(DrawPlanarContext));
-     if (context == NULL)
-     {
-         return NOTOK;
-     }
+    // Allocate a new extension context
+    context = (DrawPlanarContext *)malloc(sizeof(DrawPlanarContext));
+    if (context == NULL)
+    {
+        return NOTOK;
+    }
 
-     // First, tell the context that it is not initialized
-     context->initialized = 0;
+    // First, tell the context that it is not initialized
+    context->initialized = 0;
 
-     // Save a pointer to theGraph in the context
-     context->theGraph = theGraph;
+    // Save a pointer to theGraph in the context
+    context->theGraph = theGraph;
 
-     // Put the overload functions into the context function table.
-     // gp_AddExtension will overload the graph's functions with these, and
-     // return the base function pointers in the context function table
-     memset(&context->functions, 0, sizeof(graphFunctionTable));
+    // Put the overload functions into the context function table.
+    // gp_AddExtension will overload the graph's functions with these, and
+    // return the base function pointers in the context function table
+    memset(&context->functions, 0, sizeof(graphFunctionTable));
 
-     context->functions.fpMergeBicomps = _DrawPlanar_MergeBicomps;
-     context->functions.fpHandleInactiveVertex = _DrawPlanar_HandleInactiveVertex;
-     context->functions.fpEmbedPostprocess = _DrawPlanar_EmbedPostprocess;
-     context->functions.fpCheckEmbeddingIntegrity = _DrawPlanar_CheckEmbeddingIntegrity;
-     context->functions.fpCheckObstructionIntegrity = _DrawPlanar_CheckObstructionIntegrity;
+    context->functions.fpMergeBicomps = _DrawPlanar_MergeBicomps;
+    context->functions.fpHandleInactiveVertex = _DrawPlanar_HandleInactiveVertex;
+    context->functions.fpEmbedPostprocess = _DrawPlanar_EmbedPostprocess;
+    context->functions.fpCheckEmbeddingIntegrity = _DrawPlanar_CheckEmbeddingIntegrity;
+    context->functions.fpCheckObstructionIntegrity = _DrawPlanar_CheckObstructionIntegrity;
 
-     context->functions.fpInitGraph = _DrawPlanar_InitGraph;
-     context->functions.fpReinitializeGraph = _DrawPlanar_ReinitializeGraph;
-     context->functions.fpEnsureArcCapacity = _DrawPlanar_EnsureArcCapacity;
-     context->functions.fpSortVertices = _DrawPlanar_SortVertices;
+    context->functions.fpInitGraph = _DrawPlanar_InitGraph;
+    context->functions.fpReinitializeGraph = _DrawPlanar_ReinitializeGraph;
+    context->functions.fpEnsureArcCapacity = _DrawPlanar_EnsureArcCapacity;
+    context->functions.fpSortVertices = _DrawPlanar_SortVertices;
 
-     context->functions.fpReadPostprocess = _DrawPlanar_ReadPostprocess;
-     context->functions.fpWritePostprocess = _DrawPlanar_WritePostprocess;
+    context->functions.fpReadPostprocess = _DrawPlanar_ReadPostprocess;
+    context->functions.fpWritePostprocess = _DrawPlanar_WritePostprocess;
 
-     _DrawPlanar_ClearStructures(context);
+    _DrawPlanar_ClearStructures(context);
 
-     // Store the Draw context, including the data structure and the
-     // function pointers, as an extension of the graph
-     if (gp_AddExtension(theGraph, &DRAWPLANAR_ID, (void *) context,
-                         _DrawPlanar_DupContext, _DrawPlanar_FreeContext,
-                         &context->functions) != OK)
-     {
-         _DrawPlanar_FreeContext(context);
-         return NOTOK;
-     }
+    // Store the Draw context, including the data structure and the
+    // function pointers, as an extension of the graph
+    if (gp_AddExtension(theGraph, &DRAWPLANAR_ID, (void *)context,
+                        _DrawPlanar_DupContext, _DrawPlanar_FreeContext,
+                        &context->functions) != OK)
+    {
+        _DrawPlanar_FreeContext(context);
+        return NOTOK;
+    }
 
-     // Create the Draw-specific structures if the size of the graph is known
-     // Attach functions are typically invoked after gp_New(), but if a graph
-     // extension must be attached before gp_Read(), then the attachment
-     // also happens before gp_InitGraph() because gp_Read() invokes init only
-     // after it reads the order N of the graph.  Hence, this attach call would
-     // occur when N==0 in the case of gp_Read().
-     // But if a feature is attached after gp_InitGraph(), then N > 0 and so we
-     // need to create and initialize all the custom data structures
-     if (theGraph->N > 0)
-     {
-         if (_DrawPlanar_CreateStructures(context) != OK ||
-             _DrawPlanar_InitStructures(context) != OK)
-         {
-             _DrawPlanar_FreeContext(context);
-             return NOTOK;
-         }
-     }
+    // Create the Draw-specific structures if the size of the graph is known
+    // Attach functions are typically invoked after gp_New(), but if a graph
+    // extension must be attached before gp_Read(), then the attachment
+    // also happens before gp_InitGraph() because gp_Read() invokes init only
+    // after it reads the order N of the graph.  Hence, this attach call would
+    // occur when N==0 in the case of gp_Read().
+    // But if a feature is attached after gp_InitGraph(), then N > 0 and so we
+    // need to create and initialize all the custom data structures
+    if (theGraph->N > 0)
+    {
+        if (_DrawPlanar_CreateStructures(context) != OK ||
+            _DrawPlanar_InitStructures(context) != OK)
+        {
+            _DrawPlanar_FreeContext(context);
+            return NOTOK;
+        }
+    }
 
-     return OK;
+    return OK;
 }
 
 /********************************************************************
@@ -195,23 +195,22 @@ void _DrawPlanar_ClearStructures(DrawPlanarContext *context)
  Create uninitialized structures for the vertex and edge levels,
  and initialized structures for the graph level
  ********************************************************************/
-int  _DrawPlanar_CreateStructures(DrawPlanarContext *context)
+int _DrawPlanar_CreateStructures(DrawPlanarContext *context)
 {
-	 graphP theGraph = context->theGraph;
-     int VIsize = gp_PrimaryVertexIndexBound(theGraph);
-     int Esize = gp_EdgeIndexBound(theGraph);
+    graphP theGraph = context->theGraph;
+    int VIsize = gp_PrimaryVertexIndexBound(theGraph);
+    int Esize = gp_EdgeIndexBound(theGraph);
 
-     if (theGraph->N <= 0)
-         return NOTOK;
+    if (theGraph->N <= 0)
+        return NOTOK;
 
-     if ((context->E = (DrawPlanar_EdgeRecP) malloc(Esize*sizeof(DrawPlanar_EdgeRec))) == NULL ||
-         (context->VI = (DrawPlanar_VertexInfoP) malloc(VIsize*sizeof(DrawPlanar_VertexInfo))) == NULL
-        )
-     {
-         return NOTOK;
-     }
+    if ((context->E = (DrawPlanar_EdgeRecP)malloc(Esize * sizeof(DrawPlanar_EdgeRec))) == NULL ||
+        (context->VI = (DrawPlanar_VertexInfoP)malloc(VIsize * sizeof(DrawPlanar_VertexInfo))) == NULL)
+    {
+        return NOTOK;
+    }
 
-     return OK;
+    return OK;
 }
 
 /********************************************************************
@@ -220,27 +219,27 @@ int  _DrawPlanar_CreateStructures(DrawPlanarContext *context)
  Initializes vertex and edge levels only. Graph level is
  already initialized in _CreateStructures()
  ********************************************************************/
-int  _DrawPlanar_InitStructures(DrawPlanarContext *context)
+int _DrawPlanar_InitStructures(DrawPlanarContext *context)
 {
 #if NIL == 0
-	memset(context->VI, NIL_CHAR, gp_PrimaryVertexIndexBound(context->theGraph) * sizeof(DrawPlanar_VertexInfo));
-	memset(context->E, NIL_CHAR, gp_EdgeIndexBound(context->theGraph) * sizeof(DrawPlanar_EdgeRec));
+    memset(context->VI, NIL_CHAR, gp_PrimaryVertexIndexBound(context->theGraph) * sizeof(DrawPlanar_VertexInfo));
+    memset(context->E, NIL_CHAR, gp_EdgeIndexBound(context->theGraph) * sizeof(DrawPlanar_EdgeRec));
 #else
-     int v, e, Esize;
-     graphP theGraph = context->theGraph;
+    int v, e, Esize;
+    graphP theGraph = context->theGraph;
 
-     if (theGraph->N <= 0)
-         return NOTOK;
+    if (theGraph->N <= 0)
+        return NOTOK;
 
-     for (v = gp_GetFirstVertex(theGraph); gp_VertexInRange(theGraph, v); v++)
-          _DrawPlanar_InitVertexInfo(context, v);
+    for (v = gp_GetFirstVertex(theGraph); gp_VertexInRange(theGraph, v); v++)
+        _DrawPlanar_InitVertexInfo(context, v);
 
-     Esize = gp_EdgeIndexBound(theGraph);
-     for (e = gp_GetFirstEdge(theGraph); e < Esize; e++)
-          _DrawPlanar_InitEdgeRec(context, e);
+    Esize = gp_EdgeIndexBound(theGraph);
+    for (e = gp_GetFirstEdge(theGraph); e < Esize; e++)
+        _DrawPlanar_InitEdgeRec(context, e);
 #endif
 
-     return OK;
+    return OK;
 }
 
 /********************************************************************
@@ -249,35 +248,35 @@ int  _DrawPlanar_InitStructures(DrawPlanarContext *context)
 
 void *_DrawPlanar_DupContext(void *pContext, void *theGraph)
 {
-     DrawPlanarContext *context = (DrawPlanarContext *) pContext;
-     DrawPlanarContext *newContext = (DrawPlanarContext *) malloc(sizeof(DrawPlanarContext));
+    DrawPlanarContext *context = (DrawPlanarContext *)pContext;
+    DrawPlanarContext *newContext = (DrawPlanarContext *)malloc(sizeof(DrawPlanarContext));
 
-     if (newContext != NULL)
-     {
-         int VIsize = gp_PrimaryVertexIndexBound((graphP) theGraph);
-         int Esize = gp_EdgeIndexBound((graphP) theGraph);
+    if (newContext != NULL)
+    {
+        int VIsize = gp_PrimaryVertexIndexBound((graphP)theGraph);
+        int Esize = gp_EdgeIndexBound((graphP)theGraph);
 
-         *newContext = *context;
+        *newContext = *context;
 
-         newContext->theGraph = (graphP) theGraph;
+        newContext->theGraph = (graphP)theGraph;
 
-         newContext->initialized = 0;
-         _DrawPlanar_ClearStructures(newContext);
-         if (((graphP) theGraph)->N > 0)
-         {
-             if (_DrawPlanar_CreateStructures(newContext) != OK)
-             {
-                 _DrawPlanar_FreeContext(newContext);
-                 return NULL;
-             }
+        newContext->initialized = 0;
+        _DrawPlanar_ClearStructures(newContext);
+        if (((graphP)theGraph)->N > 0)
+        {
+            if (_DrawPlanar_CreateStructures(newContext) != OK)
+            {
+                _DrawPlanar_FreeContext(newContext);
+                return NULL;
+            }
 
-             // Initialize custom data structures by copying
-             memcpy(newContext->E, context->E, Esize*sizeof(DrawPlanar_EdgeRec));
-             memcpy(newContext->VI, context->VI, VIsize*sizeof(DrawPlanar_VertexInfo));
-         }
-     }
+            // Initialize custom data structures by copying
+            memcpy(newContext->E, context->E, Esize * sizeof(DrawPlanar_EdgeRec));
+            memcpy(newContext->VI, context->VI, VIsize * sizeof(DrawPlanar_VertexInfo));
+        }
+    }
 
-     return newContext;
+    return newContext;
 }
 
 /********************************************************************
@@ -286,34 +285,35 @@ void *_DrawPlanar_DupContext(void *pContext, void *theGraph)
 
 void _DrawPlanar_FreeContext(void *pContext)
 {
-     DrawPlanarContext *context = (DrawPlanarContext *) pContext;
+    DrawPlanarContext *context = (DrawPlanarContext *)pContext;
 
-     _DrawPlanar_ClearStructures(context);
-     free(pContext);
+    _DrawPlanar_ClearStructures(context);
+    free(pContext);
 }
 
 /********************************************************************
  ********************************************************************/
 
-int  _DrawPlanar_InitGraph(graphP theGraph, int N)
+int _DrawPlanar_InitGraph(graphP theGraph, int N)
 {
     DrawPlanarContext *context = NULL;
     gp_FindExtension(theGraph, DRAWPLANAR_ID, (void *)&context);
 
-    if (context == NULL) {
-    	return NOTOK;
+    if (context == NULL)
+    {
+        return NOTOK;
     }
 
-	theGraph->N = N;
-	theGraph->NV = N;
-	if (theGraph->arcCapacity == 0)
-		theGraph->arcCapacity = 2*DEFAULT_EDGE_LIMIT*N;
+    theGraph->N = N;
+    theGraph->NV = N;
+    if (theGraph->arcCapacity == 0)
+        theGraph->arcCapacity = 2 * DEFAULT_EDGE_LIMIT * N;
 
-	if (_DrawPlanar_CreateStructures(context) != OK ||
-		_DrawPlanar_InitStructures(context) != OK)
-		return NOTOK;
+    if (_DrawPlanar_CreateStructures(context) != OK ||
+        _DrawPlanar_InitStructures(context) != OK)
+        return NOTOK;
 
-	context->functions.fpInitGraph(theGraph, N);
+    context->functions.fpInitGraph(theGraph, N);
 
     return OK;
 }
@@ -328,11 +328,11 @@ void _DrawPlanar_ReinitializeGraph(graphP theGraph)
 
     if (context != NULL)
     {
-		// Reinitialize the graph
-		context->functions.fpReinitializeGraph(theGraph);
+        // Reinitialize the graph
+        context->functions.fpReinitializeGraph(theGraph);
 
-		// Do the reinitialization that is specific to this module
-		_DrawPlanar_InitStructures(context);
+        // Do the reinitialization that is specific to this module
+        _DrawPlanar_InitStructures(context);
     }
 }
 
@@ -345,36 +345,36 @@ void _DrawPlanar_ReinitializeGraph(graphP theGraph)
  reason to do so.
  ********************************************************************/
 
-int  _DrawPlanar_EnsureArcCapacity(graphP theGraph, int requiredArcCapacity)
+int _DrawPlanar_EnsureArcCapacity(graphP theGraph, int requiredArcCapacity)
 {
-	return NOTOK;
+    return NOTOK;
 }
 
 /********************************************************************
  ********************************************************************/
 
-int  _DrawPlanar_SortVertices(graphP theGraph)
+int _DrawPlanar_SortVertices(graphP theGraph)
 {
     DrawPlanarContext *context = NULL;
     gp_FindExtension(theGraph, DRAWPLANAR_ID, (void *)&context);
 
     if (context != NULL)
     {
-    	// If this is a planarity-based algorithm to which graph drawing has been attached,
-    	// and if the embedding process has already been completed
+        // If this is a planarity-based algorithm to which graph drawing has been attached,
+        // and if the embedding process has already been completed
         if (theGraph->embedFlags == EMBEDFLAGS_DRAWPLANAR)
         {
-        	int v, vIndex;
-        	DrawPlanar_VertexInfo temp;
+            int v, vIndex;
+            DrawPlanar_VertexInfo temp;
 
             // Relabel the context data members that indicate vertices
             for (v = gp_GetFirstVertex(theGraph); gp_VertexInRange(theGraph, v); v++)
             {
-            	if (gp_IsVertex(context->VI[v].ancestor))
-            	{
+                if (gp_IsVertex(context->VI[v].ancestor))
+                {
                     context->VI[v].ancestor = gp_GetVertexIndex(theGraph, context->VI[v].ancestor);
                     context->VI[v].ancestorChild = gp_GetVertexIndex(theGraph, context->VI[v].ancestorChild);
-            	}
+                }
             }
 
             // "Sort" the extra vertex info associated with each vertex so that it is rearranged according
@@ -384,23 +384,23 @@ int  _DrawPlanar_SortVertices(graphP theGraph)
             _ClearVertexVisitedFlags(theGraph, FALSE);
             for (v = gp_GetFirstVertex(theGraph); gp_VertexInRange(theGraph, v); v++)
             {
-            	// If the correct data has already been placed into position v
-            	// by prior steps, then skip to the next vertex
-            	if (gp_GetVertexVisited(theGraph, v))
-            		continue;
+                // If the correct data has already been placed into position v
+                // by prior steps, then skip to the next vertex
+                if (gp_GetVertexVisited(theGraph, v))
+                    continue;
 
-            	// At the beginning of processing position v, the data in position v
-            	// corresponds to data that belongs at the index of v.
-            	vIndex = gp_GetVertexIndex(theGraph, v);
+                // At the beginning of processing position v, the data in position v
+                // corresponds to data that belongs at the index of v.
+                vIndex = gp_GetVertexIndex(theGraph, v);
 
-            	// Iterate on position v until it receives the correct data
-            	while (!gp_GetVertexVisited(theGraph, v))
+                // Iterate on position v until it receives the correct data
+                while (!gp_GetVertexVisited(theGraph, v))
                 {
-            		// Place the data at position v into its proper location at position
-            		// vIndex, and move vIndex's data into position v.
-            		temp = context->VI[v];
-            		context->VI[v] = context->VI[vIndex];
-            		context->VI[vIndex] = temp;
+                    // Place the data at position v into its proper location at position
+                    // vIndex, and move vIndex's data into position v.
+                    temp = context->VI[v];
+                    context->VI[v] = context->VI[vIndex];
+                    context->VI[vIndex] = temp;
 
                     // The data at position vIndex is now marked as being correct.
                     gp_SetVertexVisited(theGraph, vIndex);
@@ -426,7 +426,7 @@ int  _DrawPlanar_SortVertices(graphP theGraph)
           or NONEMBEDDABLE if the merge is blocked
  ********************************************************************/
 
-int  _DrawPlanar_MergeBicomps(graphP theGraph, int v, int RootVertex, int W, int WPrevLink)
+int _DrawPlanar_MergeBicomps(graphP theGraph, int v, int RootVertex, int W, int WPrevLink)
 {
     DrawPlanarContext *context = NULL;
     gp_FindExtension(theGraph, DRAWPLANAR_ID, (void *)&context);
@@ -523,7 +523,7 @@ int _DrawPlanar_EmbedPostprocess(graphP theGraph, int v, int edgeEmbeddingResult
 /********************************************************************
  ********************************************************************/
 
-int  _DrawPlanar_CheckEmbeddingIntegrity(graphP theGraph, graphP origGraph)
+int _DrawPlanar_CheckEmbeddingIntegrity(graphP theGraph, graphP origGraph)
 {
     DrawPlanarContext *context = NULL;
     gp_FindExtension(theGraph, DRAWPLANAR_ID, (void *)&context);
@@ -542,15 +542,15 @@ int  _DrawPlanar_CheckEmbeddingIntegrity(graphP theGraph, graphP origGraph)
 /********************************************************************
  ********************************************************************/
 
-int  _DrawPlanar_CheckObstructionIntegrity(graphP theGraph, graphP origGraph)
+int _DrawPlanar_CheckObstructionIntegrity(graphP theGraph, graphP origGraph)
 {
-     return OK;
+    return OK;
 }
 
 /********************************************************************
  ********************************************************************/
 
-int  _DrawPlanar_ReadPostprocess(graphP theGraph, void *extraData, long extraDataSize)
+int _DrawPlanar_ReadPostprocess(graphP theGraph, void *extraData, long extraDataSize)
 {
     DrawPlanarContext *context = NULL;
     gp_FindExtension(theGraph, DRAWPLANAR_ID, (void *)&context);
@@ -573,15 +573,15 @@ int  _DrawPlanar_ReadPostprocess(graphP theGraph, void *extraData, long extraDat
                 return NOTOK;
 
             // Advance past the start tag
-            extraData = (void *) ((char *) extraData + strlen(line)+1);
+            extraData = (void *)((char *)extraData + strlen(line) + 1);
 
             // Read the N lines of vertex information
             for (v = gp_GetFirstVertex(theGraph); gp_VertexInRange(theGraph, v); v++)
             {
                 sscanf(extraData, " %d%c %d %d %d", &tempInt, &tempChar,
-                              &context->VI[v].pos,
-                              &context->VI[v].start,
-                              &context->VI[v].end);
+                       &context->VI[v].pos,
+                       &context->VI[v].start,
+                       &context->VI[v].end);
 
                 extraData = strchr(extraData, '\n') + 1;
             }
@@ -591,9 +591,9 @@ int  _DrawPlanar_ReadPostprocess(graphP theGraph, void *extraData, long extraDat
             for (e = gp_GetFirstEdge(theGraph); e < EsizeOccupied; e++)
             {
                 sscanf(extraData, " %d%c %d %d %d", &tempInt, &tempChar,
-                              &context->E[e].pos,
-                              &context->E[e].start,
-                              &context->E[e].end);
+                       &context->E[e].pos,
+                       &context->E[e].start,
+                       &context->E[e].end);
 
                 extraData = strchr(extraData, '\n') + 1;
             }
@@ -608,7 +608,7 @@ int  _DrawPlanar_ReadPostprocess(graphP theGraph, void *extraData, long extraDat
 /********************************************************************
  ********************************************************************/
 
-int  _DrawPlanar_WritePostprocess(graphP theGraph, void **pExtraData, long *pExtraDataSize)
+int _DrawPlanar_WritePostprocess(graphP theGraph, void **pExtraData, long *pExtraDataSize)
 {
     DrawPlanarContext *context = NULL;
     gp_FindExtension(theGraph, DRAWPLANAR_ID, (void *)&context);
@@ -622,7 +622,7 @@ int  _DrawPlanar_WritePostprocess(graphP theGraph, void **pExtraData, long *pExt
             int v, e, EsizeOccupied;
             char line[64];
             int maxLineSize = 64, extraDataPos = 0;
-            char *extraData = (char *) malloc((1 + theGraph->N + 2*theGraph->M + 1) * maxLineSize * sizeof(char));
+            char *extraData = (char *)malloc((1 + theGraph->N + 2 * theGraph->M + 1) * maxLineSize * sizeof(char));
             int zeroBasedVertexOffset = (theGraph->internalFlags & FLAGS_ZEROBASEDIO) ? gp_GetFirstVertex(theGraph) : 0;
             int zeroBasedEdgeOffset = (theGraph->internalFlags & FLAGS_ZEROBASEDIO) ? gp_GetFirstEdge(theGraph) : 0;
 
@@ -638,17 +638,17 @@ int  _DrawPlanar_WritePostprocess(graphP theGraph, void **pExtraData, long *pExt
             }
 
             sprintf(line, "<%s>\n", DRAWPLANAR_NAME);
-            strcpy(extraData+extraDataPos, line);
-            extraDataPos += (int) strlen(line);
+            strcpy(extraData + extraDataPos, line);
+            extraDataPos += (int)strlen(line);
 
             for (v = gp_GetFirstVertex(theGraph); gp_VertexInRange(theGraph, v); v++)
             {
-                sprintf(line, "%d: %d %d %d\n", v-zeroBasedVertexOffset,
-                              context->VI[v].pos,
-                              context->VI[v].start,
-                              context->VI[v].end);
-                strcpy(extraData+extraDataPos, line);
-                extraDataPos += (int) strlen(line);
+                sprintf(line, "%d: %d %d %d\n", v - zeroBasedVertexOffset,
+                        context->VI[v].pos,
+                        context->VI[v].start,
+                        context->VI[v].end);
+                strcpy(extraData + extraDataPos, line);
+                extraDataPos += (int)strlen(line);
             }
 
             EsizeOccupied = gp_EdgeInUseIndexBound(theGraph);
@@ -656,20 +656,20 @@ int  _DrawPlanar_WritePostprocess(graphP theGraph, void **pExtraData, long *pExt
             {
                 if (gp_EdgeInUse(theGraph, e))
                 {
-                    sprintf(line, "%d: %d %d %d\n", e-zeroBasedEdgeOffset,
-                                  context->E[e].pos,
-                                  context->E[e].start,
-                                  context->E[e].end);
-                    strcpy(extraData+extraDataPos, line);
-                    extraDataPos += (int) strlen(line);
+                    sprintf(line, "%d: %d %d %d\n", e - zeroBasedEdgeOffset,
+                            context->E[e].pos,
+                            context->E[e].start,
+                            context->E[e].end);
+                    strcpy(extraData + extraDataPos, line);
+                    extraDataPos += (int)strlen(line);
                 }
             }
 
             sprintf(line, "</%s>\n", DRAWPLANAR_NAME);
-            strcpy(extraData+extraDataPos, line);
-            extraDataPos += (int) strlen(line);
+            strcpy(extraData + extraDataPos, line);
+            extraDataPos += (int)strlen(line);
 
-            *pExtraData = (void *) extraData;
+            *pExtraData = (void *)extraData;
             *pExtraDataSize = extraDataPos * sizeof(char);
         }
 

--- a/c/graphLib/planarityRelated/graphNonplanar.c
+++ b/c/graphLib/planarityRelated/graphNonplanar.c
@@ -400,18 +400,18 @@ int _PopAndUnmarkVerticesAndEdges(graphP theGraph, int Z, int stackBottom)
 
  Sets the visited flags on the highest X-Y path, i.e. the one closest to the
  root vertex R of the biconnected component containing X and Y as well as a
- pertinent vertex W that the Walkdown could not reach due to the future 
- pertinent vertices X and Y being along both external face paths 
- emanating from the root R. 
+ pertinent vertex W that the Walkdown could not reach due to the future
+ pertinent vertices X and Y being along both external face paths
+ emanating from the root R.
 
- The caller receives an OK result if the method succeeded in operating or 
+ The caller receives an OK result if the method succeeded in operating or
  NOTOK on an internal failure. However, there may or may not be any X-Y path,
  in which case no visitation flags are set and the return result is still OK
  because the caller must decide whether the absence of an X-Y path is an
- operational error. 
+ operational error.
 
- This method also sets the isolator context's points of attachment on the 
- external face of the marked X-Y path, if there was an X-Y path.  So, the 
+ This method also sets the isolator context's points of attachment on the
+ external face of the marked X-Y path, if there was an X-Y path.  So, the
  caller can also use this call to decide if there was an X-Y path by
  testing whether theGraph->IC.px and py have been set to non-NIL values.
  ****************************************************************************/
@@ -427,18 +427,18 @@ int _MarkHighestXYPath(graphP theGraph)
  Sets the visited flags on the lowest X-Y path, i.e. the one closest to the
  pertinent vertex W that the Walkdown could not reach due to future pertinent
  vertices X and Y along both external face paths emanating from the root R
- of the biconnected component containing W, X and Y. 
+ of the biconnected component containing W, X and Y.
 
- The caller receives an OK result if the method succeeded in operating or 
+ The caller receives an OK result if the method succeeded in operating or
  NOTOK on an internal failure. However, there may or may not be any X-Y path,
  in which case no visitation flags are set and the return result is still OK
  because the caller must decide whether the absence of an X-Y path is an
- operational error. 
+ operational error.
 
- This method also sets the isolator context's points of attachment on the 
- external face of the marked X-Y path, if there was an X-Y path.  So, the 
+ This method also sets the isolator context's points of attachment on the
+ external face of the marked X-Y path, if there was an X-Y path.  So, the
  caller can also use this call to decide if there was an X-Y path by
- testing whether theGraph->IC.px and py have been set to non-NIL values.  
+ testing whether theGraph->IC.px and py have been set to non-NIL values.
  ****************************************************************************/
 
 int _MarkLowestXYPath(graphP theGraph)
@@ -449,17 +449,17 @@ int _MarkLowestXYPath(graphP theGraph)
 /****************************************************************************
  _MarkClosestXYPath()
 
- This method searches for and marks the X-Y path in the bicomp rooted by R 
- that is either closest to R (highest) or closest to W (lowest). This method 
+ This method searches for and marks the X-Y path in the bicomp rooted by R
+ that is either closest to R (highest) or closest to W (lowest). This method
  will return NOTOK if the targetVertex parameter is other than R or W.
- 
- The closest X-Y path is the path through the inside of the bicomp that 
- only attaches to the external face at its two endpoint vertices and 
+
+ The closest X-Y path is the path through the inside of the bicomp that
+ only attaches to the external face at its two endpoint vertices and
  those endpoints are closer along the external face path emanating from
  the targetVertex than the attachment points of any other X-Y path.
 
  This method returns NOTOK if there is an internal processing error and
- otherwise it returns OK. If there is no X-Y path, the method still returns 
+ otherwise it returns OK. If there is no X-Y path, the method still returns
  OK to indicate no internal failures, but on return the caller can detect
  whether there was an X-Y path by testing whether the attachment points in
  the isolator context have been set to non-NIL values. Specifically, test
@@ -476,72 +476,72 @@ int _MarkLowestXYPath(graphP theGraph)
  the external face (other than R and W) have been classified as 'high RXW',
  'low RXW', 'high RXY', or 'low RXY'. Once the vertices have been categorized,
  we proceed with trying to set the visitation flags of vertices and edges.
- First, we remove all edges incident to the targetVertex, except the two edges 
- that join it to the external face. The result is that the targetVertex and its 
- two remaining edges are a 'corner' in the external face but also in a single 
- proper face whose boundary includes the X-Y path with the closest attachment 
- points. Thus, we simply need to walk this proper face to find the desired 
- X-Y path. Note, however, that the resulting face boundary may have attached 
- cut vertices.  Any such separable component contains a vertex neighbor of 
+ First, we remove all edges incident to the targetVertex, except the two edges
+ that join it to the external face. The result is that the targetVertex and its
+ two remaining edges are a 'corner' in the external face but also in a single
+ proper face whose boundary includes the X-Y path with the closest attachment
+ points. Thus, we simply need to walk this proper face to find the desired
+ X-Y path. Note, however, that the resulting face boundary may have attached
+ cut vertices.  Any such separable component contains a vertex neighbor of
  the targetVertex, but the edge to the targetVertex has been temporarily hidden.
- The algorithm removes loops of vertices and edges along the proper face so 
+ The algorithm removes loops of vertices and edges along the proper face so
  that only the desired path is identified.
 
- To walk the proper face containing the targetVertex, we first identify an 
+ To walk the proper face containing the targetVertex, we first identify an
  arc that will be considered to be the one used to enter the targetVertex.
- When the first loop iteration exits the targetVertex, it comes out on the 
- RXW side (even though it may be an internal vertex not marked RXW). 
+ When the first loop iteration exits the targetVertex, it comes out on the
+ RXW side (even though it may be an internal vertex not marked RXW).
  Then we take either the next arc (if targetVertex==W) or predecessor arc
  (if targetVertex==R) at every subsequent corner to determine the exit arc
  for the vertex. Then, we use the twin arc of the exit arc to determine the
- entry arc for the next vertex. 
- 
- For each vertex, we mark as visited the vertex as well as both arcs of 
- the edge used to enter the vertex. We also push the visited vertices and 
- edges onto a stack. Each time the traversal lands on an external face 
+ entry arc for the next vertex.
+
+ For each vertex, we mark as visited the vertex as well as both arcs of
+ the edge used to enter the vertex. We also push the visited vertices and
+ edges onto a stack. Each time the traversal lands on an external face
  vertex on the RXW side, it is recorded as a candidate point of attachment Px.
  We also pop and unmark all previously visited vertices and edges because they
  are now known to not be part of the internal X-Y path after encountering the
- point of attachment. Instead, these preceding edges and vertices were part 
- of a path parallel to the external face that does not obstruct the space 
- between R and W inside the bicomp.  
+ point of attachment. Instead, these preceding edges and vertices were part
+ of a path parallel to the external face that does not obstruct the space
+ between R and W inside the bicomp.
 
  As we walk the proper face, we keep track of the last vertex P_x we visited of
  type RXW (high or low). If we encounter antipodalVertex of the targetVertex
- (i.e., W if the targetVertex is R, or R if the targetVertex is W), then there 
- is no obstructing X-Y path since we removed only edges incident to the 
- targetVertex, so we pop the stack unmarking everything then clear the 
+ (i.e., W if the targetVertex is R, or R if the targetVertex is W), then there
+ is no obstructing X-Y path since we removed only edges incident to the
+ targetVertex, so we pop the stack unmarking everything then clear the
  X-Y path points of attachment in the isolator context so the caller will know
- that no X-Y path was found (and then we return OK since there was no internal 
- error). 
- 
- If, during the traversal, we encounter a vertex Z previously visited, then we 
- pop the stack, unmarking the vertices and edges popped, until we find the 
+ that no X-Y path was found (and then we return OK since there was no internal
+ error).
+
+ If, during the traversal, we encounter a vertex Z previously visited, then we
+ pop the stack, unmarking the vertices and edges popped, until we find the
  prior occurence of Z on the stack. This is because we have traversed a path
- that would connect back to the targetVertex had we not hidden the internal 
+ that would connect back to the targetVertex had we not hidden the internal
  edges of the targetVertex.
 
  Otherwise, the first time we encounter a vertex of type 'RYW', we stop
  because the obstructing X-Y path has been marked visited and its points of
- attachment to the external face have been found. This second point of 
+ attachment to the external face have been found. This second point of
  attachment Py is stored in the isolator context.
 
- Once the X-Y path is identified (or once we have found that there is no 
+ Once the X-Y path is identified (or once we have found that there is no
  X-Y path), we restore the previously hidden edges incident to the targetVertex.
 
  This method uses the stack, but it preserves any prior content.
  The stack space used is no greater than 3N.  The first N accounts for hiding
- the edges incident to the targetVertex.  The other 2N accounts for the fact 
- that each iteration of the main loop visits a vertex, pushing its index and 
+ the edges incident to the targetVertex.  The other 2N accounts for the fact
+ that each iteration of the main loop visits a vertex, pushing its index and
  the location of an edge record.  If a vertex is encountered that is already
  on the stack, then it is not pushed again (and in fact part of the stack
  is removed).
 
- Returns OK on successful operation and NOTOK on internal failure. 
+ Returns OK on successful operation and NOTOK on internal failure.
  Also, if an X-Y path is found (which will be the closest), then
- the graph isolator context contains its attachment points on the 
+ the graph isolator context contains its attachment points on the
  external face of the bicomp rooted by R, and the edges and vertices
- in the X-Y path have been marked visted. 
+ in the X-Y path have been marked visted.
  ****************************************************************************/
 
 int _MarkClosestXYPath(graphP theGraph, int targetVertex)
@@ -582,14 +582,14 @@ int _MarkClosestXYPath(graphP theGraph, int targetVertex)
 
     stackBottom2 = sp_GetCurrentSize(theGraph->theStack);
 
-    /* Walk the proper face containing targetVertex to find and mark the 
+    /* Walk the proper face containing targetVertex to find and mark the
         closest X-Y path.  */
 
     Z = targetVertex;
 
     // Now we will get the arc that we consider to be the arc used to enter
-    // the targetVertex (which will be an edge on the RYW side, and the 
-    // first line of the loop code will get the previous or next arc to exit 
+    // the targetVertex (which will be an edge on the RYW side, and the
+    // first line of the loop code will get the previous or next arc to exit
     // the targetVertex on the RXW side of the bicomp)
     e = targetVertex == R ? gp_GetLastArc(theGraph, R) : gp_GetFirstArc(theGraph, W);
 
@@ -601,7 +601,7 @@ int _MarkClosestXYPath(graphP theGraph, int targetVertex)
         // Get the opposing arc of the corner at vertex Z, as the arc to exit Z
         e = targetVertex == R ? gp_GetPrevArcCircular(theGraph, e)
                               : gp_GetNextArcCircular(theGraph, e);
-        
+
         // Now use the exit arc to get the next Z to visit
         Z = gp_GetNeighbor(theGraph, e);
 
@@ -621,8 +621,8 @@ int _MarkClosestXYPath(graphP theGraph, int targetVertex)
 
         else
         {
-            /* If we find the antipodalVertex of the targetVertex (W if R, R if W), 
-               then there is no X-Y path. Never happens for Kuratowski subgraph 
+            /* If we find the antipodalVertex of the targetVertex (W if R, R if W),
+               then there is no X-Y path. Never happens for Kuratowski subgraph
                isolator, but this routine is also used to test for certain X-Y paths.
                So, we clean up and bail out in that case. */
 

--- a/c/planarityApp/planarity.c
+++ b/c/planarityApp/planarity.c
@@ -12,19 +12,19 @@ See the LICENSE.TXT file for licensing information.
 
 int main(int argc, char *argv[])
 {
-	int retVal = 0;
+    int retVal = 0;
 
-	if (argc <= 1)
-		retVal = menu();
+    if (argc <= 1)
+        retVal = menu();
 
-	else if (argv[1][0] == '-')
-		retVal = commandLine(argc, argv);
+    else if (argv[1][0] == '-')
+        retVal = commandLine(argc, argv);
 
-	else
-		retVal = legacyCommandLine(argc, argv);
+    else
+        retVal = legacyCommandLine(argc, argv);
 
-	// Close the log file if logging
-	gp_Log(NULL);
+    // Close the log file if logging
+    gp_Log(NULL);
 
-	return retVal;
+    return retVal;
 }

--- a/c/planarityApp/planarityCommandLine.c
+++ b/c/planarityApp/planarityCommandLine.c
@@ -29,63 +29,63 @@ int callTransformGraph(int argc, char *argv[]);
 
 int commandLine(int argc, char *argv[])
 {
-	int Result = OK;
+    int Result = OK;
 
-	if (argc >= 3 && strcmp(argv[2], "-q") == 0)
-		setQuietModeSetting(TRUE);
+    if (argc >= 3 && strcmp(argv[2], "-q") == 0)
+        setQuietModeSetting(TRUE);
 
-	if (strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "-help") == 0)
-	{
-		Result = helpMessage(argc >= 3 ? argv[2] : NULL);
-	}
+    if (strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "-help") == 0)
+    {
+        Result = helpMessage(argc >= 3 ? argv[2] : NULL);
+    }
 
-	else if (strcmp(argv[1], "-i") == 0 || strcmp(argv[1], "-info") == 0)
-	{
-		Result = helpMessage(argv[1]);
-	}
+    else if (strcmp(argv[1], "-i") == 0 || strcmp(argv[1], "-info") == 0)
+    {
+        Result = helpMessage(argv[1]);
+    }
 
-	else if (strcmp(argv[1], "-test") == 0)
-		Result = runQuickRegressionTests(argc, argv);
+    else if (strcmp(argv[1], "-test") == 0)
+        Result = runQuickRegressionTests(argc, argv);
 
-	else if (strcmp(argv[1], "-r") == 0)
-		Result = callRandomGraphs(argc, argv);
+    else if (strcmp(argv[1], "-r") == 0)
+        Result = callRandomGraphs(argc, argv);
 
-	else if (strcmp(argv[1], "-s") == 0)
-		Result = callSpecificGraph(argc, argv);
+    else if (strcmp(argv[1], "-s") == 0)
+        Result = callSpecificGraph(argc, argv);
 
-	else if (strcmp(argv[1], "-rm") == 0)
-		Result = callRandomMaxPlanarGraph(argc, argv);
+    else if (strcmp(argv[1], "-rm") == 0)
+        Result = callRandomMaxPlanarGraph(argc, argv);
 
-	else if (strcmp(argv[1], "-rn") == 0)
-		Result = callRandomNonplanarGraph(argc, argv);
+    else if (strcmp(argv[1], "-rn") == 0)
+        Result = callRandomNonplanarGraph(argc, argv);
 
-	else if (strncmp(argv[1], "-x", 2) == 0)
-		Result = callTransformGraph(argc, argv);
+    else if (strncmp(argv[1], "-x", 2) == 0)
+        Result = callTransformGraph(argc, argv);
 
-	else if (strncmp(argv[1], "-t", 2) == 0)
-		Result = callTestAllGraphs(argc, argv);
+    else if (strncmp(argv[1], "-t", 2) == 0)
+        Result = callTestAllGraphs(argc, argv);
 
-	else
-	{
-		ErrorMessage("Unsupported command line.  Here is the help for this program.\n");
-		helpMessage(NULL);
-		Result = NOTOK;
-	}
+    else
+    {
+        ErrorMessage("Unsupported command line.  Here is the help for this program.\n");
+        helpMessage(NULL);
+        Result = NOTOK;
+    }
 
 #ifdef DEBUG
-	// When one builds and runs the executable in an external console from an IDE
-	// such as VSCode, the external console window will close immediately upon
-	// exit 0 being returned. This means that one may miss Messages and
-	// ErrorMessages that are crucial to the debugging process. Hence, if we compile
-	// with the DDEBUG flag, this means that in appconst.h we #define DEBUG. That way,
-	// this prompt will appear only for debug builds, and will ensure the console
-	// window stays open until the user proceeds.
-	printf("\n\tPress return key to exit...\n");
-	fflush(stdout);
-	fflush(stdin);
-	getc(stdin);
+    // When one builds and runs the executable in an external console from an IDE
+    // such as VSCode, the external console window will close immediately upon
+    // exit 0 being returned. This means that one may miss Messages and
+    // ErrorMessages that are crucial to the debugging process. Hence, if we compile
+    // with the DDEBUG flag, this means that in appconst.h we #define DEBUG. That way,
+    // this prompt will appear only for debug builds, and will ensure the console
+    // window stays open until the user proceeds.
+    printf("\n\tPress return key to exit...\n");
+    fflush(stdout);
+    fflush(stdin);
+    getc(stdin);
 #endif
-	return Result == OK ? 0 : (Result == NONEMBEDDABLE ? 1 : -1);
+    return Result == OK ? 0 : (Result == NONEMBEDDABLE ? 1 : -1);
 }
 
 /****************************************************************************
@@ -94,46 +94,46 @@ int commandLine(int argc, char *argv[])
 
 int legacyCommandLine(int argc, char *argv[])
 {
-	graphP theGraph = gp_New();
-	int Result;
+    graphP theGraph = gp_New();
+    int Result;
 
-	Result = gp_Read(theGraph, argv[1]);
-	if (Result != OK)
-	{
-		if (Result != NONEMBEDDABLE)
-		{
-			char *messageFormat = "Failed to read graph \"%.*s\"";
-			char messageContents[MAXLINE + 1];
-			int charsAvailForFilename = (int)(MAXLINE - strlen(messageFormat));
-			sprintf(messageContents, messageFormat, charsAvailForFilename, argv[1]);
-			ErrorMessage(messageContents);
-			return -2;
-		}
-	}
+    Result = gp_Read(theGraph, argv[1]);
+    if (Result != OK)
+    {
+        if (Result != NONEMBEDDABLE)
+        {
+            char *messageFormat = "Failed to read graph \"%.*s\"";
+            char messageContents[MAXLINE + 1];
+            int charsAvailForFilename = (int)(MAXLINE - strlen(messageFormat));
+            sprintf(messageContents, messageFormat, charsAvailForFilename, argv[1]);
+            ErrorMessage(messageContents);
+            return -2;
+        }
+    }
 
-	Result = gp_Embed(theGraph, EMBEDFLAGS_PLANAR);
+    Result = gp_Embed(theGraph, EMBEDFLAGS_PLANAR);
 
-	if (Result == OK)
-	{
-		gp_SortVertices(theGraph);
-		gp_Write(theGraph, argv[2], WRITE_ADJLIST);
-	}
+    if (Result == OK)
+    {
+        gp_SortVertices(theGraph);
+        gp_Write(theGraph, argv[2], WRITE_ADJLIST);
+    }
 
-	else if (Result == NONEMBEDDABLE)
-	{
-		if (argc >= 5 && strcmp(argv[3], "-n") == 0)
-		{
-			gp_SortVertices(theGraph);
-			gp_Write(theGraph, argv[4], WRITE_ADJLIST);
-		}
-	}
-	else
-		Result = NOTOK;
+    else if (Result == NONEMBEDDABLE)
+    {
+        if (argc >= 5 && strcmp(argv[3], "-n") == 0)
+        {
+            gp_SortVertices(theGraph);
+            gp_Write(theGraph, argv[4], WRITE_ADJLIST);
+        }
+    }
+    else
+        Result = NOTOK;
 
-	gp_Free(&theGraph);
+    gp_Free(&theGraph);
 
-	// In the legacy 1.x versions, OK/NONEMBEDDABLE was 0 and NOTOK was -2
-	return Result == OK || Result == NONEMBEDDABLE ? 0 : -2;
+    // In the legacy 1.x versions, OK/NONEMBEDDABLE was 0 and NOTOK was -2
+    return Result == OK || Result == NONEMBEDDABLE ? 0 : -2;
 }
 
 /****************************************************************************
@@ -146,452 +146,452 @@ int runGraphTransformationTest(char *command, char *infileName, int inputInMemFl
 
 int runQuickRegressionTests(int argc, char *argv[])
 {
-	char *samplesDir = "samples";
-	int samplesDirArgLocation = 2;
+    char *samplesDir = "samples";
+    int samplesDirArgLocation = 2;
 
-	// Skip optional -q quiet mode command-line paramater, if present
-	if (argc > samplesDirArgLocation && strcmp(argv[samplesDirArgLocation], "-q") == 0)
-		samplesDirArgLocation++;
+    // Skip optional -q quiet mode command-line paramater, if present
+    if (argc > samplesDirArgLocation && strcmp(argv[samplesDirArgLocation], "-q") == 0)
+        samplesDirArgLocation++;
 
-	// Accept overriding sample directory command-line parameter, if present
-	if (argc > samplesDirArgLocation)
-		samplesDir = argv[samplesDirArgLocation];
+    // Accept overriding sample directory command-line parameter, if present
+    if (argc > samplesDirArgLocation)
+        samplesDir = argv[samplesDirArgLocation];
 
-	if (runSpecificGraphTests(samplesDir) < 0)
-		return NOTOK;
+    if (runSpecificGraphTests(samplesDir) < 0)
+        return NOTOK;
 
-	return OK;
+    return OK;
 }
 
 int runSpecificGraphTests(char *samplesDir)
 {
-	char origDir[2049];
-	int retVal = 0;
+    char origDir[2049];
+    int retVal = 0;
 
-	if (!getcwd(origDir, 2048))
-		return -1;
+    if (!getcwd(origDir, 2048))
+        return -1;
 
-	// Preserve original behavior before the samplesDir command-line parameter was available
-	if (strcmp(samplesDir, "samples") == 0)
-	{
-		if (chdir(samplesDir) != 0)
-		{
-			if (chdir("..") != 0 || chdir(samplesDir) != 0)
-			{
-				// Give success result, but Warn if no samples (except no warning if in quiet mode)
-				Message("WARNING: Unable to change to samples directory to run tests on samples.\n");
-				return 0;
-			}
-		}
-	}
-	else
-	{
-		// New behavior if samplesDir command-line parameter was specified
-		if (chdir(samplesDir) != 0)
-		{
-			Message("WARNING: Unable to change to samples directory to run tests on samples.\n");
-			return 0;
-		}
-	}
+    // Preserve original behavior before the samplesDir command-line parameter was available
+    if (strcmp(samplesDir, "samples") == 0)
+    {
+        if (chdir(samplesDir) != 0)
+        {
+            if (chdir("..") != 0 || chdir(samplesDir) != 0)
+            {
+                // Give success result, but Warn if no samples (except no warning if in quiet mode)
+                Message("WARNING: Unable to change to samples directory to run tests on samples.\n");
+                return 0;
+            }
+        }
+    }
+    else
+    {
+        // New behavior if samplesDir command-line parameter was specified
+        if (chdir(samplesDir) != 0)
+        {
+            Message("WARNING: Unable to change to samples directory to run tests on samples.\n");
+            return 0;
+        }
+    }
 
 #if NIL == 0
-	Message("Starting NIL == 0 Tests\n");
+    Message("Starting NIL == 0 Tests\n");
 
-	if (runSpecificGraphTest("-p", "maxPlanar5.txt", TRUE) < 0)
-	{
-		retVal = -1;
-		Message("Planarity test on maxPlanar5.txt failed.\n");
-	}
+    if (runSpecificGraphTest("-p", "maxPlanar5.txt", TRUE) < 0)
+    {
+        retVal = -1;
+        Message("Planarity test on maxPlanar5.txt failed.\n");
+    }
 
-	if (runSpecificGraphTest("-d", "maxPlanar5.txt", FALSE) < 0)
-	{
-		retVal = -1;
-		Message("Graph drawing test maxPlanar5.txt failed.\n");
-	}
+    if (runSpecificGraphTest("-d", "maxPlanar5.txt", FALSE) < 0)
+    {
+        retVal = -1;
+        Message("Graph drawing test maxPlanar5.txt failed.\n");
+    }
 
-	if (runSpecificGraphTest("-d", "drawExample.txt", TRUE) < 0)
-	{
-		retVal = -1;
-		Message("Graph drawing on drawExample.txt failed.\n");
-	}
+    if (runSpecificGraphTest("-d", "drawExample.txt", TRUE) < 0)
+    {
+        retVal = -1;
+        Message("Graph drawing on drawExample.txt failed.\n");
+    }
 
-	if (runSpecificGraphTest("-p", "Petersen.txt", FALSE) < 0)
-	{
-		retVal = -1;
-		Message("Planarity test on Petersen.txt failed.\n");
-	}
+    if (runSpecificGraphTest("-p", "Petersen.txt", FALSE) < 0)
+    {
+        retVal = -1;
+        Message("Planarity test on Petersen.txt failed.\n");
+    }
 
-	if (runSpecificGraphTest("-o", "Petersen.txt", TRUE) < 0)
-	{
-		retVal = -1;
-		Message("Outerplanarity test on Petersen.txt failed.\n");
-	}
+    if (runSpecificGraphTest("-o", "Petersen.txt", TRUE) < 0)
+    {
+        retVal = -1;
+        Message("Outerplanarity test on Petersen.txt failed.\n");
+    }
 
-	if (runSpecificGraphTest("-2", "Petersen.txt", FALSE) < 0)
-	{
-		retVal = -1;
-		Message("K_{2,3} search on Petersen.txt failed.\n");
-	}
+    if (runSpecificGraphTest("-2", "Petersen.txt", FALSE) < 0)
+    {
+        retVal = -1;
+        Message("K_{2,3} search on Petersen.txt failed.\n");
+    }
 
-	if (runSpecificGraphTest("-3", "Petersen.txt", TRUE) < 0)
-	{
-		retVal = -1;
-		Message("K_{3,3} search on Petersen.txt failed.\n");
-	}
+    if (runSpecificGraphTest("-3", "Petersen.txt", TRUE) < 0)
+    {
+        retVal = -1;
+        Message("K_{3,3} search on Petersen.txt failed.\n");
+    }
 
-	if (runSpecificGraphTest("-4", "Petersen.txt", FALSE) < 0)
-	{
-		retVal = -1;
-		Message("K_4 search on Petersen.txt failed.\n");
-	}
+    if (runSpecificGraphTest("-4", "Petersen.txt", FALSE) < 0)
+    {
+        retVal = -1;
+        Message("K_4 search on Petersen.txt failed.\n");
+    }
 
-	Message("Finished NIL == 0 Tests.\n\n");
+    Message("Finished NIL == 0 Tests.\n\n");
 #endif
 
-	if (runSpecificGraphTest("-p", "maxPlanar5.0-based.txt", FALSE) < 0)
-	{
-		retVal = -1;
-		Message("Planarity test on maxPlanar5.0-based.txt failed.\n");
-	}
+    if (runSpecificGraphTest("-p", "maxPlanar5.0-based.txt", FALSE) < 0)
+    {
+        retVal = -1;
+        Message("Planarity test on maxPlanar5.0-based.txt failed.\n");
+    }
 
-	if (runSpecificGraphTest("-d", "maxPlanar5.0-based.txt", TRUE) < 0)
-	{
-		retVal = -1;
-		Message("Graph drawing test maxPlanar5.0-based.txt failed.\n");
-	}
+    if (runSpecificGraphTest("-d", "maxPlanar5.0-based.txt", TRUE) < 0)
+    {
+        retVal = -1;
+        Message("Graph drawing test maxPlanar5.0-based.txt failed.\n");
+    }
 
-	if (runSpecificGraphTest("-d", "drawExample.0-based.txt", FALSE) < 0)
-	{
-		retVal = -1;
-		Message("Graph drawing on drawExample.0-based.txt failed.\n");
-	}
+    if (runSpecificGraphTest("-d", "drawExample.0-based.txt", FALSE) < 0)
+    {
+        retVal = -1;
+        Message("Graph drawing on drawExample.0-based.txt failed.\n");
+    }
 
-	if (runSpecificGraphTest("-p", "Petersen.0-based.txt", TRUE) < 0)
-	{
-		retVal = -1;
-		Message("Planarity test on Petersen.0-based.txt failed.\n");
-	}
+    if (runSpecificGraphTest("-p", "Petersen.0-based.txt", TRUE) < 0)
+    {
+        retVal = -1;
+        Message("Planarity test on Petersen.0-based.txt failed.\n");
+    }
 
-	if (runSpecificGraphTest("-o", "Petersen.0-based.txt", FALSE) < 0)
-	{
-		retVal = -1;
-		Message("Outerplanarity test on Petersen.0-based.txt failed.\n");
-	}
+    if (runSpecificGraphTest("-o", "Petersen.0-based.txt", FALSE) < 0)
+    {
+        retVal = -1;
+        Message("Outerplanarity test on Petersen.0-based.txt failed.\n");
+    }
 
-	if (runSpecificGraphTest("-2", "Petersen.0-based.txt", TRUE) < 0)
-	{
-		retVal = -1;
-		Message("K_{2,3} search on Petersen.0-based.txt failed.\n");
-	}
+    if (runSpecificGraphTest("-2", "Petersen.0-based.txt", TRUE) < 0)
+    {
+        retVal = -1;
+        Message("K_{2,3} search on Petersen.0-based.txt failed.\n");
+    }
 
-	if (runSpecificGraphTest("-3", "Petersen.0-based.txt", FALSE) < 0)
-	{
-		retVal = -1;
-		Message("K_{3,3} search on Petersen.0-based.txt failed.\n");
-	}
+    if (runSpecificGraphTest("-3", "Petersen.0-based.txt", FALSE) < 0)
+    {
+        retVal = -1;
+        Message("K_{3,3} search on Petersen.0-based.txt failed.\n");
+    }
 
-	if (runSpecificGraphTest("-4", "Petersen.0-based.txt", TRUE) < 0)
-	{
-		retVal = -1;
-		Message("K_4 search on Petersen.0-based.txt failed.\n");
-	}
+    if (runSpecificGraphTest("-4", "Petersen.0-based.txt", TRUE) < 0)
+    {
+        retVal = -1;
+        Message("K_4 search on Petersen.0-based.txt failed.\n");
+    }
 
-	/*
-		GRAPH TRANSFORMATION TESTS
-	*/
-	//	TRANSFORM TO ADJACENCY LIST
+    /*
+        GRAPH TRANSFORMATION TESTS
+    */
+    //  TRANSFORM TO ADJACENCY LIST
 
-	// runGraphTransformationTest by reading file contents into string
-	if (runGraphTransformationTest("-a", "nauty_example.g6", TRUE) < 0)
-	{
-		retVal = -1;
-		Message("Transforming nauty_example.g6 file contents as string to adjacency list failed.\n");
-	}
+    // runGraphTransformationTest by reading file contents into string
+    if (runGraphTransformationTest("-a", "nauty_example.g6", TRUE) < 0)
+    {
+        retVal = -1;
+        Message("Transforming nauty_example.g6 file contents as string to adjacency list failed.\n");
+    }
 
-	// runGraphTransformationTest by reading from file
-	if (runGraphTransformationTest("-a", "nauty_example.g6", FALSE) < 0)
-	{
-		retVal = -1;
-		Message("Transforming nauty_example.g6 using file pointer to adjacency list failed.\n");
-	}
+    // runGraphTransformationTest by reading from file
+    if (runGraphTransformationTest("-a", "nauty_example.g6", FALSE) < 0)
+    {
+        retVal = -1;
+        Message("Transforming nauty_example.g6 using file pointer to adjacency list failed.\n");
+    }
 
-	// runGraphTransformationTest by reading first graph from file into string
-	if (runGraphTransformationTest("-a", "N5-all.g6", TRUE) < 0)
-	{
-		retVal = -1;
-		Message("Transforming first graph in N5-all.g6 (read as string) to adjacency list failed.\n");
-	}
+    // runGraphTransformationTest by reading first graph from file into string
+    if (runGraphTransformationTest("-a", "N5-all.g6", TRUE) < 0)
+    {
+        retVal = -1;
+        Message("Transforming first graph in N5-all.g6 (read as string) to adjacency list failed.\n");
+    }
 
-	// runGraphTransformationTest by reading first graph from file pointer
-	if (runGraphTransformationTest("-a", "N5-all.g6", FALSE) < 0)
-	{
-		retVal = -1;
-		Message("Transforming first graph in N5-all.g6 (read from file pointer) to adjacency list failed.\n");
-	}
+    // runGraphTransformationTest by reading first graph from file pointer
+    if (runGraphTransformationTest("-a", "N5-all.g6", FALSE) < 0)
+    {
+        retVal = -1;
+        Message("Transforming first graph in N5-all.g6 (read from file pointer) to adjacency list failed.\n");
+    }
 
-	// runGraphTransformationTest by reading file contents corresponding to dense graph into string
-	if (runGraphTransformationTest("-a", "K10.g6", TRUE) < 0)
-	{
-		retVal = -1;
-		Message("Transforming K10.g6 file contents as string to adjacency list failed.\n");
-	}
+    // runGraphTransformationTest by reading file contents corresponding to dense graph into string
+    if (runGraphTransformationTest("-a", "K10.g6", TRUE) < 0)
+    {
+        retVal = -1;
+        Message("Transforming K10.g6 file contents as string to adjacency list failed.\n");
+    }
 
-	// runGraphTransformationTest by reading dense graph from file
-	if (runGraphTransformationTest("-a", "K10.g6", FALSE) < 0)
-	{
-		retVal = -1;
-		Message("Transforming K10.g6 using file pointer to adjacency list failed.\n");
-	}
+    // runGraphTransformationTest by reading dense graph from file
+    if (runGraphTransformationTest("-a", "K10.g6", FALSE) < 0)
+    {
+        retVal = -1;
+        Message("Transforming K10.g6 using file pointer to adjacency list failed.\n");
+    }
 
-	//	TRANSFORM TO ADJACENCY MATRIX
+    //  TRANSFORM TO ADJACENCY MATRIX
 
-	// runGraphTransformationTest by reading file contents into string
-	if (runGraphTransformationTest("-m", "nauty_example.g6", TRUE) < 0)
-	{
-		retVal = -1;
-		Message("Transforming nauty_example.g6 file contents as string to adjacency matrix failed.\n");
-	}
+    // runGraphTransformationTest by reading file contents into string
+    if (runGraphTransformationTest("-m", "nauty_example.g6", TRUE) < 0)
+    {
+        retVal = -1;
+        Message("Transforming nauty_example.g6 file contents as string to adjacency matrix failed.\n");
+    }
 
-	// runGraphTransformationTest by reading from file
-	if (runGraphTransformationTest("-m", "nauty_example.g6", FALSE) < 0)
-	{
-		retVal = -1;
-		Message("Transforming nauty_example.g6 using file pointer to adjacency matrix failed.\n");
-	}
+    // runGraphTransformationTest by reading from file
+    if (runGraphTransformationTest("-m", "nauty_example.g6", FALSE) < 0)
+    {
+        retVal = -1;
+        Message("Transforming nauty_example.g6 using file pointer to adjacency matrix failed.\n");
+    }
 
-	// runGraphTransformationTest by reading first graph from file into string
-	if (runGraphTransformationTest("-m", "N5-all.g6", TRUE) < 0)
-	{
-		retVal = -1;
-		Message("Transforming first graph in N5-all.g6 (read as string) to adjacency matrix failed.\n");
-	}
+    // runGraphTransformationTest by reading first graph from file into string
+    if (runGraphTransformationTest("-m", "N5-all.g6", TRUE) < 0)
+    {
+        retVal = -1;
+        Message("Transforming first graph in N5-all.g6 (read as string) to adjacency matrix failed.\n");
+    }
 
-	// runGraphTransformationTest by reading first graph from file pointer
-	if (runGraphTransformationTest("-m", "N5-all.g6", FALSE) < 0)
-	{
-		retVal = -1;
-		Message("Transforming first graph in N5-all.g6 (read from file pointer) to adjacency matrix failed.\n");
-	}
+    // runGraphTransformationTest by reading first graph from file pointer
+    if (runGraphTransformationTest("-m", "N5-all.g6", FALSE) < 0)
+    {
+        retVal = -1;
+        Message("Transforming first graph in N5-all.g6 (read from file pointer) to adjacency matrix failed.\n");
+    }
 
-	// runGraphTransformationTest by reading file contents corresponding to dense graph into string
-	if (runGraphTransformationTest("-m", "K10.g6", TRUE) < 0)
-	{
-		retVal = -1;
-		Message("Transforming K10.g6 file contents as string to adjacency matrix failed.\n");
-	}
+    // runGraphTransformationTest by reading file contents corresponding to dense graph into string
+    if (runGraphTransformationTest("-m", "K10.g6", TRUE) < 0)
+    {
+        retVal = -1;
+        Message("Transforming K10.g6 file contents as string to adjacency matrix failed.\n");
+    }
 
-	// runGraphTransformationTest by reading dense graph from file
-	if (runGraphTransformationTest("-m", "K10.g6", FALSE) < 0)
-	{
-		retVal = -1;
-		Message("Transforming K10.g6 using file pointer to adjacency matrix failed.\n");
-	}
+    // runGraphTransformationTest by reading dense graph from file
+    if (runGraphTransformationTest("-m", "K10.g6", FALSE) < 0)
+    {
+        retVal = -1;
+        Message("Transforming K10.g6 using file pointer to adjacency matrix failed.\n");
+    }
 
-	//	TRANSFORM TO .G6
+    //  TRANSFORM TO .G6
 
-	// runGraphTransformationTest by reading from file
-	if (runGraphTransformationTest("-g", "nauty_example.g6.0-based.AdjList.out.txt", TRUE) < 0)
-	{
-		retVal = -1;
-		Message("Transforming nauty_example.g6.0-based.AdjList.out.txt using file pointer to .g6 failed.\n");
-	}
+    // runGraphTransformationTest by reading from file
+    if (runGraphTransformationTest("-g", "nauty_example.g6.0-based.AdjList.out.txt", TRUE) < 0)
+    {
+        retVal = -1;
+        Message("Transforming nauty_example.g6.0-based.AdjList.out.txt using file pointer to .g6 failed.\n");
+    }
 
-	// runGraphTransformationTest by reading from file
-	if (runGraphTransformationTest("-g", "K10.g6.0-based.AdjList.out.txt", TRUE) < 0)
-	{
-		retVal = -1;
-		Message("Transforming K10.g6.0-based.AdjList.out.txt using file pointer to .g6 failed.\n");
-	}
+    // runGraphTransformationTest by reading from file
+    if (runGraphTransformationTest("-g", "K10.g6.0-based.AdjList.out.txt", TRUE) < 0)
+    {
+        retVal = -1;
+        Message("Transforming K10.g6.0-based.AdjList.out.txt using file pointer to .g6 failed.\n");
+    }
 
-	if (retVal == 0)
-		Message("Tests of all specific graphs succeeded.\n");
-	else
-		Message("One or more specific graph tests FAILED.\n");
+    if (retVal == 0)
+        Message("Tests of all specific graphs succeeded.\n");
+    else
+        Message("One or more specific graph tests FAILED.\n");
 
-	chdir(origDir);
-	FlushConsole(stdout);
-	return retVal;
+    chdir(origDir);
+    FlushConsole(stdout);
+    return retVal;
 }
 
 int runSpecificGraphTest(char *command, char *infileName, int inputInMemFlag)
 {
-	int Result = OK;
-	char algorithmCode = command[1];
+    int Result = OK;
+    char algorithmCode = command[1];
 
-	// The algorithm, indicated by algorithmCode, operating on 'infilename' is expected to produce
-	// an output that is stored in the file named 'expectedResultFileName' (return string not owned)
-	char *expectedPrimaryResultFileName = ConstructPrimaryOutputFilename(infileName, NULL, command[1]);
+    // The algorithm, indicated by algorithmCode, operating on 'infilename' is expected to produce
+    // an output that is stored in the file named 'expectedResultFileName' (return string not owned)
+    char *expectedPrimaryResultFileName = ConstructPrimaryOutputFilename(infileName, NULL, command[1]);
 
-	char *inputString = NULL;
-	char *actualOutput = NULL;
-	char *actualOutput2 = NULL;
+    char *inputString = NULL;
+    char *actualOutput = NULL;
+    char *actualOutput2 = NULL;
 
-	// SpecificGraph() can invoke gp_Read() if the graph is to be read from a file, or it can invoke
-	// gp_ReadFromString() if the inputInMemFlag is set.
-	if (inputInMemFlag)
-	{
-		inputString = ReadTextFileIntoString(infileName);
-		if (inputString == NULL)
-		{
-			ErrorMessage("Failed to read input file into string.\n");
-			Result = NOTOK;
-		}
-	}
+    // SpecificGraph() can invoke gp_Read() if the graph is to be read from a file, or it can invoke
+    // gp_ReadFromString() if the inputInMemFlag is set.
+    if (inputInMemFlag)
+    {
+        inputString = ReadTextFileIntoString(infileName);
+        if (inputString == NULL)
+        {
+            ErrorMessage("Failed to read input file into string.\n");
+            Result = NOTOK;
+        }
+    }
 
-	if (Result == OK)
-	{
-		// Perform the indicated algorithm on the graph in the input file or string. gp_ReadFromString()
-		// will handle freeing inputString.
-		Result = SpecificGraph(algorithmCode,
-							   infileName, NULL, NULL,
-							   inputString, &actualOutput, &actualOutput2);
-	}
+    if (Result == OK)
+    {
+        // Perform the indicated algorithm on the graph in the input file or string. gp_ReadFromString()
+        // will handle freeing inputString.
+        Result = SpecificGraph(algorithmCode,
+                               infileName, NULL, NULL,
+                               inputString, &actualOutput, &actualOutput2);
+    }
 
-	// Change from internal OK/NONEMBEDDABLE/NOTOK result to a command-line style 0/-1 result
-	if (Result == OK || Result == NONEMBEDDABLE)
-		Result = 0;
-	else
-	{
-		ErrorMessage("Test failed (graph processor returned failure result).\n");
-		Result = -1;
-	}
+    // Change from internal OK/NONEMBEDDABLE/NOTOK result to a command-line style 0/-1 result
+    if (Result == OK || Result == NONEMBEDDABLE)
+        Result = 0;
+    else
+    {
+        ErrorMessage("Test failed (graph processor returned failure result).\n");
+        Result = -1;
+    }
 
-	// Test that the primary actual output matches the primary expected output
-	if (Result == 0)
-	{
-		if (TextFileMatchesString(expectedPrimaryResultFileName, actualOutput) == TRUE)
-			Message("Test succeeded (result equal to exemplar).\n");
-		else
-		{
-			ErrorMessage("Test failed (result not equal to exemplar).\n");
-			Result = -1;
-		}
-	}
+    // Test that the primary actual output matches the primary expected output
+    if (Result == 0)
+    {
+        if (TextFileMatchesString(expectedPrimaryResultFileName, actualOutput) == TRUE)
+            Message("Test succeeded (result equal to exemplar).\n");
+        else
+        {
+            ErrorMessage("Test failed (result not equal to exemplar).\n");
+            Result = -1;
+        }
+    }
 
-	// Test that the secondary actual output matches the secondary expected output
-	if (algorithmCode == 'd' && Result == 0)
-	{
-		char *expectedSecondaryResultFileName = (char *)malloc(strlen(expectedPrimaryResultFileName) + strlen(".render.txt") + 1);
+    // Test that the secondary actual output matches the secondary expected output
+    if (algorithmCode == 'd' && Result == 0)
+    {
+        char *expectedSecondaryResultFileName = (char *)malloc(strlen(expectedPrimaryResultFileName) + strlen(".render.txt") + 1);
 
-		if (expectedSecondaryResultFileName != NULL)
-		{
-			sprintf(expectedSecondaryResultFileName, "%s%s", expectedPrimaryResultFileName, ".render.txt");
+        if (expectedSecondaryResultFileName != NULL)
+        {
+            sprintf(expectedSecondaryResultFileName, "%s%s", expectedPrimaryResultFileName, ".render.txt");
 
-			if (TextFileMatchesString(expectedSecondaryResultFileName, actualOutput2) == TRUE)
-				Message("Test succeeded (secondary result equal to exemplar).\n");
-			else
-			{
-				ErrorMessage("Test failed (secondary result not equal to exemplar).\n");
-				Result = -1;
-			}
+            if (TextFileMatchesString(expectedSecondaryResultFileName, actualOutput2) == TRUE)
+                Message("Test succeeded (secondary result equal to exemplar).\n");
+            else
+            {
+                ErrorMessage("Test failed (secondary result not equal to exemplar).\n");
+                Result = -1;
+            }
 
-			free(expectedSecondaryResultFileName);
-		}
-		else
-		{
-			Result = -1;
-		}
-	}
+            free(expectedSecondaryResultFileName);
+        }
+        else
+        {
+            Result = -1;
+        }
+    }
 
-	// Cleanup and then return the command-line style result code
-	Message("\n");
+    // Cleanup and then return the command-line style result code
+    Message("\n");
 
-	if (actualOutput != NULL)
-		free(actualOutput);
-	if (actualOutput2 != NULL)
-		free(actualOutput2);
+    if (actualOutput != NULL)
+        free(actualOutput);
+    if (actualOutput2 != NULL)
+        free(actualOutput2);
 
-	return Result;
+    return Result;
 }
 
 int runGraphTransformationTest(char *command, char *infileName, int inputInMemFlag)
 {
-	int Result = OK;
+    int Result = OK;
 
-	char transformationCode = '\0';
-	// runGraphTransformationTest will not test performing an algorithm on a given
-	// input graph; it will only support "-(gam)"
-	if (command == NULL || strlen(command) < 2)
-	{
-		ErrorMessage("runGraphTransformationTest only supports -(gam).\n");
-		return NOTOK;
-	}
-	else if (strlen(command) == 2)
-		transformationCode = command[1];
+    char transformationCode = '\0';
+    // runGraphTransformationTest will not test performing an algorithm on a given
+    // input graph; it will only support "-(gam)"
+    if (command == NULL || strlen(command) < 2)
+    {
+        ErrorMessage("runGraphTransformationTest only supports -(gam).\n");
+        return NOTOK;
+    }
+    else if (strlen(command) == 2)
+        transformationCode = command[1];
 
-	// SpecificGraph() can invoke gp_Read() if the graph is to be read from a file, or it can invoke
-	// gp_ReadFromString() if the inputInMemFlag is set.
-	char *inputString = NULL;
-	if (inputInMemFlag)
-	{
-		inputString = ReadTextFileIntoString(infileName);
-		if (inputString == NULL)
-		{
-			ErrorMessage("Failed to read input file into string.\n");
-			Result = NOTOK;
-		}
-	}
+    // SpecificGraph() can invoke gp_Read() if the graph is to be read from a file, or it can invoke
+    // gp_ReadFromString() if the inputInMemFlag is set.
+    char *inputString = NULL;
+    if (inputInMemFlag)
+    {
+        inputString = ReadTextFileIntoString(infileName);
+        if (inputString == NULL)
+        {
+            ErrorMessage("Failed to read input file into string.\n");
+            Result = NOTOK;
+        }
+    }
 
-	if (Result == OK)
-	{
-		// We need to capture whether output is 0- or 1-based to construct the name of the file to compare actualOutput with
-		int zeroBasedOutputFlag = 0;
-		char *actualOutput = NULL;
-		// We want to handle the test being run when we read from an input file or read from a string,
-		// so pass both infileName and inputString. Ownership of inputString is relinquished to TransformGraph(),
-		// and gp_ReadFromString() will handle freeing it.
-		// We want to output to string, so we pass in the address of the actualOutput string.
-		Result = TransformGraph(command, infileName, inputString, &zeroBasedOutputFlag, NULL, &actualOutput);
+    if (Result == OK)
+    {
+        // We need to capture whether output is 0- or 1-based to construct the name of the file to compare actualOutput with
+        int zeroBasedOutputFlag = 0;
+        char *actualOutput = NULL;
+        // We want to handle the test being run when we read from an input file or read from a string,
+        // so pass both infileName and inputString. Ownership of inputString is relinquished to TransformGraph(),
+        // and gp_ReadFromString() will handle freeing it.
+        // We want to output to string, so we pass in the address of the actualOutput string.
+        Result = TransformGraph(command, infileName, inputString, &zeroBasedOutputFlag, NULL, &actualOutput);
 
-		if (Result != OK || actualOutput == NULL)
-		{
-			ErrorMessage("Failed to perform transformation.\n");
-		}
-		else
-		{
-			// Final arg is baseFlag, which is dependent on whether the FLAGS_ZEROBASEDIO is set in a graphP's internalFlags
-			char *expectedOutfileName = NULL;
-			Result = ConstructTransformationExpectedResultFilename(infileName, &expectedOutfileName, transformationCode, zeroBasedOutputFlag ? 0 : 1);
+        if (Result != OK || actualOutput == NULL)
+        {
+            ErrorMessage("Failed to perform transformation.\n");
+        }
+        else
+        {
+            // Final arg is baseFlag, which is dependent on whether the FLAGS_ZEROBASEDIO is set in a graphP's internalFlags
+            char *expectedOutfileName = NULL;
+            Result = ConstructTransformationExpectedResultFilename(infileName, &expectedOutfileName, transformationCode, zeroBasedOutputFlag ? 0 : 1);
 
-			if (Result != OK || expectedOutfileName == NULL)
-			{
-				ErrorMessage("Unable to construct output filename for expected transformation output.\n");
-				return -1;
-			}
+            if (Result != OK || expectedOutfileName == NULL)
+            {
+                ErrorMessage("Unable to construct output filename for expected transformation output.\n");
+                return -1;
+            }
 
-			Result = TextFileMatchesString(expectedOutfileName, actualOutput);
+            Result = TextFileMatchesString(expectedOutfileName, actualOutput);
 
-			char *messageFormat = NULL;
-			char messageContents[MAXLINE + 1];
-			int charsAvailForFilename = 0;
-			if (Result == TRUE)
-			{
-				messageFormat = "For the transformation %s on file \"%.*s\", actual output file matched expected output file.\n";
-				charsAvailForFilename = (int)(MAXLINE - strlen(messageFormat));
-				sprintf(messageContents, messageFormat, command, charsAvailForFilename, infileName);
-				Message(messageContents);
-				Result = OK;
-			}
-			else
-			{
-				messageFormat = "For the transformation %s on file \"%.*s\", actual output file did not match expected output file.\n";
-				charsAvailForFilename = (int)(MAXLINE - strlen(messageFormat));
-				sprintf(messageContents, messageFormat, command, charsAvailForFilename, infileName);
-				ErrorMessage(messageContents);
-				Result = NOTOK;
-			}
+            char *messageFormat = NULL;
+            char messageContents[MAXLINE + 1];
+            int charsAvailForFilename = 0;
+            if (Result == TRUE)
+            {
+                messageFormat = "For the transformation %s on file \"%.*s\", actual output file matched expected output file.\n";
+                charsAvailForFilename = (int)(MAXLINE - strlen(messageFormat));
+                sprintf(messageContents, messageFormat, command, charsAvailForFilename, infileName);
+                Message(messageContents);
+                Result = OK;
+            }
+            else
+            {
+                messageFormat = "For the transformation %s on file \"%.*s\", actual output file did not match expected output file.\n";
+                charsAvailForFilename = (int)(MAXLINE - strlen(messageFormat));
+                sprintf(messageContents, messageFormat, command, charsAvailForFilename, infileName);
+                ErrorMessage(messageContents);
+                Result = NOTOK;
+            }
 
-			if (expectedOutfileName != NULL)
-			{
-				free(expectedOutfileName);
-				expectedOutfileName = NULL;
-			}
-		}
-	}
+            if (expectedOutfileName != NULL)
+            {
+                free(expectedOutfileName);
+                expectedOutfileName = NULL;
+            }
+        }
+    }
 
-	Message("\n");
+    Message("\n");
 
-	return (Result == OK) ? 0 : -1;
+    return (Result == OK) ? 0 : -1;
 }
 
 /****************************************************************************
@@ -601,30 +601,30 @@ int runGraphTransformationTest(char *command, char *infileName, int inputInMemFl
 // 'planarity -r [-q] C K N [O]': Random graphs
 int callRandomGraphs(int argc, char *argv[])
 {
-	char Choice = 0;
-	int offset = 0, NumGraphs, SizeOfGraphs;
-	char *outfileName = NULL;
+    char Choice = 0;
+    int offset = 0, NumGraphs, SizeOfGraphs;
+    char *outfileName = NULL;
 
-	if (argc < 5 || argc > 7)
-		return -1;
+    if (argc < 5 || argc > 7)
+        return -1;
 
-	if (argv[2][0] == '-' && (Choice = argv[2][1]) == 'q')
-	{
-		Choice = argv[3][1];
-		if (argc < 6)
-			return -1;
-		offset = 1;
-	}
+    if (argv[2][0] == '-' && (Choice = argv[2][1]) == 'q')
+    {
+        Choice = argv[3][1];
+        if (argc < 6)
+            return -1;
+        offset = 1;
+    }
 
-	NumGraphs = atoi(argv[3 + offset]);
-	SizeOfGraphs = atoi(argv[4 + offset]);
+    NumGraphs = atoi(argv[3 + offset]);
+    SizeOfGraphs = atoi(argv[4 + offset]);
 
-	if (argc == (6 + offset))
-	{
-		outfileName = argv[5 + offset];
-	}
+    if (argc == (6 + offset))
+    {
+        outfileName = argv[5 + offset];
+    }
 
-	return RandomGraphs(Choice, NumGraphs, SizeOfGraphs, outfileName);
+    return RandomGraphs(Choice, NumGraphs, SizeOfGraphs, outfileName);
 }
 
 /****************************************************************************
@@ -634,26 +634,26 @@ int callRandomGraphs(int argc, char *argv[])
 // 'planarity -s [-q] C I O [O2]': Specific graph
 int callSpecificGraph(int argc, char *argv[])
 {
-	char Choice = 0, *infileName = NULL, *outfileName = NULL, *outfile2Name = NULL;
-	int offset = 0;
+    char Choice = 0, *infileName = NULL, *outfileName = NULL, *outfile2Name = NULL;
+    int offset = 0;
 
-	if (argc < 5)
-		return -1;
+    if (argc < 5)
+        return -1;
 
-	if (argv[2][0] == '-' && (Choice = argv[2][1]) == 'q')
-	{
-		Choice = argv[3][1];
-		if (argc < 6)
-			return -1;
-		offset = 1;
-	}
+    if (argv[2][0] == '-' && (Choice = argv[2][1]) == 'q')
+    {
+        Choice = argv[3][1];
+        if (argc < 6)
+            return -1;
+        offset = 1;
+    }
 
-	infileName = argv[3 + offset];
-	outfileName = argv[4 + offset];
-	if (argc == 6 + offset)
-		outfile2Name = argv[5 + offset];
+    infileName = argv[3 + offset];
+    outfileName = argv[4 + offset];
+    if (argc == 6 + offset)
+        outfile2Name = argv[5 + offset];
 
-	return SpecificGraph(Choice, infileName, outfileName, outfile2Name, NULL, NULL, NULL);
+    return SpecificGraph(Choice, infileName, outfileName, outfile2Name, NULL, NULL, NULL);
 }
 
 /****************************************************************************
@@ -663,25 +663,25 @@ int callSpecificGraph(int argc, char *argv[])
 // 'planarity -rm [-q] N O [O2]': Maximal planar random graph
 int callRandomMaxPlanarGraph(int argc, char *argv[])
 {
-	int offset = 0, numVertices;
-	char *outfileName = NULL, *outfile2Name = NULL;
+    int offset = 0, numVertices;
+    char *outfileName = NULL, *outfile2Name = NULL;
 
-	if (argc < 4)
-		return -1;
+    if (argc < 4)
+        return -1;
 
-	if (argv[2][0] == '-' && argv[2][1] == 'q')
-	{
-		if (argc < 5)
-			return -1;
-		offset = 1;
-	}
+    if (argv[2][0] == '-' && argv[2][1] == 'q')
+    {
+        if (argc < 5)
+            return -1;
+        offset = 1;
+    }
 
-	numVertices = atoi(argv[2 + offset]);
-	outfileName = argv[3 + offset];
-	if (argc == 5 + offset)
-		outfile2Name = argv[4 + offset];
+    numVertices = atoi(argv[2 + offset]);
+    outfileName = argv[3 + offset];
+    if (argc == 5 + offset)
+        outfile2Name = argv[4 + offset];
 
-	return RandomGraph('p', 0, numVertices, outfileName, outfile2Name);
+    return RandomGraph('p', 0, numVertices, outfileName, outfile2Name);
 }
 
 /****************************************************************************
@@ -691,25 +691,25 @@ int callRandomMaxPlanarGraph(int argc, char *argv[])
 // 'planarity -rn [-q] N O [O2]': Non-planar random graph (maximal planar plus edge)
 int callRandomNonplanarGraph(int argc, char *argv[])
 {
-	int offset = 0, numVertices;
-	char *outfileName = NULL, *outfile2Name = NULL;
+    int offset = 0, numVertices;
+    char *outfileName = NULL, *outfile2Name = NULL;
 
-	if (argc < 4)
-		return -1;
+    if (argc < 4)
+        return -1;
 
-	if (argv[2][0] == '-' && argv[2][1] == 'q')
-	{
-		if (argc < 5)
-			return -1;
-		offset = 1;
-	}
+    if (argv[2][0] == '-' && argv[2][1] == 'q')
+    {
+        if (argc < 5)
+            return -1;
+        offset = 1;
+    }
 
-	numVertices = atoi(argv[2 + offset]);
-	outfileName = argv[3 + offset];
-	if (argc == 5 + offset)
-		outfile2Name = argv[4 + offset];
+    numVertices = atoi(argv[2 + offset]);
+    outfileName = argv[3 + offset];
+    if (argc == 5 + offset)
+        outfile2Name = argv[4 + offset];
 
-	return RandomGraph('p', 1, numVertices, outfileName, outfile2Name);
+    return RandomGraph('p', 1, numVertices, outfileName, outfile2Name);
 }
 
 /****************************************************************************
@@ -721,29 +721,29 @@ int callRandomNonplanarGraph(int argc, char *argv[])
 // and written to output file O.
 int callTransformGraph(int argc, char *argv[])
 {
-	int offset = 0;
-	char *commandString = NULL;
-	char *infileName = NULL, *outfileName = NULL;
+    int offset = 0;
+    char *commandString = NULL;
+    char *infileName = NULL, *outfileName = NULL;
 
-	if (argc < 5)
-		return -1;
+    if (argc < 5)
+        return -1;
 
-	if (argv[2][0] == '-' && argv[2][1] == 'q')
-	{
-		if (argc < 6)
-			return -1;
-		offset = 1;
-	}
+    if (argv[2][0] == '-' && argv[2][1] == 'q')
+    {
+        if (argc < 6)
+            return -1;
+        offset = 1;
+    }
 
-	commandString = argv[2 + offset];
+    commandString = argv[2 + offset];
 
-	infileName = argv[3 + offset];
-	outfileName = argv[4 + offset];
+    infileName = argv[3 + offset];
+    outfileName = argv[4 + offset];
 
-	// We don't want to read from string, so inputStr is NULL
-	// We don't want to write to string, so outputStr is NULL
-	// We don't need to capture whether output is 0- or 1-based, so zeroBasedOutputFlag arg is NULL
-	return TransformGraph(commandString, infileName, NULL, NULL, outfileName, NULL);
+    // We don't want to read from string, so inputStr is NULL
+    // We don't want to write to string, so outputStr is NULL
+    // We don't need to capture whether output is 0- or 1-based, so zeroBasedOutputFlag arg is NULL
+    return TransformGraph(commandString, infileName, NULL, NULL, outfileName, NULL);
 }
 
 /****************************************************************************
@@ -757,25 +757,25 @@ int callTransformGraph(int argc, char *argv[])
 // in output file O.
 int callTestAllGraphs(int argc, char *argv[])
 {
-	int offset = 0;
-	char *commandString = NULL;
-	char *infileName = NULL, *outfileName = NULL;
+    int offset = 0;
+    char *commandString = NULL;
+    char *infileName = NULL, *outfileName = NULL;
 
-	if (argc < 5)
-		return -1;
+    if (argc < 5)
+        return -1;
 
-	if (argv[2][0] == '-' && argv[2][1] == 'q')
-	{
-		if (argc < 6)
-			return -1;
-		offset = 1;
-	}
+    if (argv[2][0] == '-' && argv[2][1] == 'q')
+    {
+        if (argc < 6)
+            return -1;
+        offset = 1;
+    }
 
-	commandString = argv[2 + offset];
+    commandString = argv[2 + offset];
 
-	infileName = argv[3 + offset];
-	outfileName = argv[4 + offset];
+    infileName = argv[3 + offset];
+    outfileName = argv[4 + offset];
 
-	// NOTE: We don't want to write to string, so outputStr is NULL
-	return TestAllGraphs(commandString, infileName, outfileName, NULL);
+    // NOTE: We don't want to write to string, so outputStr is NULL
+    return TestAllGraphs(commandString, infileName, outfileName, NULL);
 }

--- a/c/planarityApp/planarityRandomGraphs.c
+++ b/c/planarityApp/planarityRandomGraphs.c
@@ -23,325 +23,325 @@ graphP MakeGraph(int Size, char command);
 
 int RandomGraphs(char command, int NumGraphs, int SizeOfGraphs, char *outfileName)
 {
-	char theFileName[MAXLINE + 1];
-	int K, countUpdateFreq;
-	int Result = OK, MainStatistic = 0;
-	int ObstructionMinorFreqs[NUM_MINORS];
-	graphP theGraph = NULL, origGraph = NULL;
-	platform_time start, end;
-	int embedFlags = GetEmbedFlags(command);
-	int ReuseGraphs = TRUE;
-	int writeResult;
-	int writeErrorReported_Random = FALSE, writeErrorReported_Embedded = FALSE,
-		writeErrorReported_AdjList = FALSE, writeErrorReported_Obstructed = FALSE,
-		writeErrorReported_Error = FALSE;
+    char theFileName[MAXLINE + 1];
+    int K, countUpdateFreq;
+    int Result = OK, MainStatistic = 0;
+    int ObstructionMinorFreqs[NUM_MINORS];
+    graphP theGraph = NULL, origGraph = NULL;
+    platform_time start, end;
+    int embedFlags = GetEmbedFlags(command);
+    int ReuseGraphs = TRUE;
+    int writeResult;
+    int writeErrorReported_Random = FALSE, writeErrorReported_Embedded = FALSE,
+        writeErrorReported_AdjList = FALSE, writeErrorReported_Obstructed = FALSE,
+        writeErrorReported_Error = FALSE;
 
-	char *messageFormat = NULL;
-	char messageContents[MAXLINE + 1];
-	int charsAvailForStr = 0;
+    char *messageFormat = NULL;
+    char messageContents[MAXLINE + 1];
+    int charsAvailForStr = 0;
 
-	GetNumberIfZero(&NumGraphs, "Enter number of graphs to generate:", 1, 1000000000);
-	GetNumberIfZero(&SizeOfGraphs, "Enter size of graphs:", 1, 10000);
+    GetNumberIfZero(&NumGraphs, "Enter number of graphs to generate:", 1, 1000000000);
+    GetNumberIfZero(&SizeOfGraphs, "Enter size of graphs:", 1, 10000);
 
-	theGraph = MakeGraph(SizeOfGraphs, command);
-	origGraph = MakeGraph(SizeOfGraphs, command);
-	if (theGraph == NULL || origGraph == NULL)
-	{
-		gp_Free(&theGraph);
-		return NOTOK;
-	}
+    theGraph = MakeGraph(SizeOfGraphs, command);
+    origGraph = MakeGraph(SizeOfGraphs, command);
+    if (theGraph == NULL || origGraph == NULL)
+    {
+        gp_Free(&theGraph);
+        return NOTOK;
+    }
 
-	// Initialize a secondary statistics array
-	for (K = 0; K < NUM_MINORS; K++)
-		ObstructionMinorFreqs[K] = 0;
+    // Initialize a secondary statistics array
+    for (K = 0; K < NUM_MINORS; K++)
+        ObstructionMinorFreqs[K] = 0;
 
-	G6WriteIterator *pG6WriteIterator = NULL;
-	if (outfileName != NULL || (tolower(OrigOut) == 'y' && tolower(OrigOutFormat) == 'g'))
-	{
-		if (allocateG6WriteIterator(&pG6WriteIterator, theGraph) != OK)
-		{
-			ErrorMessage("Unable to allocate G6WriteIterator.\n");
-			gp_Free(&theGraph);
-			return NOTOK;
-		}
-	}
+    G6WriteIterator *pG6WriteIterator = NULL;
+    if (outfileName != NULL || (tolower(OrigOut) == 'y' && tolower(OrigOutFormat) == 'g'))
+    {
+        if (allocateG6WriteIterator(&pG6WriteIterator, theGraph) != OK)
+        {
+            ErrorMessage("Unable to allocate G6WriteIterator.\n");
+            gp_Free(&theGraph);
+            return NOTOK;
+        }
+    }
 
-	if (outfileName != NULL)
-	{
-		if (beginG6WriteIterationToG6FilePath(pG6WriteIterator, outfileName) != OK)
-		{
-			ErrorMessage("Unable to begin writing random graphs to G6WriteIterator.\n");
+    if (outfileName != NULL)
+    {
+        if (beginG6WriteIterationToG6FilePath(pG6WriteIterator, outfileName) != OK)
+        {
+            ErrorMessage("Unable to begin writing random graphs to G6WriteIterator.\n");
 
-			if (freeG6WriteIterator(&pG6WriteIterator) != OK)
-			{
-				ErrorMessage("Unable to free G6WriteIterator.\n");
-			}
+            if (freeG6WriteIterator(&pG6WriteIterator) != OK)
+            {
+                ErrorMessage("Unable to free G6WriteIterator.\n");
+            }
 
-			gp_Free(&theGraph);
-			return NOTOK;
-		}
-	}
-	else
-	{
-		// If outfileName is NULL, then the only case in which we would want to
-		// output the generated random graphs to .g6 is if we Reconfigure() and
-		// choose these options; in that case, need to set a default output filename.
-		if (tolower(OrigOut) == 'y' && tolower(OrigOutFormat) == 'g')
-		{
-			sprintf(theFileName, "random%cn%d.k%d.g6", FILE_DELIMITER, SizeOfGraphs, NumGraphs);
-			if (beginG6WriteIterationToG6FilePath(pG6WriteIterator, theFileName) != OK)
-			{
-				ErrorMessage("Unable to begin writing random graphs to G6WriteIterator.\n");
+            gp_Free(&theGraph);
+            return NOTOK;
+        }
+    }
+    else
+    {
+        // If outfileName is NULL, then the only case in which we would want to
+        // output the generated random graphs to .g6 is if we Reconfigure() and
+        // choose these options; in that case, need to set a default output filename.
+        if (tolower(OrigOut) == 'y' && tolower(OrigOutFormat) == 'g')
+        {
+            sprintf(theFileName, "random%cn%d.k%d.g6", FILE_DELIMITER, SizeOfGraphs, NumGraphs);
+            if (beginG6WriteIterationToG6FilePath(pG6WriteIterator, theFileName) != OK)
+            {
+                ErrorMessage("Unable to begin writing random graphs to G6WriteIterator.\n");
 
-				if (freeG6WriteIterator(&pG6WriteIterator) != OK)
-				{
-					ErrorMessage("Unable to free G6WriteIterator.\n");
-				}
+                if (freeG6WriteIterator(&pG6WriteIterator) != OK)
+                {
+                    ErrorMessage("Unable to free G6WriteIterator.\n");
+                }
 
-				gp_Free(&theGraph);
-				return NOTOK;
-			}
-		}
-	}
+                gp_Free(&theGraph);
+                return NOTOK;
+            }
+        }
+    }
 
-	// Seed the random number generator with "now". Do it after any prompting
-	// to tie randomness to human process of answering the prompt.
-	srand(time(NULL));
+    // Seed the random number generator with "now". Do it after any prompting
+    // to tie randomness to human process of answering the prompt.
+    srand(time(NULL));
 
-	// Select a counter update frequency that updates more frequently with larger graphs
-	// and which is relatively prime with 10 so that all digits of the count will change
-	// even though we aren't showing the count value on every iteration
-	countUpdateFreq = 3579 / SizeOfGraphs;
-	countUpdateFreq = countUpdateFreq < 1 ? 1 : countUpdateFreq;
-	countUpdateFreq = countUpdateFreq % 2 == 0 ? countUpdateFreq + 1 : countUpdateFreq;
-	countUpdateFreq = countUpdateFreq % 5 == 0 ? countUpdateFreq + 2 : countUpdateFreq;
+    // Select a counter update frequency that updates more frequently with larger graphs
+    // and which is relatively prime with 10 so that all digits of the count will change
+    // even though we aren't showing the count value on every iteration
+    countUpdateFreq = 3579 / SizeOfGraphs;
+    countUpdateFreq = countUpdateFreq < 1 ? 1 : countUpdateFreq;
+    countUpdateFreq = countUpdateFreq % 2 == 0 ? countUpdateFreq + 1 : countUpdateFreq;
+    countUpdateFreq = countUpdateFreq % 5 == 0 ? countUpdateFreq + 2 : countUpdateFreq;
 
-	// Start the count
-	fprintf(stdout, "0\r");
-	fflush(stdout);
+    // Start the count
+    fprintf(stdout, "0\r");
+    fflush(stdout);
 
-	// Start the timer
-	platform_GetTime(start);
+    // Start the timer
+    platform_GetTime(start);
 
-	messageFormat = "Failed to write graph \"%.*s\"\nMake the directory if not present\n";
-	charsAvailForStr = (int)(MAXLINE - strlen(messageFormat));
-	// Generate and process the number of graphs requested
-	for (K = 0; K < NumGraphs; K++)
-	{
-		if ((Result = gp_CreateRandomGraph(theGraph)) == OK)
-		{
-			if (pG6WriteIterator != NULL)
-			{
-				writeResult = writeGraphUsingG6WriteIterator(pG6WriteIterator);
-				if (writeResult != OK)
-				{
-					sprintf(messageContents, "Unable to write graph number %d using G6WriteIterator.\n", K);
-					ErrorMessage(messageContents);
-				}
-			}
-			if (tolower(OrigOut) == 'y' && tolower(OrigOutFormat) == 'a')
-			{
-				sprintf(theFileName, "random%c%d.txt", FILE_DELIMITER, K % 10);
-				writeResult = gp_Write(theGraph, theFileName, WRITE_ADJLIST);
-				if (writeResult != OK && !writeErrorReported_Random)
-				{
-					sprintf(messageContents, messageFormat, charsAvailForStr, theFileName);
-					ErrorMessage(messageContents);
-					writeErrorReported_Random = TRUE;
-				}
-			}
+    messageFormat = "Failed to write graph \"%.*s\"\nMake the directory if not present\n";
+    charsAvailForStr = (int)(MAXLINE - strlen(messageFormat));
+    // Generate and process the number of graphs requested
+    for (K = 0; K < NumGraphs; K++)
+    {
+        if ((Result = gp_CreateRandomGraph(theGraph)) == OK)
+        {
+            if (pG6WriteIterator != NULL)
+            {
+                writeResult = writeGraphUsingG6WriteIterator(pG6WriteIterator);
+                if (writeResult != OK)
+                {
+                    sprintf(messageContents, "Unable to write graph number %d using G6WriteIterator.\n", K);
+                    ErrorMessage(messageContents);
+                }
+            }
+            if (tolower(OrigOut) == 'y' && tolower(OrigOutFormat) == 'a')
+            {
+                sprintf(theFileName, "random%c%d.txt", FILE_DELIMITER, K % 10);
+                writeResult = gp_Write(theGraph, theFileName, WRITE_ADJLIST);
+                if (writeResult != OK && !writeErrorReported_Random)
+                {
+                    sprintf(messageContents, messageFormat, charsAvailForStr, theFileName);
+                    ErrorMessage(messageContents);
+                    writeErrorReported_Random = TRUE;
+                }
+            }
 
-			gp_CopyGraph(origGraph, theGraph);
+            gp_CopyGraph(origGraph, theGraph);
 
-			if (strchr(GetAlgorithmChoices(), command))
-			{
-				Result = gp_Embed(theGraph, embedFlags);
+            if (strchr(GetAlgorithmChoices(), command))
+            {
+                Result = gp_Embed(theGraph, embedFlags);
 
-				if (gp_TestEmbedResultIntegrity(theGraph, origGraph, Result) != Result)
-					Result = NOTOK;
+                if (gp_TestEmbedResultIntegrity(theGraph, origGraph, Result) != Result)
+                    Result = NOTOK;
 
-				if (Result == OK)
-				{
-					MainStatistic++;
+                if (Result == OK)
+                {
+                    MainStatistic++;
 
-					if (tolower(EmbeddableOut) == 'y')
-					{
-						sprintf(theFileName, "embedded%c%d.txt", FILE_DELIMITER, K % 10);
-						writeResult = gp_Write(theGraph, theFileName, WRITE_ADJMATRIX);
-						if (writeResult != OK && !writeErrorReported_Embedded)
-						{
-							sprintf(messageContents, messageFormat, charsAvailForStr, theFileName);
-							ErrorMessage(messageContents);
-							writeErrorReported_Embedded = TRUE;
-						}
-					}
+                    if (tolower(EmbeddableOut) == 'y')
+                    {
+                        sprintf(theFileName, "embedded%c%d.txt", FILE_DELIMITER, K % 10);
+                        writeResult = gp_Write(theGraph, theFileName, WRITE_ADJMATRIX);
+                        if (writeResult != OK && !writeErrorReported_Embedded)
+                        {
+                            sprintf(messageContents, messageFormat, charsAvailForStr, theFileName);
+                            ErrorMessage(messageContents);
+                            writeErrorReported_Embedded = TRUE;
+                        }
+                    }
 
-					if (tolower(AdjListsForEmbeddingsOut) == 'y')
-					{
-						sprintf(theFileName, "adjlist%c%d.txt", FILE_DELIMITER, K % 10);
-						writeResult = gp_Write(theGraph, theFileName, WRITE_ADJLIST);
-						if (writeResult != OK && !writeErrorReported_AdjList)
-						{
-							sprintf(messageContents, messageFormat, charsAvailForStr, theFileName);
-							ErrorMessage(messageContents);
-							writeErrorReported_AdjList = TRUE;
-						}
-					}
-				}
-				else if (Result == NONEMBEDDABLE)
-				{
-					if (embedFlags == EMBEDFLAGS_PLANAR || embedFlags == EMBEDFLAGS_OUTERPLANAR)
-					{
-						if (theGraph->IC.minorType & MINORTYPE_A)
-							ObstructionMinorFreqs[0]++;
-						else if (theGraph->IC.minorType & MINORTYPE_B)
-							ObstructionMinorFreqs[1]++;
-						else if (theGraph->IC.minorType & MINORTYPE_C)
-							ObstructionMinorFreqs[2]++;
-						else if (theGraph->IC.minorType & MINORTYPE_D)
-							ObstructionMinorFreqs[3]++;
-						else if (theGraph->IC.minorType & MINORTYPE_E)
-							ObstructionMinorFreqs[4]++;
+                    if (tolower(AdjListsForEmbeddingsOut) == 'y')
+                    {
+                        sprintf(theFileName, "adjlist%c%d.txt", FILE_DELIMITER, K % 10);
+                        writeResult = gp_Write(theGraph, theFileName, WRITE_ADJLIST);
+                        if (writeResult != OK && !writeErrorReported_AdjList)
+                        {
+                            sprintf(messageContents, messageFormat, charsAvailForStr, theFileName);
+                            ErrorMessage(messageContents);
+                            writeErrorReported_AdjList = TRUE;
+                        }
+                    }
+                }
+                else if (Result == NONEMBEDDABLE)
+                {
+                    if (embedFlags == EMBEDFLAGS_PLANAR || embedFlags == EMBEDFLAGS_OUTERPLANAR)
+                    {
+                        if (theGraph->IC.minorType & MINORTYPE_A)
+                            ObstructionMinorFreqs[0]++;
+                        else if (theGraph->IC.minorType & MINORTYPE_B)
+                            ObstructionMinorFreqs[1]++;
+                        else if (theGraph->IC.minorType & MINORTYPE_C)
+                            ObstructionMinorFreqs[2]++;
+                        else if (theGraph->IC.minorType & MINORTYPE_D)
+                            ObstructionMinorFreqs[3]++;
+                        else if (theGraph->IC.minorType & MINORTYPE_E)
+                            ObstructionMinorFreqs[4]++;
 
-						if (theGraph->IC.minorType & MINORTYPE_E1)
-							ObstructionMinorFreqs[5]++;
-						else if (theGraph->IC.minorType & MINORTYPE_E2)
-							ObstructionMinorFreqs[6]++;
-						else if (theGraph->IC.minorType & MINORTYPE_E3)
-							ObstructionMinorFreqs[7]++;
-						else if (theGraph->IC.minorType & MINORTYPE_E4)
-							ObstructionMinorFreqs[8]++;
+                        if (theGraph->IC.minorType & MINORTYPE_E1)
+                            ObstructionMinorFreqs[5]++;
+                        else if (theGraph->IC.minorType & MINORTYPE_E2)
+                            ObstructionMinorFreqs[6]++;
+                        else if (theGraph->IC.minorType & MINORTYPE_E3)
+                            ObstructionMinorFreqs[7]++;
+                        else if (theGraph->IC.minorType & MINORTYPE_E4)
+                            ObstructionMinorFreqs[8]++;
 
-						if (tolower(ObstructedOut) == 'y')
-						{
-							sprintf(theFileName, "obstructed%c%d.txt", FILE_DELIMITER, K % 10);
-							writeResult = gp_Write(theGraph, theFileName, WRITE_ADJMATRIX);
-							if (writeResult != OK && !writeErrorReported_Obstructed)
-							{
-								sprintf(messageContents, messageFormat, charsAvailForStr, theFileName);
-								ErrorMessage(messageContents);
-								writeErrorReported_Obstructed = TRUE;
-							}
-						}
-					}
-				}
-			}
+                        if (tolower(ObstructedOut) == 'y')
+                        {
+                            sprintf(theFileName, "obstructed%c%d.txt", FILE_DELIMITER, K % 10);
+                            writeResult = gp_Write(theGraph, theFileName, WRITE_ADJMATRIX);
+                            if (writeResult != OK && !writeErrorReported_Obstructed)
+                            {
+                                sprintf(messageContents, messageFormat, charsAvailForStr, theFileName);
+                                ErrorMessage(messageContents);
+                                writeErrorReported_Obstructed = TRUE;
+                            }
+                        }
+                    }
+                }
+            }
 
-			// If there is an error in processing, then write the file for debugging
-			if (Result != OK && Result != NONEMBEDDABLE)
-			{
-				sprintf(theFileName, "error%c%d.txt", FILE_DELIMITER, K % 10);
-				writeResult = gp_Write(origGraph, theFileName, WRITE_ADJLIST);
-				if (writeResult != OK && !writeErrorReported_Error)
-				{
-					sprintf(messageContents, messageFormat, charsAvailForStr, theFileName);
-					ErrorMessage(messageContents);
-					writeErrorReported_Error = TRUE;
-				}
-			}
-		}
+            // If there is an error in processing, then write the file for debugging
+            if (Result != OK && Result != NONEMBEDDABLE)
+            {
+                sprintf(theFileName, "error%c%d.txt", FILE_DELIMITER, K % 10);
+                writeResult = gp_Write(origGraph, theFileName, WRITE_ADJLIST);
+                if (writeResult != OK && !writeErrorReported_Error)
+                {
+                    sprintf(messageContents, messageFormat, charsAvailForStr, theFileName);
+                    ErrorMessage(messageContents);
+                    writeErrorReported_Error = TRUE;
+                }
+            }
+        }
 
-		// Reinitialize or recreate graphs for next iteration
-		ReinitializeGraph(&theGraph, ReuseGraphs, command);
-		ReinitializeGraph(&origGraph, ReuseGraphs, command);
+        // Reinitialize or recreate graphs for next iteration
+        ReinitializeGraph(&theGraph, ReuseGraphs, command);
+        ReinitializeGraph(&origGraph, ReuseGraphs, command);
 
-		// Show progress, but not so often that it bogs down progress
-		if (!getQuietModeSetting() && (K + 1) % countUpdateFreq == 0)
-		{
-			fprintf(stdout, "%d\r", K + 1);
-			fflush(stdout);
-		}
+        // Show progress, but not so often that it bogs down progress
+        if (!getQuietModeSetting() && (K + 1) % countUpdateFreq == 0)
+        {
+            fprintf(stdout, "%d\r", K + 1);
+            fflush(stdout);
+        }
 
-		// Terminate loop on error
-		if (Result != OK && Result != NONEMBEDDABLE)
-		{
-			ErrorMessage("\nError found\n");
-			Result = NOTOK;
-			break;
-		}
-	}
+        // Terminate loop on error
+        if (Result != OK && Result != NONEMBEDDABLE)
+        {
+            ErrorMessage("\nError found\n");
+            Result = NOTOK;
+            break;
+        }
+    }
 
-	// Stop the timer
-	platform_GetTime(end);
+    // Stop the timer
+    platform_GetTime(end);
 
-	// Finish the count
-	fprintf(stdout, "%d\n", NumGraphs);
-	fflush(stdout);
+    // Finish the count
+    fprintf(stdout, "%d\n", NumGraphs);
+    fflush(stdout);
 
-	if (pG6WriteIterator != NULL)
-	{
-		if (endG6WriteIteration(pG6WriteIterator) != OK && freeG6WriteIterator(&pG6WriteIterator) != OK)
-		{
-			ErrorMessage("Unable to properly terminate .g6 write iteration.\n");
-		}
-	}
-	// Free the graph structures created before the loop
-	gp_Free(&theGraph);
-	gp_Free(&origGraph);
+    if (pG6WriteIterator != NULL)
+    {
+        if (endG6WriteIteration(pG6WriteIterator) != OK && freeG6WriteIterator(&pG6WriteIterator) != OK)
+        {
+            ErrorMessage("Unable to properly terminate .g6 write iteration.\n");
+        }
+    }
+    // Free the graph structures created before the loop
+    gp_Free(&theGraph);
+    gp_Free(&origGraph);
 
-	// Print some demographic results
-	if (Result == OK || Result == NONEMBEDDABLE)
-		Message("\nNo Errors Found.");
+    // Print some demographic results
+    if (Result == OK || Result == NONEMBEDDABLE)
+        Message("\nNo Errors Found.");
 
-	sprintf(messageContents, "\nDone (%.3lf seconds).\n", platform_GetDuration(start, end));
-	Message(messageContents);
+    sprintf(messageContents, "\nDone (%.3lf seconds).\n", platform_GetDuration(start, end));
+    Message(messageContents);
 
-	// Report statistics for planar or outerplanar embedding
-	if (embedFlags == EMBEDFLAGS_PLANAR || embedFlags == EMBEDFLAGS_OUTERPLANAR)
-	{
-		sprintf(messageContents, "Num Embedded=%d.\n", MainStatistic);
-		Message(messageContents);
+    // Report statistics for planar or outerplanar embedding
+    if (embedFlags == EMBEDFLAGS_PLANAR || embedFlags == EMBEDFLAGS_OUTERPLANAR)
+    {
+        sprintf(messageContents, "Num Embedded=%d.\n", MainStatistic);
+        Message(messageContents);
 
-		for (K = 0; K < 5; K++)
-		{
-			// Outerplanarity does not produces minors C and D
-			if (embedFlags == EMBEDFLAGS_OUTERPLANAR && (K == 2 || K == 3))
-				continue;
+        for (K = 0; K < 5; K++)
+        {
+            // Outerplanarity does not produces minors C and D
+            if (embedFlags == EMBEDFLAGS_OUTERPLANAR && (K == 2 || K == 3))
+                continue;
 
-			sprintf(messageContents, "Minor %c = %d\n", K + 'A', ObstructionMinorFreqs[K]);
-			Message(messageContents);
-		}
+            sprintf(messageContents, "Minor %c = %d\n", K + 'A', ObstructionMinorFreqs[K]);
+            Message(messageContents);
+        }
 
-		if (!(embedFlags & ~EMBEDFLAGS_PLANAR))
-		{
-			sprintf(messageContents, "\nNote: E1 are added to C, E2 are added to A, and E=E3+E4+K5 homeomorphs.\n");
-			Message(messageContents);
+        if (!(embedFlags & ~EMBEDFLAGS_PLANAR))
+        {
+            sprintf(messageContents, "\nNote: E1 are added to C, E2 are added to A, and E=E3+E4+K5 homeomorphs.\n");
+            Message(messageContents);
 
-			for (K = 5; K < NUM_MINORS; K++)
-			{
-				sprintf(messageContents, "Minor E%d = %d\n", K - 4, ObstructionMinorFreqs[K]);
-				Message(messageContents);
-			}
-		}
-	}
+            for (K = 5; K < NUM_MINORS; K++)
+            {
+                sprintf(messageContents, "Minor E%d = %d\n", K - 4, ObstructionMinorFreqs[K]);
+                Message(messageContents);
+            }
+        }
+    }
 
-	// Report statistics for graph drawing
-	else if (embedFlags == EMBEDFLAGS_DRAWPLANAR)
-	{
-		sprintf(messageContents, "Num Graphs Embedded and Drawn=%d.\n", MainStatistic);
-		Message(messageContents);
-	}
+    // Report statistics for graph drawing
+    else if (embedFlags == EMBEDFLAGS_DRAWPLANAR)
+    {
+        sprintf(messageContents, "Num Graphs Embedded and Drawn=%d.\n", MainStatistic);
+        Message(messageContents);
+    }
 
-	// Report statistics for subgraph homeomorphism algorithms
-	else if (embedFlags == EMBEDFLAGS_SEARCHFORK23)
-	{
-		sprintf(messageContents, "Of the generated graphs, %d did not contain a K_{2,3} homeomorph as a subgraph.\n", MainStatistic);
-		Message(messageContents);
-	}
-	else if (embedFlags == EMBEDFLAGS_SEARCHFORK33)
-	{
-		sprintf(messageContents, "Of the generated graphs, %d did not contain a K_{3,3} homeomorph as a subgraph.\n", MainStatistic);
-		Message(messageContents);
-	}
-	else if (embedFlags == EMBEDFLAGS_SEARCHFORK4)
-	{
-		sprintf(messageContents, "Of the generated graphs, %d did not contain a K_4 homeomorph as a subgraph.\n", MainStatistic);
-		Message(messageContents);
-	}
+    // Report statistics for subgraph homeomorphism algorithms
+    else if (embedFlags == EMBEDFLAGS_SEARCHFORK23)
+    {
+        sprintf(messageContents, "Of the generated graphs, %d did not contain a K_{2,3} homeomorph as a subgraph.\n", MainStatistic);
+        Message(messageContents);
+    }
+    else if (embedFlags == EMBEDFLAGS_SEARCHFORK33)
+    {
+        sprintf(messageContents, "Of the generated graphs, %d did not contain a K_{3,3} homeomorph as a subgraph.\n", MainStatistic);
+        Message(messageContents);
+    }
+    else if (embedFlags == EMBEDFLAGS_SEARCHFORK4)
+    {
+        sprintf(messageContents, "Of the generated graphs, %d did not contain a K_4 homeomorph as a subgraph.\n", MainStatistic);
+        Message(messageContents);
+    }
 
-	FlushConsole(stdout);
+    FlushConsole(stdout);
 
-	return Result == OK || Result == NONEMBEDDABLE ? OK : NOTOK;
+    return Result == OK || Result == NONEMBEDDABLE ? OK : NOTOK;
 }
 
 /****************************************************************************
@@ -355,24 +355,24 @@ int RandomGraphs(char command, int NumGraphs, int SizeOfGraphs, char *outfileNam
 
 void GetNumberIfZero(int *pNum, char *prompt, int min, int max)
 {
-	if (*pNum == 0)
-	{
-		Prompt(prompt);
-		scanf(" %d", pNum);
-	}
+    if (*pNum == 0)
+    {
+        Prompt(prompt);
+        scanf(" %d", pNum);
+    }
 
-	if (min < 1)
-		min = 1;
-	if (max < min)
-		max = min;
+    if (min < 1)
+        min = 1;
+    if (max < min)
+        max = min;
 
-	if (*pNum < min || *pNum > max)
-	{
-		*pNum = (max + min) / 2;
-		char messageContents[MAXLINE + 1];
-		sprintf(messageContents, "Number out of range [%d, %d]; changed to %d\n", min, max, *pNum);
-		ErrorMessage(messageContents);
-	}
+    if (*pNum < min || *pNum > max)
+    {
+        *pNum = (max + min) / 2;
+        char messageContents[MAXLINE + 1];
+        sprintf(messageContents, "Number out of range [%d, %d]; changed to %d\n", min, max, *pNum);
+        ErrorMessage(messageContents);
+    }
 }
 
 /****************************************************************************
@@ -383,36 +383,36 @@ void GetNumberIfZero(int *pNum, char *prompt, int min, int max)
 
 graphP MakeGraph(int Size, char command)
 {
-	graphP theGraph;
-	if ((theGraph = gp_New()) == NULL || gp_InitGraph(theGraph, Size) != OK)
-	{
-		ErrorMessage("Error creating space for a graph of the given size.\n");
-		gp_Free(&theGraph);
-		return NULL;
-	}
+    graphP theGraph;
+    if ((theGraph = gp_New()) == NULL || gp_InitGraph(theGraph, Size) != OK)
+    {
+        ErrorMessage("Error creating space for a graph of the given size.\n");
+        gp_Free(&theGraph);
+        return NULL;
+    }
 
-	// Enable the appropriate feature. Although the same code appears in SpecificGraph,
-	// it is deliberately not separated to a common utility because SpecificGraph is
-	// used as a self-contained tutorial.  It is not that hard to update both locations
-	// when new algorithms are added.
+    // Enable the appropriate feature. Although the same code appears in SpecificGraph,
+    // it is deliberately not separated to a common utility because SpecificGraph is
+    // used as a self-contained tutorial.  It is not that hard to update both locations
+    // when new algorithms are added.
 
-	switch (command)
-	{
-	case 'd':
-		gp_AttachDrawPlanar(theGraph);
-		break;
-	case '2':
-		gp_AttachK23Search(theGraph);
-		break;
-	case '3':
-		gp_AttachK33Search(theGraph);
-		break;
-	case '4':
-		gp_AttachK4Search(theGraph);
-		break;
-	}
+    switch (command)
+    {
+    case 'd':
+        gp_AttachDrawPlanar(theGraph);
+        break;
+    case '2':
+        gp_AttachK23Search(theGraph);
+        break;
+    case '3':
+        gp_AttachK33Search(theGraph);
+        break;
+    case '4':
+        gp_AttachK4Search(theGraph);
+        break;
+    }
 
-	return theGraph;
+    return theGraph;
 }
 
 /****************************************************************************
@@ -423,14 +423,14 @@ graphP MakeGraph(int Size, char command)
 
 void ReinitializeGraph(graphP *pGraph, int ReuseGraphs, char command)
 {
-	if (ReuseGraphs)
-		gp_ReinitializeGraph(*pGraph);
-	else
-	{
-		graphP newGraph = MakeGraph((*pGraph)->N, command);
-		gp_Free(pGraph);
-		*pGraph = newGraph;
-	}
+    if (ReuseGraphs)
+        gp_ReinitializeGraph(*pGraph);
+    else
+    {
+        graphP newGraph = MakeGraph((*pGraph)->N, command);
+        gp_Free(pGraph);
+        *pGraph = newGraph;
+    }
 }
 
 /****************************************************************************
@@ -439,109 +439,109 @@ void ReinitializeGraph(graphP *pGraph, int ReuseGraphs, char command)
 
 int RandomGraph(char command, int extraEdges, int numVertices, char *outfileName, char *outfile2Name)
 {
-	int Result;
-	platform_time start, end;
-	graphP theGraph = NULL, origGraph;
-	int embedFlags = GetEmbedFlags(command);
-	char saveEdgeListFormat;
+    int Result;
+    platform_time start, end;
+    graphP theGraph = NULL, origGraph;
+    int embedFlags = GetEmbedFlags(command);
+    char saveEdgeListFormat;
 
-	char *messageFormat = NULL;
-	char messageContents[MAXLINE + 1];
-	int charsAvailForStr = 0;
+    char *messageFormat = NULL;
+    char messageContents[MAXLINE + 1];
+    int charsAvailForStr = 0;
 
-	GetNumberIfZero(&numVertices, "Enter number of vertices:", 1, 1000000);
-	if ((theGraph = MakeGraph(numVertices, command)) == NULL)
-		return NOTOK;
+    GetNumberIfZero(&numVertices, "Enter number of vertices:", 1, 1000000);
+    if ((theGraph = MakeGraph(numVertices, command)) == NULL)
+        return NOTOK;
 
-	srand(time(NULL));
+    srand(time(NULL));
 
-	Message("Creating the random graph...\n");
-	platform_GetTime(start);
-	if (gp_CreateRandomGraphEx(theGraph, 3 * numVertices - 6 + extraEdges) != OK)
-	{
-		ErrorMessage("gp_CreateRandomGraphEx() failed\n");
-		return NOTOK;
-	}
-	platform_GetTime(end);
+    Message("Creating the random graph...\n");
+    platform_GetTime(start);
+    if (gp_CreateRandomGraphEx(theGraph, 3 * numVertices - 6 + extraEdges) != OK)
+    {
+        ErrorMessage("gp_CreateRandomGraphEx() failed\n");
+        return NOTOK;
+    }
+    platform_GetTime(end);
 
-	sprintf(messageContents, "Created random graph with %d edges in %.3lf seconds. ", theGraph->M, platform_GetDuration(start, end));
-	Message(messageContents);
-	FlushConsole(stdout);
+    sprintf(messageContents, "Created random graph with %d edges in %.3lf seconds. ", theGraph->M, platform_GetDuration(start, end));
+    Message(messageContents);
+    FlushConsole(stdout);
 
-	// The user may have requested a copy of the random graph before processing
-	if (outfile2Name != NULL)
-	{
-		gp_Write(theGraph, outfile2Name, WRITE_ADJLIST);
-	}
+    // The user may have requested a copy of the random graph before processing
+    if (outfile2Name != NULL)
+    {
+        gp_Write(theGraph, outfile2Name, WRITE_ADJLIST);
+    }
 
-	origGraph = gp_DupGraph(theGraph);
+    origGraph = gp_DupGraph(theGraph);
 
-	// Do the requested algorithm on the randomly generated graph
-	Message("Now processing\n");
-	FlushConsole(stdout);
+    // Do the requested algorithm on the randomly generated graph
+    Message("Now processing\n");
+    FlushConsole(stdout);
 
-	if (strchr(GetAlgorithmChoices(), command))
-	{
-		platform_GetTime(start);
-		Result = gp_Embed(theGraph, embedFlags);
-		platform_GetTime(end);
+    if (strchr(GetAlgorithmChoices(), command))
+    {
+        platform_GetTime(start);
+        Result = gp_Embed(theGraph, embedFlags);
+        platform_GetTime(end);
 
-		gp_SortVertices(theGraph);
+        gp_SortVertices(theGraph);
 
-		if (gp_TestEmbedResultIntegrity(theGraph, origGraph, Result) != Result)
-			Result = NOTOK;
-	}
-	else
-		Result = NOTOK;
+        if (gp_TestEmbedResultIntegrity(theGraph, origGraph, Result) != Result)
+            Result = NOTOK;
+    }
+    else
+        Result = NOTOK;
 
-	// Write what the algorithm determined and how long it took
-	WriteAlgorithmResults(theGraph, Result, command, start, end, NULL);
+    // Write what the algorithm determined and how long it took
+    WriteAlgorithmResults(theGraph, Result, command, start, end, NULL);
 
-	// On successful algorithm result, write the output file and see if the
-	// user wants the edge list formatted file.
-	if (Result == OK || Result == NONEMBEDDABLE)
-	{
-		if (outfileName != NULL)
-			gp_Write(theGraph, outfileName, WRITE_ADJLIST);
+    // On successful algorithm result, write the output file and see if the
+    // user wants the edge list formatted file.
+    if (Result == OK || Result == NONEMBEDDABLE)
+    {
+        if (outfileName != NULL)
+            gp_Write(theGraph, outfileName, WRITE_ADJLIST);
 
-		if (!getQuietModeSetting())
-		{
-			Prompt("Do you want to save the generated graph in edge list format (y/n)? ");
-			fflush(stdin);
-			scanf(" %c", &saveEdgeListFormat);
-		}
-		else
-			saveEdgeListFormat = 'n';
+        if (!getQuietModeSetting())
+        {
+            Prompt("Do you want to save the generated graph in edge list format (y/n)? ");
+            fflush(stdin);
+            scanf(" %c", &saveEdgeListFormat);
+        }
+        else
+            saveEdgeListFormat = 'n';
 
-		if (tolower(saveEdgeListFormat) == 'y')
-		{
-			char theFileName[256];
+        if (tolower(saveEdgeListFormat) == 'y')
+        {
+            char theFileName[256];
 
-			if (extraEdges > 0)
-				strcpy(theFileName, "nonPlanarEdgeList.txt");
-			else
-				strcpy(theFileName, "maxPlanarEdgeList.txt");
+            if (extraEdges > 0)
+                strcpy(theFileName, "nonPlanarEdgeList.txt");
+            else
+                strcpy(theFileName, "maxPlanarEdgeList.txt");
 
-			messageFormat = "Saving edge list format of original graph to \"%.*s\"\n";
-			charsAvailForStr = (int)(MAXLINE - strlen(messageFormat));
-			sprintf(messageContents, messageFormat, charsAvailForStr, theFileName);
-			Message(messageContents);
-			SaveAsciiGraph(origGraph, theFileName);
+            messageFormat = "Saving edge list format of original graph to \"%.*s\"\n";
+            charsAvailForStr = (int)(MAXLINE - strlen(messageFormat));
+            sprintf(messageContents, messageFormat, charsAvailForStr, theFileName);
+            Message(messageContents);
+            SaveAsciiGraph(origGraph, theFileName);
 
-			strcat(theFileName, ".out.txt");
-			messageFormat = "Saving edge list format of result to \"%.*s\"\n";
-			charsAvailForStr = (int)(MAXLINE - strlen(messageFormat));
-			sprintf(messageContents, messageFormat, charsAvailForStr, theFileName);
-			Message(messageContents);
-			SaveAsciiGraph(theGraph, theFileName);
-		}
-	}
-	else
-		ErrorMessage("Failure occurred");
+            strcat(theFileName, ".out.txt");
+            messageFormat = "Saving edge list format of result to \"%.*s\"\n";
+            charsAvailForStr = (int)(MAXLINE - strlen(messageFormat));
+            sprintf(messageContents, messageFormat, charsAvailForStr, theFileName);
+            Message(messageContents);
+            SaveAsciiGraph(theGraph, theFileName);
+        }
+    }
+    else
+        ErrorMessage("Failure occurred");
 
-	gp_Free(&theGraph);
-	gp_Free(&origGraph);
+    gp_Free(&theGraph);
+    gp_Free(&origGraph);
 
-	FlushConsole(stdout);
-	return Result;
+    FlushConsole(stdout);
+    return Result;
 }

--- a/c/planarityApp/planarityTestAllGraphs.c
+++ b/c/planarityApp/planarityTestAllGraphs.c
@@ -8,11 +8,11 @@ See the LICENSE.TXT file for licensing information.
 
 typedef struct
 {
-	double duration;
-	int numGraphsRead;
-	int numOK;
-	int numNONEMBEDDABLE;
-	int errorFlag;
+    double duration;
+    int numGraphsRead;
+    int numOK;
+    int numNONEMBEDDABLE;
+    int errorFlag;
 } testAllStats;
 
 typedef testAllStats *testAllStatsP;
@@ -30,391 +30,391 @@ int outputTestAllGraphsResults(char command, testAllStatsP stats, char *infileNa
  ****************************************************************************/
 int TestAllGraphs(char *commandString, char *infileName, char *outfileName, char **outputStr)
 {
-	int Result = OK;
-	platform_time start, end;
+    int Result = OK;
+    platform_time start, end;
 
-	int charsAvailForFilename = 0;
-	char *messageFormat = NULL;
-	char messageContents[MAXLINE + 1];
-	messageContents[MAXLINE] = '\0';
+    int charsAvailForFilename = 0;
+    char *messageFormat = NULL;
+    char messageContents[MAXLINE + 1];
+    messageContents[MAXLINE] = '\0';
 
-	graphP theGraph;
+    graphP theGraph;
 
-	// Create the graph and, if needed, attach the correct algorithm to it
-	theGraph = gp_New();
+    // Create the graph and, if needed, attach the correct algorithm to it
+    theGraph = gp_New();
 
-	if (commandString[0] == '-')
-	{
-		if (strchr(GetAlgorithmChoices(), commandString[1]))
-		{
-			if (infileName == NULL)
-			{
-				ErrorMessage("No input file provided.\n");
-				Result = NOTOK;
-			}
-			else
-			{
-				messageFormat = "Start testing all graphs in \"%.*s\".\n";
-				charsAvailForFilename = (int)(MAXLINE - strlen(messageFormat));
-				sprintf(messageContents, messageFormat, charsAvailForFilename, infileName);
-				Message(messageContents);
+    if (commandString[0] == '-')
+    {
+        if (strchr(GetAlgorithmChoices(), commandString[1]))
+        {
+            if (infileName == NULL)
+            {
+                ErrorMessage("No input file provided.\n");
+                Result = NOTOK;
+            }
+            else
+            {
+                messageFormat = "Start testing all graphs in \"%.*s\".\n";
+                charsAvailForFilename = (int)(MAXLINE - strlen(messageFormat));
+                sprintf(messageContents, messageFormat, charsAvailForFilename, infileName);
+                Message(messageContents);
 
-				// Start the timer
-				platform_GetTime(start);
+                // Start the timer
+                platform_GetTime(start);
 
-				FILE *infile = fopen(infileName, "r");
-				if (infile == NULL)
-				{
-					messageFormat = "Unable to open file \"%.*s\" for input.\n";
-					charsAvailForFilename = (int)(MAXLINE - strlen(messageFormat));
-					sprintf(messageContents, messageFormat, charsAvailForFilename, infileName);
-					ErrorMessage(messageContents);
+                FILE *infile = fopen(infileName, "r");
+                if (infile == NULL)
+                {
+                    messageFormat = "Unable to open file \"%.*s\" for input.\n";
+                    charsAvailForFilename = (int)(MAXLINE - strlen(messageFormat));
+                    sprintf(messageContents, messageFormat, charsAvailForFilename, infileName);
+                    ErrorMessage(messageContents);
 
-					gp_Free(&theGraph);
+                    gp_Free(&theGraph);
 
-					return NOTOK;
-				}
+                    return NOTOK;
+                }
 
-				testAllStats stats;
-				memset(&stats, 0, sizeof(testAllStats));
+                testAllStats stats;
+                memset(&stats, 0, sizeof(testAllStats));
 
-				char command = commandString[1];
-				Result = testAllGraphs(theGraph, command, infile, &stats);
+                char command = commandString[1];
+                Result = testAllGraphs(theGraph, command, infile, &stats);
 
-				// Stop the timer
-				platform_GetTime(end);
-				stats.duration = platform_GetDuration(start, end);
+                // Stop the timer
+                platform_GetTime(end);
+                stats.duration = platform_GetDuration(start, end);
 
-				if (Result != OK && Result != NONEMBEDDABLE)
-				{
-					messageFormat = "\nEncountered error while running command '%c' on all graphs in \"%.*s\".\n";
-					charsAvailForFilename = (int)(MAXLINE - strlen(messageFormat));
-					sprintf(messageContents, messageFormat, command, charsAvailForFilename, infileName);
-					ErrorMessage(messageContents);
-				}
-				else
-				{
-					sprintf(messageContents, "\nDone testing all graphs (%.3lf seconds).\n", stats.duration);
-					Message(messageContents);
-				}
+                if (Result != OK && Result != NONEMBEDDABLE)
+                {
+                    messageFormat = "\nEncountered error while running command '%c' on all graphs in \"%.*s\".\n";
+                    charsAvailForFilename = (int)(MAXLINE - strlen(messageFormat));
+                    sprintf(messageContents, messageFormat, command, charsAvailForFilename, infileName);
+                    ErrorMessage(messageContents);
+                }
+                else
+                {
+                    sprintf(messageContents, "\nDone testing all graphs (%.3lf seconds).\n", stats.duration);
+                    Message(messageContents);
+                }
 
-				if (outputTestAllGraphsResults(command, &stats, infileName, outfileName, outputStr) != OK)
-				{
-					messageFormat = "Error outputting results running command '%c' on all graphs in \"%.*s\".\n";
-					charsAvailForFilename = (int)(MAXLINE - strlen(messageFormat));
-					sprintf(messageContents, messageFormat, command, charsAvailForFilename, infileName);
-					ErrorMessage(messageContents);
-					Result = NOTOK;
-				}
-			}
-		}
-		else
-		{
-			ErrorMessage("Invalid argument; only -(pdo234) is allowed.\n");
-			Result = NOTOK;
-		}
-	}
-	else
-	{
-		ErrorMessage("Invalid argument; must start with '-'.\n");
-		Result = NOTOK;
-	}
+                if (outputTestAllGraphsResults(command, &stats, infileName, outfileName, outputStr) != OK)
+                {
+                    messageFormat = "Error outputting results running command '%c' on all graphs in \"%.*s\".\n";
+                    charsAvailForFilename = (int)(MAXLINE - strlen(messageFormat));
+                    sprintf(messageContents, messageFormat, command, charsAvailForFilename, infileName);
+                    ErrorMessage(messageContents);
+                    Result = NOTOK;
+                }
+            }
+        }
+        else
+        {
+            ErrorMessage("Invalid argument; only -(pdo234) is allowed.\n");
+            Result = NOTOK;
+        }
+    }
+    else
+    {
+        ErrorMessage("Invalid argument; must start with '-'.\n");
+        Result = NOTOK;
+    }
 
-	gp_Free(&theGraph);
-	return Result;
+    gp_Free(&theGraph);
+    return Result;
 }
 
 int testAllGraphs(graphP theGraph, char command, FILE *infile, testAllStatsP stats)
 {
-	int Result = OK;
+    int Result = OK;
 
-	char *messageFormat = NULL;
-	char messageContents[MAXLINE + 1];
-	messageContents[MAXLINE] = '\0';
+    char *messageFormat = NULL;
+    char messageContents[MAXLINE + 1];
+    messageContents[MAXLINE] = '\0';
 
-	graphP copyOfOrigGraph = NULL;
-	int embedFlags = GetEmbedFlags(command);
-	int numOK = 0, numNONEMBEDDABLE = 0, errorFlag = FALSE;
+    graphP copyOfOrigGraph = NULL;
+    int embedFlags = GetEmbedFlags(command);
+    int numOK = 0, numNONEMBEDDABLE = 0, errorFlag = FALSE;
 
-	G6ReadIterator *pG6ReadIterator = NULL;
-	Result = allocateG6ReadIterator(&pG6ReadIterator, theGraph);
+    G6ReadIterator *pG6ReadIterator = NULL;
+    Result = allocateG6ReadIterator(&pG6ReadIterator, theGraph);
 
-	if (Result != OK)
-	{
-		ErrorMessage("Unable to allocate G6ReadIterator.\n");
-		stats->errorFlag = TRUE;
-		return Result;
-	}
+    if (Result != OK)
+    {
+        ErrorMessage("Unable to allocate G6ReadIterator.\n");
+        stats->errorFlag = TRUE;
+        return Result;
+    }
 
-	Result = beginG6ReadIterationFromG6FilePointer(pG6ReadIterator, infile);
+    Result = beginG6ReadIterationFromG6FilePointer(pG6ReadIterator, infile);
 
-	if (Result != OK)
-	{
-		ErrorMessage("Unable to begin .g6 read iteration.\n");
-		freeG6ReadIterator(&pG6ReadIterator);
-		stats->errorFlag = TRUE;
-		return Result;
-	}
+    if (Result != OK)
+    {
+        ErrorMessage("Unable to begin .g6 read iteration.\n");
+        freeG6ReadIterator(&pG6ReadIterator);
+        stats->errorFlag = TRUE;
+        return Result;
+    }
 
-	int graphOrder = pG6ReadIterator->graphOrder;
-	// We have to set the maximum arc capacity (i.e. (N * (N - 1))) because some of the test files
-	// can contain complete graphs, and the graph drawing, K_{3, 3} search, and K_4 search extensions
-	// don't support expanding the arc capacity after being attached.
-	if (strchr("d34", command) != NULL)
-	{
-		Result = gp_EnsureArcCapacity(pG6ReadIterator->currGraph, (graphOrder * (graphOrder - 1)));
-		if (Result != OK)
-		{
-			ErrorMessage("Unable to maximize arc capacity of G6ReadIterator's graph struct.\n");
-			freeG6ReadIterator(&pG6ReadIterator);
-			stats->errorFlag = TRUE;
-			return Result;
-		}
-	}
+    int graphOrder = pG6ReadIterator->graphOrder;
+    // We have to set the maximum arc capacity (i.e. (N * (N - 1))) because some of the test files
+    // can contain complete graphs, and the graph drawing, K_{3, 3} search, and K_4 search extensions
+    // don't support expanding the arc capacity after being attached.
+    if (strchr("d34", command) != NULL)
+    {
+        Result = gp_EnsureArcCapacity(pG6ReadIterator->currGraph, (graphOrder * (graphOrder - 1)));
+        if (Result != OK)
+        {
+            ErrorMessage("Unable to maximize arc capacity of G6ReadIterator's graph struct.\n");
+            freeG6ReadIterator(&pG6ReadIterator);
+            stats->errorFlag = TRUE;
+            return Result;
+        }
+    }
 
-	AttachAlgorithm(pG6ReadIterator->currGraph, command);
+    AttachAlgorithm(pG6ReadIterator->currGraph, command);
 
-	copyOfOrigGraph = gp_New();
-	if (copyOfOrigGraph == NULL)
-	{
-		ErrorMessage("Unable to allocate graph to store copy of original graph before embedding.\n");
-		stats->errorFlag = TRUE;
-		return NOTOK;
-	}
+    copyOfOrigGraph = gp_New();
+    if (copyOfOrigGraph == NULL)
+    {
+        ErrorMessage("Unable to allocate graph to store copy of original graph before embedding.\n");
+        stats->errorFlag = TRUE;
+        return NOTOK;
+    }
 
-	Result = gp_InitGraph(copyOfOrigGraph, graphOrder);
-	if (Result != OK)
-	{
-		ErrorMessage("Unable to initialize graph datastructure to store copy of original graph before embedding.\n");
-		gp_Free(&copyOfOrigGraph);
-		freeG6ReadIterator(&pG6ReadIterator);
-		stats->errorFlag = TRUE;
-		return Result;
-	}
+    Result = gp_InitGraph(copyOfOrigGraph, graphOrder);
+    if (Result != OK)
+    {
+        ErrorMessage("Unable to initialize graph datastructure to store copy of original graph before embedding.\n");
+        gp_Free(&copyOfOrigGraph);
+        freeG6ReadIterator(&pG6ReadIterator);
+        stats->errorFlag = TRUE;
+        return Result;
+    }
 
-	if (strchr("d34", command) != NULL)
-	{
-		Result = gp_EnsureArcCapacity(copyOfOrigGraph, (graphOrder * (graphOrder - 1)));
-		if (Result != OK)
-		{
-			ErrorMessage("Unable to maximize arc capacity of graph struct to contain copy of original graph.\n");
-			gp_Free(&copyOfOrigGraph);
-			freeG6ReadIterator(&pG6ReadIterator);
-			stats->errorFlag = TRUE;
-			return Result;
-		}
-	}
+    if (strchr("d34", command) != NULL)
+    {
+        Result = gp_EnsureArcCapacity(copyOfOrigGraph, (graphOrder * (graphOrder - 1)));
+        if (Result != OK)
+        {
+            ErrorMessage("Unable to maximize arc capacity of graph struct to contain copy of original graph.\n");
+            gp_Free(&copyOfOrigGraph);
+            freeG6ReadIterator(&pG6ReadIterator);
+            stats->errorFlag = TRUE;
+            return Result;
+        }
+    }
 
-	while (true)
-	{
-		Result = readGraphUsingG6ReadIterator(pG6ReadIterator);
+    while (true)
+    {
+        Result = readGraphUsingG6ReadIterator(pG6ReadIterator);
 
-		if (Result != OK)
-		{
-			messageFormat = "Unable to read graph on line %d from .g6 read iterator.\n";
-			sprintf(messageContents, messageFormat, pG6ReadIterator->numGraphsRead + 1);
-			ErrorMessage(messageContents);
-			errorFlag = TRUE;
-			break;
-		}
+        if (Result != OK)
+        {
+            messageFormat = "Unable to read graph on line %d from .g6 read iterator.\n";
+            sprintf(messageContents, messageFormat, pG6ReadIterator->numGraphsRead + 1);
+            ErrorMessage(messageContents);
+            errorFlag = TRUE;
+            break;
+        }
 
-		if (pG6ReadIterator->currGraph == NULL)
-			break;
+        if (pG6ReadIterator->currGraph == NULL)
+            break;
 
-		gp_CopyGraph(copyOfOrigGraph, pG6ReadIterator->currGraph);
+        gp_CopyGraph(copyOfOrigGraph, pG6ReadIterator->currGraph);
 
-		Result = gp_Embed(pG6ReadIterator->currGraph, embedFlags);
+        Result = gp_Embed(pG6ReadIterator->currGraph, embedFlags);
 
-		if (gp_TestEmbedResultIntegrity(pG6ReadIterator->currGraph, copyOfOrigGraph, Result) != Result)
-			Result = NOTOK;
+        if (gp_TestEmbedResultIntegrity(pG6ReadIterator->currGraph, copyOfOrigGraph, Result) != Result)
+            Result = NOTOK;
 
-		if (Result == OK)
-			numOK++;
-		else if (Result == NONEMBEDDABLE)
-			numNONEMBEDDABLE++;
-		else
-		{
-			messageFormat = "Error applying algorithm '%c' to graph on line %d.\n";
-			sprintf(messageContents, messageFormat, command, pG6ReadIterator->numGraphsRead + 1);
-			ErrorMessage(messageContents);
-			errorFlag = TRUE;
-			break;
-		}
+        if (Result == OK)
+            numOK++;
+        else if (Result == NONEMBEDDABLE)
+            numNONEMBEDDABLE++;
+        else
+        {
+            messageFormat = "Error applying algorithm '%c' to graph on line %d.\n";
+            sprintf(messageContents, messageFormat, command, pG6ReadIterator->numGraphsRead + 1);
+            ErrorMessage(messageContents);
+            errorFlag = TRUE;
+            break;
+        }
 
-		gp_ReinitializeGraph(copyOfOrigGraph);
-	}
+        gp_ReinitializeGraph(copyOfOrigGraph);
+    }
 
-	stats->numGraphsRead = pG6ReadIterator->numGraphsRead;
-	stats->numOK = numOK;
-	stats->numNONEMBEDDABLE = numNONEMBEDDABLE;
-	stats->errorFlag = errorFlag;
+    stats->numGraphsRead = pG6ReadIterator->numGraphsRead;
+    stats->numOK = numOK;
+    stats->numNONEMBEDDABLE = numNONEMBEDDABLE;
+    stats->errorFlag = errorFlag;
 
-	if (endG6ReadIteration(pG6ReadIterator) != OK)
-		ErrorMessage("Unable to end G6ReadIterator.\n");
+    if (endG6ReadIteration(pG6ReadIterator) != OK)
+        ErrorMessage("Unable to end G6ReadIterator.\n");
 
-	if (freeG6ReadIterator(&pG6ReadIterator) != OK)
-		ErrorMessage("Unable to free G6ReadIterator.\n");
+    if (freeG6ReadIterator(&pG6ReadIterator) != OK)
+        ErrorMessage("Unable to free G6ReadIterator.\n");
 
-	gp_Free(&copyOfOrigGraph);
+    gp_Free(&copyOfOrigGraph);
 
-	return Result;
+    return Result;
 }
 
 int outputTestAllGraphsResults(char command, testAllStatsP stats, char *infileName, char *outfileName, char **outputStr)
 {
-	int Result = OK;
+    int Result = OK;
 
-	int charsAvailForFilename = 0;
-	char *messageFormat = NULL;
-	char messageContents[MAXLINE + 1];
+    int charsAvailForFilename = 0;
+    char *messageFormat = NULL;
+    char messageContents[MAXLINE + 1];
 
-	char *finalSlash = strrchr(infileName, FILE_DELIMITER);
-	char *infileBasename = finalSlash ? (finalSlash + 1) : infileName;
+    char *finalSlash = strrchr(infileName, FILE_DELIMITER);
+    char *infileBasename = finalSlash ? (finalSlash + 1) : infileName;
 
-	char *headerFormat = "FILENAME=\"%s\" DURATION=\"%.3lf\"\n";
-	char *headerStr = (char *)malloc(
-		(
-			strlen(headerFormat) +
-			strlen(infileBasename) +
-			strlen("-1.7976931348623158e+308") + // -DBL_MAX from float.h
-			3) *
-		sizeof(char));
-	if (headerStr == NULL)
-	{
-		ErrorMessage("Unable allocate memory for output file header.\n");
-		return NOTOK;
-	}
+    char *headerFormat = "FILENAME=\"%s\" DURATION=\"%.3lf\"\n";
+    char *headerStr = (char *)malloc(
+        (
+            strlen(headerFormat) +
+            strlen(infileBasename) +
+            strlen("-1.7976931348623158e+308") + // -DBL_MAX from float.h
+            3) *
+        sizeof(char));
+    if (headerStr == NULL)
+    {
+        ErrorMessage("Unable allocate memory for output file header.\n");
+        return NOTOK;
+    }
 
-	sprintf(headerStr, headerFormat, infileBasename, stats->duration);
+    sprintf(headerStr, headerFormat, infileBasename, stats->duration);
 
-	char *resultsStr = (char *)malloc(
-		(
-			3 + GetNumCharsToReprInt(stats->numGraphsRead) +
-			1 + GetNumCharsToReprInt(stats->numOK) +
-			1 + GetNumCharsToReprInt(stats->numNONEMBEDDABLE) +
-			1 + 8 + // either ERROR or SUCCESS, so the longer of which is 7 + 1 chars
-			3) *
-		sizeof(char));
-	if (resultsStr == NULL)
-	{
-		ErrorMessage("Unable allocate memory for results string.\n");
+    char *resultsStr = (char *)malloc(
+        (
+            3 + GetNumCharsToReprInt(stats->numGraphsRead) +
+            1 + GetNumCharsToReprInt(stats->numOK) +
+            1 + GetNumCharsToReprInt(stats->numNONEMBEDDABLE) +
+            1 + 8 + // either ERROR or SUCCESS, so the longer of which is 7 + 1 chars
+            3) *
+        sizeof(char));
+    if (resultsStr == NULL)
+    {
+        ErrorMessage("Unable allocate memory for results string.\n");
 
-		free(headerStr);
-		headerStr = NULL;
+        free(headerStr);
+        headerStr = NULL;
 
-		return NOTOK;
-	}
+        return NOTOK;
+    }
 
-	sprintf(resultsStr, "-%c %d %d %d %s\n",
-			command, stats->numGraphsRead, stats->numOK, stats->numNONEMBEDDABLE, stats->errorFlag ? "ERROR" : "SUCCESS");
+    sprintf(resultsStr, "-%c %d %d %d %s\n",
+            command, stats->numGraphsRead, stats->numOK, stats->numNONEMBEDDABLE, stats->errorFlag ? "ERROR" : "SUCCESS");
 
-	strOrFileP testOutput = NULL;
+    strOrFileP testOutput = NULL;
 
-	if (outfileName != NULL)
-	{
-		FILE *outputFileP = fopen(outfileName, "w");
-		if (outputFileP == NULL)
-		{
-			messageFormat = "Unable to open file \"%.*s\" for output.\n";
-			charsAvailForFilename = (int)(MAXLINE - strlen(messageFormat));
-			sprintf(messageContents, messageFormat, charsAvailForFilename, outfileName);
-			ErrorMessage(messageContents);
-		}
-		else
-		{
-			testOutput = sf_New(outputFileP, NULL);
-			if (testOutput == NULL)
-			{
-				fclose(outputFileP);
-				outputFileP = NULL;
-				// TODO: (#56) What happens to file that we opened for write, then immediately close? We won't be able to remove
-				// because testOutput failed to initialize
-			}
-		}
-	}
-	else
-	{
-		if (outputStr == NULL)
-		{
-			ErrorMessage("Both outfileName and pointer to outputStr are NULL.\n");
-		}
-		else
-		{
-			if ((*outputStr) != NULL)
-				ErrorMessage("Expected memory to which outputStr points to be NULL.\n");
-			else
-			{
-				(*outputStr) = (char *)malloc(1 * sizeof(char));
+    if (outfileName != NULL)
+    {
+        FILE *outputFileP = fopen(outfileName, "w");
+        if (outputFileP == NULL)
+        {
+            messageFormat = "Unable to open file \"%.*s\" for output.\n";
+            charsAvailForFilename = (int)(MAXLINE - strlen(messageFormat));
+            sprintf(messageContents, messageFormat, charsAvailForFilename, outfileName);
+            ErrorMessage(messageContents);
+        }
+        else
+        {
+            testOutput = sf_New(outputFileP, NULL);
+            if (testOutput == NULL)
+            {
+                fclose(outputFileP);
+                outputFileP = NULL;
+                // TODO: (#56) What happens to file that we opened for write, then immediately close? We won't be able to remove
+                // because testOutput failed to initialize
+            }
+        }
+    }
+    else
+    {
+        if (outputStr == NULL)
+        {
+            ErrorMessage("Both outfileName and pointer to outputStr are NULL.\n");
+        }
+        else
+        {
+            if ((*outputStr) != NULL)
+                ErrorMessage("Expected memory to which outputStr points to be NULL.\n");
+            else
+            {
+                (*outputStr) = (char *)malloc(1 * sizeof(char));
 
-				if ((*outputStr) == NULL)
-				{
-					ErrorMessage("Unable to allocate memory for outputStr.\n");
-				}
-				else
-				{
-					(*outputStr)[0] = '\0';
-					testOutput = sf_New(NULL, (*outputStr));
-				}
-			}
-		}
-	}
+                if ((*outputStr) == NULL)
+                {
+                    ErrorMessage("Unable to allocate memory for outputStr.\n");
+                }
+                else
+                {
+                    (*outputStr)[0] = '\0';
+                    testOutput = sf_New(NULL, (*outputStr));
+                }
+            }
+        }
+    }
 
-	if (testOutput == NULL)
-	{
-		ErrorMessage("Unable to set up string-or-file container for test output.\n");
+    if (testOutput == NULL)
+    {
+        ErrorMessage("Unable to set up string-or-file container for test output.\n");
 
-		free(headerStr);
-		headerStr = NULL;
+        free(headerStr);
+        headerStr = NULL;
 
-		free(resultsStr);
-		resultsStr = NULL;
+        free(resultsStr);
+        resultsStr = NULL;
 
-		if (outputStr != NULL && (*outputStr) != NULL)
-		{
-			free((*outputStr));
-			(*outputStr) = NULL;
-		}
+        if (outputStr != NULL && (*outputStr) != NULL)
+        {
+            free((*outputStr));
+            (*outputStr) = NULL;
+        }
 
-		return NOTOK;
-	}
+        return NOTOK;
+    }
 
-	if (sf_fputs(headerStr, testOutput) < 0)
-	{
-		ErrorMessage("Unable to output headerStr to testOutput.\n");
-		Result = NOTOK;
-	}
+    if (sf_fputs(headerStr, testOutput) < 0)
+    {
+        ErrorMessage("Unable to output headerStr to testOutput.\n");
+        Result = NOTOK;
+    }
 
-	if (Result == OK)
-	{
-		if (sf_fputs(resultsStr, testOutput) < 0)
-		{
-			ErrorMessage("Unable to output resultsStr to testOutput.\n");
-			Result = NOTOK;
-		}
-	}
+    if (Result == OK)
+    {
+        if (sf_fputs(resultsStr, testOutput) < 0)
+        {
+            ErrorMessage("Unable to output resultsStr to testOutput.\n");
+            Result = NOTOK;
+        }
+    }
 
-	if (Result == OK)
-	{
-		if (outputStr != NULL)
-			(*outputStr) = sf_takeTheStr(testOutput);
-	}
+    if (Result == OK)
+    {
+        if (outputStr != NULL)
+            (*outputStr) = sf_takeTheStr(testOutput);
+    }
 
-	free(headerStr);
-	headerStr = NULL;
+    free(headerStr);
+    headerStr = NULL;
 
-	free(resultsStr);
-	resultsStr = NULL;
+    free(resultsStr);
+    resultsStr = NULL;
 
-	if (sf_closeFile(testOutput) != OK)
-	{
-		messageFormat = "Unable to close output file \"%.*s\".\n";
-		charsAvailForFilename = (int)(MAXLINE - strlen(messageFormat));
-		sprintf(messageContents, messageFormat, charsAvailForFilename, outfileName);
-		ErrorMessage(messageContents);
-		Result = NOTOK;
-	}
+    if (sf_closeFile(testOutput) != OK)
+    {
+        messageFormat = "Unable to close output file \"%.*s\".\n";
+        charsAvailForFilename = (int)(MAXLINE - strlen(messageFormat));
+        sprintf(messageContents, messageFormat, charsAvailForFilename, outfileName);
+        ErrorMessage(messageContents);
+        Result = NOTOK;
+    }
 
-	sf_Free(&testOutput);
+    sf_Free(&testOutput);
 
-	return Result;
+    return Result;
 }

--- a/c/planarityApp/planarityTransformGraph.c
+++ b/c/planarityApp/planarityTransformGraph.c
@@ -22,81 +22,81 @@ int transformString(graphP theGraph, char *inputStr);
  ****************************************************************************/
 int TransformGraph(char *commandString, char *infileName, char *inputStr, int *outputBase, char *outfileName, char **outputStr)
 {
-	int Result = OK;
+    int Result = OK;
 
-	graphP theGraph;
+    graphP theGraph;
 
-	theGraph = gp_New();
+    theGraph = gp_New();
 
-	int outputFormat = -1;
+    int outputFormat = -1;
 
-	if (commandString[0] == '-')
-	{
-		if (commandString[1] == 'g')
-			outputFormat = WRITE_G6;
-		else if (commandString[1] == 'a')
-			outputFormat = WRITE_ADJLIST;
-		else if (commandString[1] == 'm')
-			outputFormat = WRITE_ADJMATRIX;
-		else
-		{
-			ErrorMessage("Invalid argument; only -(gam) is allowed.\n");
-			return NOTOK;
-		}
+    if (commandString[0] == '-')
+    {
+        if (commandString[1] == 'g')
+            outputFormat = WRITE_G6;
+        else if (commandString[1] == 'a')
+            outputFormat = WRITE_ADJLIST;
+        else if (commandString[1] == 'm')
+            outputFormat = WRITE_ADJMATRIX;
+        else
+        {
+            ErrorMessage("Invalid argument; only -(gam) is allowed.\n");
+            return NOTOK;
+        }
 
-		if (inputStr)
-			Result = transformString(theGraph, inputStr);
-		else
-			Result = transformFile(theGraph, infileName);
+        if (inputStr)
+            Result = transformString(theGraph, inputStr);
+        else
+            Result = transformFile(theGraph, infileName);
 
-		if (Result != OK)
-		{
-			ErrorMessage("Unable to transform input graph.\n");
-		}
-		else
-		{
-			// Want to know whether the output is 0- or 1-based; will always be
-			// 0-based for transformations of .g6 input
-			if (outputBase != NULL)
-				(*outputBase) = (theGraph->internalFlags & FLAGS_ZEROBASEDIO) ? 1 : 0;
+        if (Result != OK)
+        {
+            ErrorMessage("Unable to transform input graph.\n");
+        }
+        else
+        {
+            // Want to know whether the output is 0- or 1-based; will always be
+            // 0-based for transformations of .g6 input
+            if (outputBase != NULL)
+                (*outputBase) = (theGraph->internalFlags & FLAGS_ZEROBASEDIO) ? 1 : 0;
 
-			if (outputStr != NULL)
-				Result = gp_WriteToString(theGraph, outputStr, outputFormat);
-			else
-				Result = gp_Write(theGraph, outfileName, outputFormat);
+            if (outputStr != NULL)
+                Result = gp_WriteToString(theGraph, outputStr, outputFormat);
+            else
+                Result = gp_Write(theGraph, outfileName, outputFormat);
 
-			if (Result != OK)
-				ErrorMessage("Unable to write graph.\n");
-		}
-	}
-	else
-	{
-		ErrorMessage("Invalid argument; must start with '-'.\n");
-		Result = NOTOK;
-	}
+            if (Result != OK)
+                ErrorMessage("Unable to write graph.\n");
+        }
+    }
+    else
+    {
+        ErrorMessage("Invalid argument; must start with '-'.\n");
+        Result = NOTOK;
+    }
 
-	gp_Free(&theGraph);
-	return Result;
+    gp_Free(&theGraph);
+    return Result;
 }
 
 int transformFile(graphP theGraph, char *infileName)
 {
-	if (infileName == NULL)
-	{
-		if ((infileName = ConstructInputFilename(infileName)) == NULL)
-			return NOTOK;
-	}
+    if (infileName == NULL)
+    {
+        if ((infileName = ConstructInputFilename(infileName)) == NULL)
+            return NOTOK;
+    }
 
-	return gp_Read(theGraph, infileName);
+    return gp_Read(theGraph, infileName);
 }
 
 int transformString(graphP theGraph, char *inputStr)
 {
-	if (inputStr == NULL || strlen(inputStr) == 0)
-	{
-		ErrorMessage("Input string is null or empty.\n");
-		return NOTOK;
-	}
+    if (inputStr == NULL || strlen(inputStr) == 0)
+    {
+        ErrorMessage("Input string is null or empty.\n");
+        return NOTOK;
+    }
 
-	return gp_ReadFromString(theGraph, inputStr);
+    return gp_ReadFromString(theGraph, inputStr);
 }

--- a/c/planarityApp/planarityUtils.c
+++ b/c/planarityApp/planarityUtils.c
@@ -11,62 +11,62 @@ See the LICENSE.TXT file for licensing information.
  ****************************************************************************/
 
 char Mode = 'r',
-	 OrigOut = 'n',
-	 OrigOutFormat = 'a',
-	 EmbeddableOut = 'n',
-	 ObstructedOut = 'n',
-	 AdjListsForEmbeddingsOut = 'n';
+     OrigOut = 'n',
+     OrigOutFormat = 'a',
+     EmbeddableOut = 'n',
+     ObstructedOut = 'n',
+     AdjListsForEmbeddingsOut = 'n';
 
 void Reconfigure(void)
 {
-	fflush(stdin);
+    fflush(stdin);
 
-	Prompt("\nDo you want to \n"
-		   "  Randomly generate graphs (r),\n"
-		   "  Specify a graph (s),\n"
-		   "  Randomly generate a maximal planar graph (m), or\n"
-		   "  Randomly generate a non-planar graph (n)? ");
-	scanf(" %c", &Mode);
+    Prompt("\nDo you want to \n"
+           "  Randomly generate graphs (r),\n"
+           "  Specify a graph (s),\n"
+           "  Randomly generate a maximal planar graph (m), or\n"
+           "  Randomly generate a non-planar graph (n)? ");
+    scanf(" %c", &Mode);
 
-	Mode = tolower(Mode);
-	if (!strchr("rsmn", Mode))
-		Mode = 's';
+    Mode = tolower(Mode);
+    if (!strchr("rsmn", Mode))
+        Mode = 's';
 
-	if (Mode == 'r')
-	{
-		Message("\nNOTE: The directories for the graphs you want must exist.\n\n");
+    if (Mode == 'r')
+    {
+        Message("\nNOTE: The directories for the graphs you want must exist.\n\n");
 
-		Prompt("Do you want original graphs in directory 'random'? (y/n) ");
-		scanf(" %c", &OrigOut);
+        Prompt("Do you want original graphs in directory 'random'? (y/n) ");
+        scanf(" %c", &OrigOut);
 
-		if (tolower(OrigOut) == 'y')
-		{
-			Prompt("Do you want to output generated graphs to Adjacency List (last 10 only) or to G6 (all)? (a/g) ");
-			scanf(" %c", &OrigOutFormat);
-		}
+        if (tolower(OrigOut) == 'y')
+        {
+            Prompt("Do you want to output generated graphs to Adjacency List (last 10 only) or to G6 (all)? (a/g) ");
+            scanf(" %c", &OrigOutFormat);
+        }
 
-		Prompt("Do you want adj. matrix of embeddable graphs in directory 'embedded' (last 10 max))? (y/n) ");
-		scanf(" %c", &EmbeddableOut);
+        Prompt("Do you want adj. matrix of embeddable graphs in directory 'embedded' (last 10 max))? (y/n) ");
+        scanf(" %c", &EmbeddableOut);
 
-		Prompt("Do you want adj. matrix of obstructed graphs in directory 'obstructed' (last 10 max)? (y/n) ");
-		scanf(" %c", &ObstructedOut);
+        Prompt("Do you want adj. matrix of obstructed graphs in directory 'obstructed' (last 10 max)? (y/n) ");
+        scanf(" %c", &ObstructedOut);
 
-		Prompt("Do you want adjacency list format of embeddings in directory 'adjlist' (last 10 max)? (y/n) ");
-		scanf(" %c", &AdjListsForEmbeddingsOut);
-	}
+        Prompt("Do you want adjacency list format of embeddings in directory 'adjlist' (last 10 max)? (y/n) ");
+        scanf(" %c", &AdjListsForEmbeddingsOut);
+    }
 
-	FlushConsole(stdout);
+    FlushConsole(stdout);
 }
 
 void FlushConsole(FILE *f)
 {
-	fflush(f);
+    fflush(f);
 }
 
 void Prompt(char *message)
 {
-	Message(message);
-	FlushConsole(stdout);
+    Message(message);
+    FlushConsole(stdout);
 }
 
 /****************************************************************************
@@ -74,49 +74,49 @@ void Prompt(char *message)
 
 void SaveAsciiGraph(graphP theGraph, char *filename)
 {
-	int e, EsizeOccupied, vertexLabelFix;
-	FILE *outfile = fopen(filename, WRITETEXT);
+    int e, EsizeOccupied, vertexLabelFix;
+    FILE *outfile = fopen(filename, WRITETEXT);
 
-	// The filename may specify a directory that doesn't exist
-	if (outfile == NULL)
-	{
-		char messageContents[MAXLINE + 1];
-		char *messageFormat = "Failed to write to \"%.*s\"\nMake the directory if not present\n";
-		int charsAvailForStrToInclude = (int)(MAXLINE - strlen(messageFormat));
-		sprintf(messageContents, messageFormat, charsAvailForStrToInclude, filename);
-		ErrorMessage(messageContents);
-		return;
-	}
+    // The filename may specify a directory that doesn't exist
+    if (outfile == NULL)
+    {
+        char messageContents[MAXLINE + 1];
+        char *messageFormat = "Failed to write to \"%.*s\"\nMake the directory if not present\n";
+        int charsAvailForStrToInclude = (int)(MAXLINE - strlen(messageFormat));
+        sprintf(messageContents, messageFormat, charsAvailForStrToInclude, filename);
+        ErrorMessage(messageContents);
+        return;
+    }
 
-	// If filename includes path elements, remove them before writing the file's name to the file
-	if (strrchr(filename, FILE_DELIMITER))
-		filename = strrchr(filename, FILE_DELIMITER) + 1;
+    // If filename includes path elements, remove them before writing the file's name to the file
+    if (strrchr(filename, FILE_DELIMITER))
+        filename = strrchr(filename, FILE_DELIMITER) + 1;
 
-	fprintf(outfile, "%s\n", filename);
+    fprintf(outfile, "%s\n", filename);
 
-	// This edge list file format uses 1-based vertex numbering, and the current code
-	// internally uses 1-based indexing by default, so this vertex label 'fix' adds zero
-	// But earlier code used 0-based indexing and added one on output, so we replicate
-	// that behavior in case the current code has been compiled with zero-based indexing.
-	vertexLabelFix = 1 - gp_GetFirstVertex(theGraph);
+    // This edge list file format uses 1-based vertex numbering, and the current code
+    // internally uses 1-based indexing by default, so this vertex label 'fix' adds zero
+    // But earlier code used 0-based indexing and added one on output, so we replicate
+    // that behavior in case the current code has been compiled with zero-based indexing.
+    vertexLabelFix = 1 - gp_GetFirstVertex(theGraph);
 
-	// Iterate over the edges of the graph
-	EsizeOccupied = gp_EdgeInUseIndexBound(theGraph);
-	for (e = gp_GetFirstEdge(theGraph); e < EsizeOccupied; e += 2)
-	{
-		// Only output edges that haven't been deleted (i.e. skip the edge holes)
-		if (gp_EdgeInUse(theGraph, e))
-		{
-			fprintf(outfile, "%d %d\n",
-					gp_GetNeighbor(theGraph, e) + vertexLabelFix,
-					gp_GetNeighbor(theGraph, e + 1) + vertexLabelFix);
-		}
-	}
+    // Iterate over the edges of the graph
+    EsizeOccupied = gp_EdgeInUseIndexBound(theGraph);
+    for (e = gp_GetFirstEdge(theGraph); e < EsizeOccupied; e += 2)
+    {
+        // Only output edges that haven't been deleted (i.e. skip the edge holes)
+        if (gp_EdgeInUse(theGraph, e))
+        {
+            fprintf(outfile, "%d %d\n",
+                    gp_GetNeighbor(theGraph, e) + vertexLabelFix,
+                    gp_GetNeighbor(theGraph, e + 1) + vertexLabelFix);
+        }
+    }
 
-	// Since vertex numbers are at least 1, this indicates the end of the edge list
-	fprintf(outfile, "0 0\n");
+    // Since vertex numbers are at least 1, this indicates the end of the edge list
+    fprintf(outfile, "0 0\n");
 
-	fclose(outfile);
+    fclose(outfile);
 }
 
 /****************************************************************************
@@ -129,30 +129,30 @@ void SaveAsciiGraph(graphP theGraph, char *filename)
 
 char *ReadTextFileIntoString(char *infileName)
 {
-	FILE *infile = NULL;
-	char *inputString = NULL;
+    FILE *infile = NULL;
+    char *inputString = NULL;
 
-	if ((infile = fopen(infileName, "r")) == NULL)
-		ErrorMessage("fopen() failed.\n");
-	else
-	{
-		long filePos = ftell(infile);
-		long fileSize;
+    if ((infile = fopen(infileName, "r")) == NULL)
+        ErrorMessage("fopen() failed.\n");
+    else
+    {
+        long filePos = ftell(infile);
+        long fileSize;
 
-		fseek(infile, 0, SEEK_END);
-		fileSize = ftell(infile);
-		fseek(infile, filePos, SEEK_SET);
+        fseek(infile, 0, SEEK_END);
+        fileSize = ftell(infile);
+        fseek(infile, filePos, SEEK_SET);
 
-		if ((inputString = (char *)malloc((fileSize + 1) * sizeof(char))) != NULL)
-		{
-			long bytesRead = fread((void *)inputString, 1, fileSize, infile);
-			inputString[bytesRead] = '\0';
-		}
+        if ((inputString = (char *)malloc((fileSize + 1) * sizeof(char))) != NULL)
+        {
+            long bytesRead = fread((void *)inputString, 1, fileSize, infile);
+            inputString[bytesRead] = '\0';
+        }
 
-		fclose(infile);
-	}
+        fclose(infile);
+    }
 
-	return inputString;
+    return inputString;
 }
 
 /****************************************************************************
@@ -169,55 +169,55 @@ char *ReadTextFileIntoString(char *infileName)
 
 int TextFileMatchesString(char *theFilename, char *theString)
 {
-	FILE *infile = NULL;
-	int Result = TRUE;
+    FILE *infile = NULL;
+    int Result = TRUE;
 
-	if (theFilename != NULL)
-		infile = fopen(theFilename, "r");
+    if (theFilename != NULL)
+        infile = fopen(theFilename, "r");
 
-	if (infile == NULL)
-		Result = FALSE;
-	else
-	{
-		int c1 = 0, c2 = 0, stringIndex = 0;
+    if (infile == NULL)
+        Result = FALSE;
+    else
+    {
+        int c1 = 0, c2 = 0, stringIndex = 0;
 
-		// Read the input file to the end
-		while ((c1 = fgetc(infile)) != EOF)
-		{
-			// Want to suppress distinction between lines ending with CRLF versus LF
-			// by looking at only LF characters in the file
-			if (c1 == '\r')
-				continue;
+        // Read the input file to the end
+        while ((c1 = fgetc(infile)) != EOF)
+        {
+            // Want to suppress distinction between lines ending with CRLF versus LF
+            // by looking at only LF characters in the file
+            if (c1 == '\r')
+                continue;
 
-			// Since c1 now has a non-CR, non-EOF from the input file,  we now also
-			// get a character from the string, except ignoring CRs again
-			while ((c2 = (int)theString[stringIndex++]) == '\r')
-				;
+            // Since c1 now has a non-CR, non-EOF from the input file,  we now also
+            // get a character from the string, except ignoring CRs again
+            while ((c2 = (int)theString[stringIndex++]) == '\r')
+                ;
 
-			// If c1 doesn't equal c2 (whether c2 is a null terminator or a different character)
-			// then the file content doesn't match the string
-			if (c1 != c2)
-			{
-				Result = FALSE;
-				break;
-			}
-		}
+            // If c1 doesn't equal c2 (whether c2 is a null terminator or a different character)
+            // then the file content doesn't match the string
+            if (c1 != c2)
+            {
+                Result = FALSE;
+                break;
+            }
+        }
 
-		// If the outer while loop got to the end of the file
-		if (c1 == EOF)
-		{
-			// Then get another character from the string, once again suppressing CRs, and then...
-			while ((c2 = (int)theString[stringIndex++]) == '\r')
-				;
-			// Test whether or not the second file also ends, same as the first.
-			if (c2 != '\0')
-				Result = FALSE;
-		}
-	}
+        // If the outer while loop got to the end of the file
+        if (c1 == EOF)
+        {
+            // Then get another character from the string, once again suppressing CRs, and then...
+            while ((c2 = (int)theString[stringIndex++]) == '\r')
+                ;
+            // Test whether or not the second file also ends, same as the first.
+            if (c2 != '\0')
+                Result = FALSE;
+        }
+    }
 
-	if (infile != NULL)
-		fclose(infile);
-	return Result;
+    if (infile != NULL)
+        fclose(infile);
+    return Result;
 }
 
 /****************************************************************************
@@ -225,63 +225,63 @@ int TextFileMatchesString(char *theFilename, char *theString)
 
 int TextFilesEqual(char *file1Name, char *file2Name)
 {
-	FILE *infile1 = NULL, *infile2 = NULL;
-	int Result = TRUE;
+    FILE *infile1 = NULL, *infile2 = NULL;
+    int Result = TRUE;
 
-	infile1 = fopen(file1Name, "r");
-	infile2 = fopen(file2Name, "r");
+    infile1 = fopen(file1Name, "r");
+    infile2 = fopen(file2Name, "r");
 
-	if (infile1 == NULL || infile2 == NULL)
-		Result = FALSE;
-	else
-	{
-		int c1 = 0, c2 = 0;
+    if (infile1 == NULL || infile2 == NULL)
+        Result = FALSE;
+    else
+    {
+        int c1 = 0, c2 = 0;
 
-		// Read the first file to the end
-		while ((c1 = fgetc(infile1)) != EOF)
-		{
-			// Want to suppress distinction between lines ending with CRLF versus LF
-			if (c1 == '\r')
-				continue;
+        // Read the first file to the end
+        while ((c1 = fgetc(infile1)) != EOF)
+        {
+            // Want to suppress distinction between lines ending with CRLF versus LF
+            if (c1 == '\r')
+                continue;
 
-			// Get a char from the second file, except suppress CR again
-			while ((c2 = fgetc(infile2)) == '\r')
-				;
+            // Get a char from the second file, except suppress CR again
+            while ((c2 = fgetc(infile2)) == '\r')
+                ;
 
-			// If we got a char from the first file, but not from the second
-			// then the second file is shorter, so files are not equal
-			if (c2 == EOF)
-			{
-				Result = FALSE;
-				break;
-			}
+            // If we got a char from the first file, but not from the second
+            // then the second file is shorter, so files are not equal
+            if (c2 == EOF)
+            {
+                Result = FALSE;
+                break;
+            }
 
-			// If we got a char from second file, but not equal to char from
-			// first file, then files are not equal
-			if (c1 != c2)
-			{
-				Result = FALSE;
-				break;
-			}
-		}
+            // If we got a char from second file, but not equal to char from
+            // first file, then files are not equal
+            if (c1 != c2)
+            {
+                Result = FALSE;
+                break;
+            }
+        }
 
-		// If we got to the end of the first file without breaking the loop...
-		if (c1 == EOF)
-		{
-			// Then, once again, suppress CRs first, and then...
-			while ((c2 = fgetc(infile2)) == '\r')
-				;
-			// Test whether or not the second file also ends, same as the first.
-			if (fgetc(infile2) != EOF)
-				Result = FALSE;
-		}
-	}
+        // If we got to the end of the first file without breaking the loop...
+        if (c1 == EOF)
+        {
+            // Then, once again, suppress CRs first, and then...
+            while ((c2 = fgetc(infile2)) == '\r')
+                ;
+            // Test whether or not the second file also ends, same as the first.
+            if (fgetc(infile2) != EOF)
+                Result = FALSE;
+        }
+    }
 
-	if (infile1 != NULL)
-		fclose(infile1);
-	if (infile2 != NULL)
-		fclose(infile2);
-	return Result;
+    if (infile1 != NULL)
+        fclose(infile1);
+    if (infile2 != NULL)
+        fclose(infile2);
+    return Result;
 }
 
 /****************************************************************************
@@ -289,52 +289,52 @@ int TextFilesEqual(char *file1Name, char *file2Name)
 
 int BinaryFilesEqual(char *file1Name, char *file2Name)
 {
-	FILE *infile1 = NULL, *infile2 = NULL;
-	int Result = TRUE;
+    FILE *infile1 = NULL, *infile2 = NULL;
+    int Result = TRUE;
 
-	infile1 = fopen(file1Name, "r");
-	infile2 = fopen(file2Name, "r");
+    infile1 = fopen(file1Name, "r");
+    infile2 = fopen(file2Name, "r");
 
-	if (infile1 == NULL || infile2 == NULL)
-		Result = FALSE;
-	else
-	{
-		int c1 = 0, c2 = 0;
+    if (infile1 == NULL || infile2 == NULL)
+        Result = FALSE;
+    else
+    {
+        int c1 = 0, c2 = 0;
 
-		// Read the first file to the end
-		while ((c1 = fgetc(infile1)) != EOF)
-		{
-			// If we got a char from the first file, but not from the second
-			// then the second file is shorter, so files are not equal
-			if ((c2 = fgetc(infile2)) == EOF)
-			{
-				Result = FALSE;
-				break;
-			}
+        // Read the first file to the end
+        while ((c1 = fgetc(infile1)) != EOF)
+        {
+            // If we got a char from the first file, but not from the second
+            // then the second file is shorter, so files are not equal
+            if ((c2 = fgetc(infile2)) == EOF)
+            {
+                Result = FALSE;
+                break;
+            }
 
-			// If we got a char from second file, but not equal to char from
-			// first file, then files are not equal
-			if (c1 != c2)
-			{
-				Result = FALSE;
-				break;
-			}
-		}
+            // If we got a char from second file, but not equal to char from
+            // first file, then files are not equal
+            if (c1 != c2)
+            {
+                Result = FALSE;
+                break;
+            }
+        }
 
-		// If we got to the end of the first file without breaking the loop...
-		if (c1 == EOF)
-		{
-			// Then attempt to read from the second file to ensure it also ends.
-			if (fgetc(infile2) != EOF)
-				Result = FALSE;
-		}
-	}
+        // If we got to the end of the first file without breaking the loop...
+        if (c1 == EOF)
+        {
+            // Then attempt to read from the second file to ensure it also ends.
+            if (fgetc(infile2) != EOF)
+                Result = FALSE;
+        }
+    }
 
-	if (infile1 != NULL)
-		fclose(infile1);
-	if (infile2 != NULL)
-		fclose(infile2);
-	return Result;
+    if (infile1 != NULL)
+        fclose(infile1);
+    if (infile2 != NULL)
+        fclose(infile2);
+    return Result;
 }
 
 /****************************************************************************
@@ -343,29 +343,29 @@ int BinaryFilesEqual(char *file1Name, char *file2Name)
 
 char *GetAlgorithmFlags(void)
 {
-	return "C = command (algorithm implementation to run)\n"
-		   "    -p = Planar embedding and Kuratowski subgraph isolation\n"
-		   "    -d = Planar graph drawing by visibility representation\n"
-		   "    -o = Outerplanar embedding and obstruction isolation\n"
-		   "    -2 = Search for subgraph homeomorphic to K_{2,3}\n"
-		   "    -3 = Search for subgraph homeomorphic to K_{3,3}\n"
-		   "    -4 = Search for subgraph homeomorphic to K_4\n"
-		   "\n";
+    return "C = command (algorithm implementation to run)\n"
+           "    -p = Planar embedding and Kuratowski subgraph isolation\n"
+           "    -d = Planar graph drawing by visibility representation\n"
+           "    -o = Outerplanar embedding and obstruction isolation\n"
+           "    -2 = Search for subgraph homeomorphic to K_{2,3}\n"
+           "    -3 = Search for subgraph homeomorphic to K_{3,3}\n"
+           "    -4 = Search for subgraph homeomorphic to K_4\n"
+           "\n";
 }
 
 char *GetAlgorithmSpecifiers(void)
 {
-	return "P. Planar embedding and Kuratowski subgraph isolation\n"
-		   "D. Planar graph drawing by visibility representation\n"
-		   "O. Outerplanar embedding and obstruction isolation\n"
-		   "2. Search for subgraph homeomorphic to K_{2,3}\n"
-		   "3. Search for subgraph homeomorphic to K_{3,3}\n"
-		   "4. Search for subgraph homeomorphic to K_4\n";
+    return "P. Planar embedding and Kuratowski subgraph isolation\n"
+           "D. Planar graph drawing by visibility representation\n"
+           "O. Outerplanar embedding and obstruction isolation\n"
+           "2. Search for subgraph homeomorphic to K_{2,3}\n"
+           "3. Search for subgraph homeomorphic to K_{3,3}\n"
+           "4. Search for subgraph homeomorphic to K_4\n";
 }
 
 char *GetAlgorithmChoices(void)
 {
-	return "pdo234";
+    return "pdo234";
 }
 
 /****************************************************************************
@@ -373,31 +373,31 @@ char *GetAlgorithmChoices(void)
 
 int GetEmbedFlags(char command)
 {
-	int embedFlags = 0;
+    int embedFlags = 0;
 
-	switch (command)
-	{
-	case 'o':
-		embedFlags = EMBEDFLAGS_OUTERPLANAR;
-		break;
-	case 'p':
-		embedFlags = EMBEDFLAGS_PLANAR;
-		break;
-	case 'd':
-		embedFlags = EMBEDFLAGS_DRAWPLANAR;
-		break;
-	case '2':
-		embedFlags = EMBEDFLAGS_SEARCHFORK23;
-		break;
-	case '3':
-		embedFlags = EMBEDFLAGS_SEARCHFORK33;
-		break;
-	case '4':
-		embedFlags = EMBEDFLAGS_SEARCHFORK4;
-		break;
-	}
+    switch (command)
+    {
+    case 'o':
+        embedFlags = EMBEDFLAGS_OUTERPLANAR;
+        break;
+    case 'p':
+        embedFlags = EMBEDFLAGS_PLANAR;
+        break;
+    case 'd':
+        embedFlags = EMBEDFLAGS_DRAWPLANAR;
+        break;
+    case '2':
+        embedFlags = EMBEDFLAGS_SEARCHFORK23;
+        break;
+    case '3':
+        embedFlags = EMBEDFLAGS_SEARCHFORK33;
+        break;
+    case '4':
+        embedFlags = EMBEDFLAGS_SEARCHFORK4;
+        break;
+    }
 
-	return embedFlags;
+    return embedFlags;
 }
 
 /****************************************************************************
@@ -405,31 +405,31 @@ int GetEmbedFlags(char command)
 
 char *GetAlgorithmName(char command)
 {
-	char *algorithmName = "UnsupportedAlgorithm";
+    char *algorithmName = "UnsupportedAlgorithm";
 
-	switch (command)
-	{
-	case 'p':
-		algorithmName = "PlanarEmbed";
-		break;
-	case 'd':
-		algorithmName = DRAWPLANAR_NAME;
-		break;
-	case 'o':
-		algorithmName = "OuterplanarEmbed";
-		break;
-	case '2':
-		algorithmName = K23SEARCH_NAME;
-		break;
-	case '3':
-		algorithmName = K33SEARCH_NAME;
-		break;
-	case '4':
-		algorithmName = K4SEARCH_NAME;
-		break;
-	}
+    switch (command)
+    {
+    case 'p':
+        algorithmName = "PlanarEmbed";
+        break;
+    case 'd':
+        algorithmName = DRAWPLANAR_NAME;
+        break;
+    case 'o':
+        algorithmName = "OuterplanarEmbed";
+        break;
+    case '2':
+        algorithmName = K23SEARCH_NAME;
+        break;
+    case '3':
+        algorithmName = K33SEARCH_NAME;
+        break;
+    case '4':
+        algorithmName = K4SEARCH_NAME;
+        break;
+    }
 
-	return algorithmName;
+    return algorithmName;
 }
 
 /****************************************************************************
@@ -437,34 +437,34 @@ char *GetAlgorithmName(char command)
 
 char *GetTransformationName(char command)
 {
-	char *transformationName = "UnsupportedTransformation";
+    char *transformationName = "UnsupportedTransformation";
 
-	switch (command)
-	{
-	case 'g':
-		transformationName = "G6";
-		break;
-	case 'a':
-		transformationName = "AdjList";
-		break;
-	case 'm':
-		transformationName = "AdjMat";
-		break;
-	}
+    switch (command)
+    {
+    case 'g':
+        transformationName = "G6";
+        break;
+    case 'a':
+        transformationName = "AdjList";
+        break;
+    case 'm':
+        transformationName = "AdjMat";
+        break;
+    }
 
-	return transformationName;
+    return transformationName;
 }
 
 char *GetSupportedOutputChoices(void)
 {
-	return "G. G6 format\n"
-		   "A. Adjacency List format\n"
-		   "M. Adjacency Matrix format\n";
+    return "G. G6 format\n"
+           "A. Adjacency List format\n"
+           "M. Adjacency Matrix format\n";
 }
 
 char *GetSupportedOutputFormats(void)
 {
-	return "gam";
+    return "gam";
 }
 
 /****************************************************************************
@@ -472,9 +472,9 @@ char *GetSupportedOutputFormats(void)
 
 char *GetBaseName(int baseFlag)
 {
-	char *transformationName = baseFlag ? "1-based" : "0-based";
+    char *transformationName = baseFlag ? "1-based" : "0-based";
 
-	return transformationName;
+    return transformationName;
 }
 
 /****************************************************************************
@@ -482,21 +482,21 @@ char *GetBaseName(int baseFlag)
 
 void AttachAlgorithm(graphP theGraph, char command)
 {
-	switch (command)
-	{
-	case 'd':
-		gp_AttachDrawPlanar(theGraph);
-		break;
-	case '2':
-		gp_AttachK23Search(theGraph);
-		break;
-	case '3':
-		gp_AttachK33Search(theGraph);
-		break;
-	case '4':
-		gp_AttachK4Search(theGraph);
-		break;
-	}
+    switch (command)
+    {
+    case 'd':
+        gp_AttachDrawPlanar(theGraph);
+        break;
+    case '2':
+        gp_AttachK23Search(theGraph);
+        break;
+    case '3':
+        gp_AttachK33Search(theGraph);
+        break;
+    case '4':
+        gp_AttachK4Search(theGraph);
+        break;
+    }
 }
 
 /****************************************************************************
@@ -521,26 +521,26 @@ char theFileName[FILENAMEMAXLENGTH + 1 + ALGORITHMNAMEMAXLENGTH + 1 + SUFFIXMAXL
 
 char *ConstructInputFilename(char *infileName)
 {
-	if (infileName == NULL)
-	{
-		Prompt("Enter graph file name: ");
-		fflush(stdin);
-		scanf(" %s", theFileName);
+    if (infileName == NULL)
+    {
+        Prompt("Enter graph file name: ");
+        fflush(stdin);
+        scanf(" %s", theFileName);
 
-		if (!strchr(theFileName, '.'))
-			strcat(theFileName, ".txt");
-	}
-	else
-	{
-		if (strlen(infileName) > FILENAMEMAXLENGTH)
-		{
-			ErrorMessage("Filename is too long");
-			return NULL;
-		}
-		strcpy(theFileName, infileName);
-	}
+        if (!strchr(theFileName, '.'))
+            strcat(theFileName, ".txt");
+    }
+    else
+    {
+        if (strlen(infileName) > FILENAMEMAXLENGTH)
+        {
+            ErrorMessage("Filename is too long");
+            return NULL;
+        }
+        strcpy(theFileName, infileName);
+    }
 
-	return theFileName;
+    return theFileName;
 }
 
 /****************************************************************************
@@ -555,54 +555,54 @@ char *ConstructInputFilename(char *infileName)
 
 char *ConstructPrimaryOutputFilename(char *infileName, char *outfileName, char command)
 {
-	char *algorithmName = GetAlgorithmName(command);
+    char *algorithmName = GetAlgorithmName(command);
 
-	if (outfileName == NULL)
-	{
-		// The output filename is based on the input filename
-		if (theFileName != infileName)
-			strcpy(theFileName, infileName);
+    if (outfileName == NULL)
+    {
+        // The output filename is based on the input filename
+        if (theFileName != infileName)
+            strcpy(theFileName, infileName);
 
-		// If the primary output filename has not been given, then we use
-		// the input filename + the algorithm name + a simple suffix
-		if (strlen(algorithmName) <= ALGORITHMNAMEMAXLENGTH)
-		{
-			strcat(theFileName, ".");
-			strcat(theFileName, algorithmName);
-		}
-		else
-			ErrorMessage("Algorithm Name is too long, so it will not be used in output filename.");
+        // If the primary output filename has not been given, then we use
+        // the input filename + the algorithm name + a simple suffix
+        if (strlen(algorithmName) <= ALGORITHMNAMEMAXLENGTH)
+        {
+            strcat(theFileName, ".");
+            strcat(theFileName, algorithmName);
+        }
+        else
+            ErrorMessage("Algorithm Name is too long, so it will not be used in output filename.");
 
-		strcat(theFileName, ".out.txt");
-	}
-	else
-	{
-		if (strlen(outfileName) > FILENAMEMAXLENGTH)
-		{
-			// The output filename is based on the input filename
-			if (theFileName != infileName)
-				strcpy(theFileName, infileName);
+        strcat(theFileName, ".out.txt");
+    }
+    else
+    {
+        if (strlen(outfileName) > FILENAMEMAXLENGTH)
+        {
+            // The output filename is based on the input filename
+            if (theFileName != infileName)
+                strcpy(theFileName, infileName);
 
-			if (strlen(algorithmName) <= ALGORITHMNAMEMAXLENGTH)
-			{
-				strcat(theFileName, ".");
-				strcat(theFileName, algorithmName);
-			}
-			strcat(theFileName, ".out.txt");
-			char messageContents[MAXLINE + 1];
-			char *messageFormat = "Outfile filename is too long. Result placed in \"%.*s\"";
-			int charsAvailForStrToInclude = (int)(MAXLINE - strlen(messageFormat));
-			sprintf(messageContents, messageFormat, charsAvailForStrToInclude, theFileName);
-			ErrorMessage(messageContents);
-		}
-		else
-		{
-			if (theFileName != outfileName)
-				strcpy(theFileName, outfileName);
-		}
-	}
+            if (strlen(algorithmName) <= ALGORITHMNAMEMAXLENGTH)
+            {
+                strcat(theFileName, ".");
+                strcat(theFileName, algorithmName);
+            }
+            strcat(theFileName, ".out.txt");
+            char messageContents[MAXLINE + 1];
+            char *messageFormat = "Outfile filename is too long. Result placed in \"%.*s\"";
+            int charsAvailForStrToInclude = (int)(MAXLINE - strlen(messageFormat));
+            sprintf(messageContents, messageFormat, charsAvailForStrToInclude, theFileName);
+            ErrorMessage(messageContents);
+        }
+        else
+        {
+            if (theFileName != outfileName)
+                strcpy(theFileName, outfileName);
+        }
+    }
 
-	return theFileName;
+    return theFileName;
 }
 
 /****************************************************************************
@@ -617,49 +617,49 @@ char *ConstructPrimaryOutputFilename(char *infileName, char *outfileName, char c
 
 int ConstructTransformationExpectedResultFilename(char *infileName, char **outfileName, char command, int baseFlag)
 {
-	int Result = OK;
-	char *baseName = GetBaseName(baseFlag);
-	char *transformationName = GetTransformationName(command);
-	int infileNameLen = -1;
+    int Result = OK;
+    char *baseName = GetBaseName(baseFlag);
+    char *transformationName = GetTransformationName(command);
+    int infileNameLen = -1;
 
-	if (infileName == NULL || (infileNameLen = strlen(infileName)) < 1)
-	{
-		ErrorMessage("Cannot construct transformation output filename for empty infileName.\n");
-		return NOTOK;
-	}
+    if (infileName == NULL || (infileNameLen = strlen(infileName)) < 1)
+    {
+        ErrorMessage("Cannot construct transformation output filename for empty infileName.\n");
+        return NOTOK;
+    }
 
-	if ((*outfileName) == NULL)
-	{
-		(*outfileName) = (char *)calloc(infileNameLen + 1 + strlen(baseName) + 1 + strlen(transformationName) + ((command == 'g') ? strlen(".out.g6") : strlen(".out.txt")) + 1, sizeof(char));
+    if ((*outfileName) == NULL)
+    {
+        (*outfileName) = (char *)calloc(infileNameLen + 1 + strlen(baseName) + 1 + strlen(transformationName) + ((command == 'g') ? strlen(".out.g6") : strlen(".out.txt")) + 1, sizeof(char));
 
-		if ((*outfileName) == NULL)
-		{
-			ErrorMessage("Unable to allocate memory for output filename.\n");
-			return NOTOK;
-		}
+        if ((*outfileName) == NULL)
+        {
+            ErrorMessage("Unable to allocate memory for output filename.\n");
+            return NOTOK;
+        }
 
-		strcpy((*outfileName), infileName);
-		strcat((*outfileName), ".");
-		strcat((*outfileName), baseName);
-		strcat((*outfileName), ".");
-		strcat((*outfileName), transformationName);
-		strcat((*outfileName), command == 'g' ? ".out.g6" : ".out.txt");
-	}
-	else
-	{
-		ErrorMessage("outfileName already allocated.\n");
-		Result = NOTOK;
-	}
+        strcpy((*outfileName), infileName);
+        strcat((*outfileName), ".");
+        strcat((*outfileName), baseName);
+        strcat((*outfileName), ".");
+        strcat((*outfileName), transformationName);
+        strcat((*outfileName), command == 'g' ? ".out.g6" : ".out.txt");
+    }
+    else
+    {
+        ErrorMessage("outfileName already allocated.\n");
+        Result = NOTOK;
+    }
 
-	return Result;
+    return Result;
 }
 
 int GetNumCharsToReprInt(int theNum)
 {
-	int numCharsRequired = 1;
+    int numCharsRequired = 1;
 
-	while (theNum /= 10)
-		numCharsRequired++;
+    while (theNum /= 10)
+        numCharsRequired++;
 
-	return numCharsRequired;
+    return numCharsRequired;
 }


### PR DESCRIPTION
Resolves #27 and #104

Used the [Format Files](https://marketplace.visualstudio.com/items?itemName=jbockle.jbockle-format-files) VSCode extension on my MacBook Pro (rather than going through the process of installing `clang` on my Windows box and configuring VSCode accordingly), then manually search-and-replaced tab characters with four spaces, as the formatting only made indentation consistently spaces if spaces were used for indentation in at least one portion of the source file.