### PR TITLE
Changes for 40 release

### DIFF
--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -1,5 +1,5 @@
 The Edge Addition Planarity Suite
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved. Includes a reference implementation of the following:
 
 * John M. Boyer. "Subgraph Homeomorphism via the Edge Addition Planarity Algorithm".

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The primary purpose of this repository is to provide implementations of the edge
 
 * [Simplified O(n) Algorithms for Planar Graph Embedding, Kuratowski Subgraph Isolation, and Related Problems](https://dspace.library.uvic.ca/handle/1828/9918)
 
-As secondary purpose of this repository is to provide a generalized graph API that enables implementation of a very wide range of in-memory graph algorithms including basic methods for reading, writing, depth first search, and lowpoint as well as advanced methods for solving planarity, outerplanarity, drawing, and selected subgraph homeomorphism problems. An extension mechanism is also provided to enable implementation of planarity-related algorithms by overriding and augmenting data structures and methods of the core planarity algorithm.
+A secondary purpose of this repository is to provide a generalized graph API that enables implementation of a very wide range of in-memory graph algorithms including basic methods for reading, writing, depth first search, and lowpoint as well as advanced methods for solving planarity, outerplanarity, drawing, and selected subgraph homeomorphism problems. An extension mechanism is also provided to enable implementation of planarity-related algorithms by overriding and augmenting data structures and methods of the core planarity algorithm.
 
 ## Getting Started
 
@@ -60,9 +60,9 @@ On Linux, the planarity program can also be installed by entering `sudo make ins
 
 ## Versioning
 
-The APIs for the graph library and the planarity algorithm implementations are versioned using the method documented in [`configure.ac`](configure.ac).
+The overall project and the APIs for the graph library and the planarity-related algorithm implementations are versioned using the methods documented in [`configure.ac`](configure.ac) and [`graphLib.h`](c/graphLib/graphLib.h). The overall project version adheres to a `Major.Minor.Maintenance.Tweak` numbering system, and the `libPlanarity` shared library, which contains the graph library and planarity-related algorithm implementations, is versioned using the _current:revision:age_ system from `LibTool`.
 
-The `planarity.exe` application, which provides command-line and menu-driven interfaces for the graph library and planarity algorithms, is versioned according to the `Major.Minor.Maintenance.Tweak` numbering system documented in the comments in [`planarity.c`](c/planarity.c). 
+The `planarity.exe` application, which provides command-line and menu-driven interfaces for the graph library and planarity-related algorithms, is versioned using the overall project version defined in [`graphLib.h`](c/graphLib/graphLib.h) (see [`planarityHelp.c`](c/planarityApp/planarityHelp.c)). 
 
 ## License
 

--- a/c/graph.h
+++ b/c/graph.h
@@ -2,7 +2,7 @@
 #define HELPERSTUB_GRAPH_H
 
 /*
-Copyright (c) 1997-2024, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib.h
+++ b/c/graphLib.h
@@ -2,7 +2,7 @@
 #define HELPERSTUB_GRAPHLIB_H
 
 /*
-Copyright (c) 1997-2024, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/extensionSystem/graphExtensions.c
+++ b/c/graphLib/extensionSystem/graphExtensions.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/extensionSystem/graphExtensions.h
+++ b/c/graphLib/extensionSystem/graphExtensions.h
@@ -2,7 +2,7 @@
 #define GRAPH_EXTENSIONS_H
 
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/extensionSystem/graphExtensions.private.h
+++ b/c/graphLib/extensionSystem/graphExtensions.private.h
@@ -2,7 +2,7 @@
 #define GRAPH_EXTENSIONS_PRIVATE_H
 
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/extensionSystem/graphFunctionTable.h
+++ b/c/graphLib/extensionSystem/graphFunctionTable.h
@@ -2,7 +2,7 @@
 #define GRAPHFUNCTIONTABLE_H
 
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/graph.h
+++ b/c/graphLib/graph.h
@@ -2,7 +2,7 @@
 #define GRAPH_H
 
 /*
-Copyright (c) 1997-2024, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/graphDFSUtils.c
+++ b/c/graphLib/graphDFSUtils.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/graphLib.h
+++ b/c/graphLib/graphLib.h
@@ -2,7 +2,7 @@
 #define GRAPHLIB_H
 
 /*
-Copyright (c) 1997-2024, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/graphLib.h
+++ b/c/graphLib/graphLib.h
@@ -26,6 +26,32 @@ extern "C"
 #include "homeomorphSearch/graphK4Search.h"
 #include "planarityRelated/graphDrawPlanar.h"
 
+    // This is the main location for the project and shared library version numbering.
+    // Changes here must be mirrored in configure.ac
+    //
+    // The overall project version numbering format is major.minor.maintenance.tweak
+    // Major is for an overhaul (e.g. many features, data structure change, change of backward compatibility)
+    // Minor is for feature addition (e.g. a new algorithm implementation added, new interface)
+    // Maintenance is for functional revision (e.g. bug fix to existing algorithm implementation)
+    // Tweak is for a non-functional revision (e.g. change of build scripts or testing code, user-facing string changes)
+
+#define GP_PROJECTVERSION_MAJOR 4
+#define GP_PROJECTVERSION_MINOR 0
+#define GP_PROJECTVERSION_MAINT 0
+#define GP_PROJECTVERSION_TWEAK 0
+
+    char *gp_GetProjectVersionFull(void);
+
+// Any change to the project version numbers should also affect the
+// shared library version numbers below.
+//
+// See configure.ac for how to update these version numbers
+#define GP_LIBPLANARITYVERSION_CURRENT 2
+#define GP_LIBPLANARITYVERSION_REVISION 0
+#define GP_LIBPLANARITYVERSION_AGE 0
+
+    char *gp_GetLibPlanarityVersionFull(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/c/graphLib/graphStructures.h
+++ b/c/graphLib/graphStructures.h
@@ -2,7 +2,7 @@
 #define GRAPHSTRUCTURE_H
 
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/graphUtils.c
+++ b/c/graphLib/graphUtils.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/graphUtils.c
+++ b/c/graphLib/graphUtils.c
@@ -6,8 +6,6 @@ See the LICENSE.TXT file for licensing information.
 
 #include <stdlib.h>
 
-// #include "graphStructures.h"
-// #include "graph.h"
 #include "graphLib.h"
 
 /* Imported functions for FUNCTION POINTERS */

--- a/c/graphLib/graphUtils.c
+++ b/c/graphLib/graphUtils.c
@@ -6,8 +6,9 @@ See the LICENSE.TXT file for licensing information.
 
 #include <stdlib.h>
 
-#include "graphStructures.h"
-#include "graph.h"
+// #include "graphStructures.h"
+// #include "graph.h"
+#include "graphLib.h"
 
 /* Imported functions for FUNCTION POINTERS */
 
@@ -80,6 +81,37 @@ void _InitEdgeRec(graphP theGraph, int e);
 int _InitGraph(graphP theGraph, int N);
 void _ReinitializeGraph(graphP theGraph);
 int _EnsureArcCapacity(graphP theGraph, int requiredArcCapacity);
+
+/********************************************************************
+ gp_GetProjectVersionFull()
+ Return full major.minor.maint.tweak version string for the graph planarity project
+ ********************************************************************/
+
+char *gp_GetProjectVersionFull(void)
+{
+    static char projectVersionStr[MAXLINE + 1];
+    sprintf(projectVersionStr, "%d.%d.%d.%d",
+            GP_PROJECTVERSION_MAJOR,
+            GP_PROJECTVERSION_MINOR,
+            GP_PROJECTVERSION_MAINT,
+            GP_PROJECTVERSION_TWEAK);
+    return projectVersionStr;
+}
+
+/********************************************************************
+ gp_GetLibPlanarityVersionFull()
+ Returns full current:revision:age version string for the graph planarity shared library
+ ********************************************************************/
+
+char *gp_GetLibPlanarityVersionFull(void)
+{
+    static char libPlanarityVersionStr[MAXLINE + 1];
+    sprintf(libPlanarityVersionStr, "%d:%d:%d",
+            GP_LIBPLANARITYVERSION_CURRENT,
+            GP_LIBPLANARITYVERSION_REVISION,
+            GP_LIBPLANARITYVERSION_AGE);
+    return libPlanarityVersionStr;
+}
 
 /********************************************************************
  gp_New()

--- a/c/graphLib/homeomorphSearch/graphK23Search.c
+++ b/c/graphLib/homeomorphSearch/graphK23Search.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/homeomorphSearch/graphK23Search.h
+++ b/c/graphLib/homeomorphSearch/graphK23Search.h
@@ -2,7 +2,7 @@
 #define GRAPH_K23SEARCH_H
 
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/homeomorphSearch/graphK23Search.private.h
+++ b/c/graphLib/homeomorphSearch/graphK23Search.private.h
@@ -2,7 +2,7 @@
 #define GRAPH_K23SEARCH_PRIVATE_H
 
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/homeomorphSearch/graphK23Search_Extensions.c
+++ b/c/graphLib/homeomorphSearch/graphK23Search_Extensions.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/homeomorphSearch/graphK33Search.c
+++ b/c/graphLib/homeomorphSearch/graphK33Search.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/homeomorphSearch/graphK33Search.h
+++ b/c/graphLib/homeomorphSearch/graphK33Search.h
@@ -2,7 +2,7 @@
 #define GRAPH_K33SEARCH_H
 
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/homeomorphSearch/graphK33Search.private.h
+++ b/c/graphLib/homeomorphSearch/graphK33Search.private.h
@@ -2,7 +2,7 @@
 #define GRAPH_K33SEARCH_PRIVATE_H
 
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/homeomorphSearch/graphK33Search_Extensions.c
+++ b/c/graphLib/homeomorphSearch/graphK33Search_Extensions.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/homeomorphSearch/graphK4Search.c
+++ b/c/graphLib/homeomorphSearch/graphK4Search.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/homeomorphSearch/graphK4Search.h
+++ b/c/graphLib/homeomorphSearch/graphK4Search.h
@@ -2,7 +2,7 @@
 #define GRAPH_K4SEARCH_H
 
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/homeomorphSearch/graphK4Search.private.h
+++ b/c/graphLib/homeomorphSearch/graphK4Search.private.h
@@ -2,7 +2,7 @@
 #define GRAPH_K4SEARCH_PRIVATE_H
 
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/homeomorphSearch/graphK4Search_Extensions.c
+++ b/c/graphLib/homeomorphSearch/graphK4Search_Extensions.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/io/g6-api-utilities.c
+++ b/c/graphLib/io/g6-api-utilities.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2024, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/io/g6-api-utilities.h
+++ b/c/graphLib/io/g6-api-utilities.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2024, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/io/g6-read-iterator.c
+++ b/c/graphLib/io/g6-read-iterator.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2024, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/io/g6-read-iterator.h
+++ b/c/graphLib/io/g6-read-iterator.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2024, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/io/g6-write-iterator.c
+++ b/c/graphLib/io/g6-write-iterator.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2024, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/io/g6-write-iterator.h
+++ b/c/graphLib/io/g6-write-iterator.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2024, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/io/graphIO.c
+++ b/c/graphLib/io/graphIO.c
@@ -1016,7 +1016,7 @@ void _LogLine(char *Str)
     _Log("\n");
 }
 
-static char LogStr[512];
+static char LogStr[MAXLINE + 1];
 
 char *_MakeLogStr1(char *format, int one)
 {

--- a/c/graphLib/io/graphIO.c
+++ b/c/graphLib/io/graphIO.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/io/strOrFile.c
+++ b/c/graphLib/io/strOrFile.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2024, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/io/strOrFile.h
+++ b/c/graphLib/io/strOrFile.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2024, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/io/strbuf.c
+++ b/c/graphLib/io/strbuf.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/io/strbuf.h
+++ b/c/graphLib/io/strbuf.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/lowLevelUtils/apiutils.c
+++ b/c/graphLib/lowLevelUtils/apiutils.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2024, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/lowLevelUtils/apiutils.h
+++ b/c/graphLib/lowLevelUtils/apiutils.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2024, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/lowLevelUtils/appconst.h
+++ b/c/graphLib/lowLevelUtils/appconst.h
@@ -2,7 +2,7 @@
 #define APPCONST_H
 
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/lowLevelUtils/listcoll.c
+++ b/c/graphLib/lowLevelUtils/listcoll.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/lowLevelUtils/listcoll.h
+++ b/c/graphLib/lowLevelUtils/listcoll.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/lowLevelUtils/platformTime.h
+++ b/c/graphLib/lowLevelUtils/platformTime.h
@@ -2,7 +2,7 @@
 #define PLATFORM_TIME
 
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/lowLevelUtils/stack.c
+++ b/c/graphLib/lowLevelUtils/stack.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/lowLevelUtils/stack.h
+++ b/c/graphLib/lowLevelUtils/stack.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/planarityRelated/graphDrawPlanar.c
+++ b/c/graphLib/planarityRelated/graphDrawPlanar.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/planarityRelated/graphDrawPlanar.h
+++ b/c/graphLib/planarityRelated/graphDrawPlanar.h
@@ -2,7 +2,7 @@
 #define GRAPH_DRAWPLANAR_H
 
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/planarityRelated/graphDrawPlanar.private.h
+++ b/c/graphLib/planarityRelated/graphDrawPlanar.private.h
@@ -2,7 +2,7 @@
 #define GRAPH_DRAWPLANAR_PRIVATE_H
 
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/planarityRelated/graphDrawPlanar_Extensions.c
+++ b/c/graphLib/planarityRelated/graphDrawPlanar_Extensions.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/planarityRelated/graphEmbed.c
+++ b/c/graphLib/planarityRelated/graphEmbed.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/planarityRelated/graphIsolator.c
+++ b/c/graphLib/planarityRelated/graphIsolator.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/planarityRelated/graphNonplanar.c
+++ b/c/graphLib/planarityRelated/graphNonplanar.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/planarityRelated/graphOuterplanarObstruction.c
+++ b/c/graphLib/planarityRelated/graphOuterplanarObstruction.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/graphLib/planarityRelated/graphTests.c
+++ b/c/graphLib/planarityRelated/graphTests.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/planarityApp/planarity.c
+++ b/c/planarityApp/planarity.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2024, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/planarityApp/planarity.h
+++ b/c/planarityApp/planarity.h
@@ -2,7 +2,7 @@
 #define PLANARITY_H
 
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/planarityApp/planarityCommandLine.c
+++ b/c/planarityApp/planarityCommandLine.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/planarityApp/planarityHelp.c
+++ b/c/planarityApp/planarityHelp.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2024, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */
@@ -21,7 +21,7 @@ char *GetProjectTitle(void)
 
     return "\n=================================================="
            "\nThe Edge Addition Planarity Suite version 3.0.2.0"
-           "\nCopyright (c) 1997-2024 by John M. Boyer"
+           "\nCopyright (c) 1997-2025 by John M. Boyer"
            "\nAll rights reserved."
            "\nSee the LICENSE.TXT file for licensing information."
            "\nContact info: jboyer at acm.org"

--- a/c/planarityApp/planarityHelp.c
+++ b/c/planarityApp/planarityHelp.c
@@ -8,24 +8,20 @@ See the LICENSE.TXT file for licensing information.
 
 char *GetProjectTitle(void)
 {
-    // This message is the main location of the version number.
-    // The format is major.minor.maintenance.tweak
-    // Major is for an overhaul (e.g. many features, data structure change, change of backward compatibility)
-    // Minor is for feature addition (e.g. a new algorithm implementation added, new interface)
-    // Maintenance is for functional revision (e.g. bug fix to existing algorithm implementation)
-    // Tweak is for a non-functional revision (e.g. change of build scripts or testing code, user-facing string changes)
+    static char projectTitle[MAXLINE + 1];
+    sprintf(projectTitle,
+            "\n==================================================="
+            "\nThe Edge Addition Planarity Suite version %s"
+            "\nbased on libPlanarity graph library version %s"
+            "\nCopyright (c) 1997-2025 by John M. Boyer"
+            "\nAll rights reserved."
+            "\nSee the LICENSE.TXT file for licensing information."
+            "\nContact info: jboyer at acm.org"
+            "\n===================================================\n",
+            gp_GetProjectVersionFull(),
+            gp_GetLibPlanarityVersionFull());
 
-    // If the version here is increased, also increase it in configure.ac
-    // Furthermore, a change of Major, Minor or Maintenance here should cause a change
-    // of Current, Revision and/or Age as documented in configure.ac
-
-    return "\n=================================================="
-           "\nThe Edge Addition Planarity Suite version 4.0.0.0"
-           "\nCopyright (c) 1997-2025 by John M. Boyer"
-           "\nAll rights reserved."
-           "\nSee the LICENSE.TXT file for licensing information."
-           "\nContact info: jboyer at acm.org"
-           "\n==================================================\n";
+    return projectTitle;
 }
 
 /****************************************************************************

--- a/c/planarityApp/planarityHelp.c
+++ b/c/planarityApp/planarityHelp.c
@@ -20,7 +20,7 @@ char *GetProjectTitle(void)
     // of Current, Revision and/or Age as documented in configure.ac
 
     return "\n=================================================="
-           "\nThe Edge Addition Planarity Suite version 3.0.2.0"
+           "\nThe Edge Addition Planarity Suite version 4.0.0.0"
            "\nCopyright (c) 1997-2025 by John M. Boyer"
            "\nAll rights reserved."
            "\nSee the LICENSE.TXT file for licensing information."

--- a/c/planarityApp/planarityMenu.c
+++ b/c/planarityApp/planarityMenu.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2024, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/planarityApp/planarityRandomGraphs.c
+++ b/c/planarityApp/planarityRandomGraphs.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/planarityApp/planaritySpecificGraph.c
+++ b/c/planarityApp/planaritySpecificGraph.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/planarityApp/planarityTestAllGraphs.c
+++ b/c/planarityApp/planarityTestAllGraphs.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2024, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/planarityApp/planarityTransformGraph.c
+++ b/c/planarityApp/planarityTransformGraph.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2024, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/c/planarityApp/planarityUtils.c
+++ b/c/planarityApp/planarityUtils.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 1997-2022, John M. Boyer
+Copyright (c) 1997-2025, John M. Boyer
 All rights reserved.
 See the LICENSE.TXT file for licensing information.
 */

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([planarity],[3.0.2.0],[jboyer@acm.org])
+AC_INIT([planarity],[4.0.0.0],[jboyer@acm.org])
 AM_INIT_AUTOMAKE([subdir-objects] [foreign])
 AC_CONFIG_MACRO_DIRS([m4])
 AC_CONFIG_SRCDIR([c/])
@@ -14,9 +14,9 @@ AC_CONFIG_SRCDIR([c/])
 # revision to zero and increment age.
 # 3. If interfaces were removed (breaks backward compatibility): increment
 # current, and set both revision and age to zero.
-LT_CURRENT=1
+LT_CURRENT=2
 LT_REVISION=0
-LT_AGE=1
+LT_AGE=0
 AC_SUBST(LT_CURRENT)
 AC_SUBST(LT_REVISION)
 AC_SUBST(LT_AGE)

--- a/configure.ac
+++ b/configure.ac
@@ -1,3 +1,5 @@
+# The version number in the following line must be synchronized with 
+# the project version numbering in graphLib.h 
 AC_INIT([planarity],[4.0.0.0],[jboyer@acm.org])
 AM_INIT_AUTOMAKE([subdir-objects] [foreign])
 AC_CONFIG_MACRO_DIRS([m4])
@@ -6,6 +8,9 @@ AC_CONFIG_SRCDIR([c/])
 # The version of the libtool library is of the form current:revision:age
 #
 # See http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
+#
+# The version number in the following line must be synchronized with 
+# the LibPlanarity version numbers in graphLib.h 
 #
 # When doing a release, they should be updated like this:
 # 1. If no interfaces changed, only implementations: just increment


### PR DESCRIPTION
Changed copyright year in comments and display strings, changed version numbering for project and shared library, changed how version numbering was expressed and maintained to make it easier to programmatically request project and API version numbering information. Intended to close #138 