### PR TITLE
Issue #46 - Resolve suggestions and warnings for autotools build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,10 +69,10 @@ libtool
 test-samples.sh
 Makefile
 config.status
-config.guess
-config.sub
+config.guess*
+config.sub*
 depcomp
-install-sh
+install-sh*
 Makefile.in
 missing
 ltmain.sh
@@ -84,6 +84,7 @@ test-driver
 planarity-*
 planarity-*/*
 libplanarity.pc
+m4/
 
 # Ignoring configuration for VSCode
 /.vscode/

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,7 @@
 SUBDIRS = c/samples
 
+ACLOCAL_AMFLAGS = -I m4
+
 lib_LTLIBRARIES = libplanarity.la
 
 libplanarity_la_SOURCES = \

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Once one has set up the development environment and is able to work with the cod
 1. Ensure that the `autotools`, `configure`, and `make` are available on the command-line (e.g. add `C:\msys64\usr\bin` to the system `PATH` before Windows Program Files to ensure that the `find` program is the one from `MSYS2` rather than the one from Windows (e.g. adjust the `PATH` variable as needed)). 
 2. Open the start menu and start typing "MSYS2 UCRT64" to open the correct terminal app, then navigate to the root of the `edge-addition-planarity-suite` repository (i.e. the directory containing `configure.ac` and the `c` subdirectory)
 3. Enter the following commands:
-    1. `./autogen.sh`
+    1. `autoreconf -fi`
     2. `./configure`
     3. `make dist`
     4. `make distcheck`

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-aclocal &&
-autoconf &&
-libtoolize --copy &&
-automake --add-missing --copy &&
-rm -rf autom4te.cache

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,6 @@
 AC_INIT([planarity],[3.0.2.0],[jboyer@acm.org])
 AM_INIT_AUTOMAKE([subdir-objects] [foreign])
+AC_CONFIG_MACRO_DIRS([m4])
 AC_CONFIG_SRCDIR([c/])
 
 # The version of the libtool library is of the form current:revision:age

--- a/devEnvSetupAndDefaults/devEnvSetup.sh
+++ b/devEnvSetupAndDefaults/devEnvSetup.sh
@@ -15,3 +15,6 @@ mkdir -p ../embedded
 mkdir -p ../adjlist
 mkdir -p ../obstructed
 mkdir -p ../error
+
+echo -e "Making m4 directory for autotools build process.\n"
+mkdir -p ../m4


### PR DESCRIPTION
Resolves #46 

## Deleted

* `autogen.sh` - One must now run `autoreconf -fi` instead of the `autogen.sh` script as the first step of the autotools build process.
    * _**N.B.**_ `autogen.sh` was introduced in [85e191](https://github.com/graph-algorithms/edge-addition-planarity-suite/commit/85e1918a84b1bce4ea8a8378440c9a18997959b4) and updated in #1 and #6 (see #5 )

## Updated

* `.gitignore` - Ignore `m4` directory, as well as intermediate files from build process
* `configure.ac` - added `AC_CONFIG_MACRO_DIRS([m4])` (see [autoconf manual - Input](https://www.gnu.org/software/autoconf/manual/autoconf-2.70/html_node/Input.html)) to specify the `m4` directory as the location of additional local Autoconf macros
* `Makefile.am` - Added `ACLOCAL_AMFLAGS = -I m4` for where `.m4` files are to be copied
* `README.md` - updated instructions in "Making the Distribution" section to run `autoreconf -fi` instead of the `autogen.sh` script
* `devEnvSetupAndDefaults/devEnvSetup.sh` - Now create `m4` directory upon development environment setup script invocation

---

I successfully confirmed that the process to build the distribution works on Windows with MinGW-w64 UCRT, and that the process to build the distribution works on Debian (12.7 bookworm) and that the installed executable and libraries work (i.e. successful run of `planarity -test {samples directory}` after creating `/etc/ld.so.conf.d/planarity.conf` containing `/usr/local/lib` and running `sudo ldconfig`)