### PR TITLE
Issue #24 - Use compiler preprocessor option to Signal 1-based versus 0-based Array Indexing

### DIFF
--- a/c/graphLib/graphStructures.h
+++ b/c/graphLib/graphStructures.h
@@ -64,14 +64,14 @@ extern "C"
 
     typedef edgeRec *edgeRecP;
 
-#ifdef ZEROBASED
-#define gp_IsArc(e) ((e) != NIL)
-#define gp_IsNotArc(e) ((e) == NIL)
-#define gp_GetFirstEdge(theGraph) (0)
-#else
+#ifdef USE_FASTER_1BASEDARRAYS
 #define gp_IsArc(e) (e)
 #define gp_IsNotArc(e) (!(e))
 #define gp_GetFirstEdge(theGraph) (2)
+#else
+#define gp_IsArc(e) ((e) != NIL)
+#define gp_IsNotArc(e) ((e) == NIL)
+#define gp_GetFirstEdge(theGraph) (0)
 #endif
 
 #define gp_EdgeInUse(theGraph, e) (gp_IsVertex(gp_GetNeighbor(theGraph, e)))
@@ -218,26 +218,7 @@ extern "C"
 #define gp_SetArc(theGraph, v, theLink, newArc) (theGraph->V[v].link[theLink] = newArc)
 
 // Vertex conversions and iteration
-#ifdef ZEROBASED
-#define gp_IsVertex(v) ((v) != NIL)
-#define gp_IsNotVertex(v) ((v) == NIL)
-
-#define gp_GetFirstVertex(theGraph) (0)
-#define gp_GetLastVertex(theGraph) ((theGraph)->N - 1)
-#define gp_VertexInRange(theGraph, v) ((v) < (theGraph)->N)
-#define gp_VertexInRangeDescending(theGraph, v) ((v) >= 0)
-
-#define gp_PrimaryVertexIndexBound(theGraph) (gp_GetFirstVertex(theGraph) + (theGraph)->N)
-#define gp_VertexIndexBound(theGraph) (gp_PrimaryVertexIndexBound(theGraph) + (theGraph)->N)
-
-#define gp_IsVirtualVertex(theGraph, v) ((v) >= theGraph->N)
-#define gp_IsNotVirtualVertex(theGraph, v) ((v) < theGraph->N)
-#define gp_VirtualVertexInUse(theGraph, virtualVertex) (gp_IsArc(gp_GetFirstArc(theGraph, virtualVertex)))
-#define gp_VirtualVertexNotInUse(theGraph, virtualVertex) (gp_IsNotArc(gp_GetFirstArc(theGraph, virtualVertex)))
-#define gp_GetFirstVirtualVertex(theGraph) (theGraph->N)
-#define gp_GetLastVirtualVertex(theGraph) (theGraph->N + theGraph->NV - 1)
-#define gp_VirtualVertexInRange(theGraph, v) ((v) < theGraph->N + theGraph->NV)
-#else
+#ifdef USE_FASTER_1BASEDARRAYS
 #define gp_IsVertex(v) (v)
 #define gp_IsNotVertex(v) (!(v))
 
@@ -256,6 +237,25 @@ extern "C"
 #define gp_GetFirstVirtualVertex(theGraph) (theGraph->N + 1)
 #define gp_GetLastVirtualVertex(theGraph) (theGraph->N + theGraph->NV)
 #define gp_VirtualVertexInRange(theGraph, v) ((v) <= theGraph->N + theGraph->NV)
+#else
+#define gp_IsVertex(v) ((v) != NIL)
+#define gp_IsNotVertex(v) ((v) == NIL)
+
+#define gp_GetFirstVertex(theGraph) (0)
+#define gp_GetLastVertex(theGraph) ((theGraph)->N - 1)
+#define gp_VertexInRange(theGraph, v) ((v) < (theGraph)->N)
+#define gp_VertexInRangeDescending(theGraph, v) ((v) >= 0)
+
+#define gp_PrimaryVertexIndexBound(theGraph) (gp_GetFirstVertex(theGraph) + (theGraph)->N)
+#define gp_VertexIndexBound(theGraph) (gp_PrimaryVertexIndexBound(theGraph) + (theGraph)->N)
+
+#define gp_IsVirtualVertex(theGraph, v) ((v) >= theGraph->N)
+#define gp_IsNotVirtualVertex(theGraph, v) ((v) < theGraph->N)
+#define gp_VirtualVertexInUse(theGraph, virtualVertex) (gp_IsArc(gp_GetFirstArc(theGraph, virtualVertex)))
+#define gp_VirtualVertexNotInUse(theGraph, virtualVertex) (gp_IsNotArc(gp_GetFirstArc(theGraph, virtualVertex)))
+#define gp_GetFirstVirtualVertex(theGraph) (theGraph->N)
+#define gp_GetLastVirtualVertex(theGraph) (theGraph->N + theGraph->NV - 1)
+#define gp_VirtualVertexInRange(theGraph, v) ((v) < theGraph->N + theGraph->NV)
 #endif
 
 #define gp_GetRootFromDFSChild(theGraph, c) ((c) + theGraph->N)

--- a/c/graphLib/graphStructures.h
+++ b/c/graphLib/graphStructures.h
@@ -64,16 +64,14 @@ extern "C"
 
     typedef edgeRec *edgeRecP;
 
-#if NIL == 0
-#define gp_IsArc(e) (e)
-#define gp_IsNotArc(e) (!(e))
-#define gp_GetFirstEdge(theGraph) (2)
-#elif NIL == -1
+#ifdef ZEROBASED
 #define gp_IsArc(e) ((e) != NIL)
 #define gp_IsNotArc(e) ((e) == NIL)
 #define gp_GetFirstEdge(theGraph) (0)
 #else
-#error NIL must be 0 or -1
+#define gp_IsArc(e) (e)
+#define gp_IsNotArc(e) (!(e))
+#define gp_GetFirstEdge(theGraph) (2)
 #endif
 
 #define gp_EdgeInUse(theGraph, e) (gp_IsVertex(gp_GetNeighbor(theGraph, e)))
@@ -220,27 +218,7 @@ extern "C"
 #define gp_SetArc(theGraph, v, theLink, newArc) (theGraph->V[v].link[theLink] = newArc)
 
 // Vertex conversions and iteration
-#if NIL == 0
-#define gp_IsVertex(v) (v)
-#define gp_IsNotVertex(v) (!(v))
-
-#define gp_GetFirstVertex(theGraph) (1)
-#define gp_GetLastVertex(theGraph) ((theGraph)->N)
-#define gp_VertexInRange(theGraph, v) ((v) <= (theGraph)->N)
-#define gp_VertexInRangeDescending(theGraph, v) (v)
-
-#define gp_PrimaryVertexIndexBound(theGraph) (gp_GetFirstVertex(theGraph) + (theGraph)->N)
-#define gp_VertexIndexBound(theGraph) (gp_PrimaryVertexIndexBound(theGraph) + (theGraph)->N)
-
-#define gp_IsVirtualVertex(theGraph, v) ((v) > theGraph->N)
-#define gp_IsNotVirtualVertex(theGraph, v) ((v) <= theGraph->N)
-#define gp_VirtualVertexInUse(theGraph, virtualVertex) (gp_IsArc(gp_GetFirstArc(theGraph, virtualVertex)))
-#define gp_VirtualVertexNotInUse(theGraph, virtualVertex) (gp_IsNotArc(gp_GetFirstArc(theGraph, virtualVertex)))
-#define gp_GetFirstVirtualVertex(theGraph) (theGraph->N + 1)
-#define gp_GetLastVirtualVertex(theGraph) (theGraph->N + theGraph->NV)
-#define gp_VirtualVertexInRange(theGraph, v) ((v) <= theGraph->N + theGraph->NV)
-
-#elif NIL == -1
+#ifdef ZEROBASED
 #define gp_IsVertex(v) ((v) != NIL)
 #define gp_IsNotVertex(v) ((v) == NIL)
 
@@ -259,9 +237,25 @@ extern "C"
 #define gp_GetFirstVirtualVertex(theGraph) (theGraph->N)
 #define gp_GetLastVirtualVertex(theGraph) (theGraph->N + theGraph->NV - 1)
 #define gp_VirtualVertexInRange(theGraph, v) ((v) < theGraph->N + theGraph->NV)
-
 #else
-#error NIL must be 0 or -1
+#define gp_IsVertex(v) (v)
+#define gp_IsNotVertex(v) (!(v))
+
+#define gp_GetFirstVertex(theGraph) (1)
+#define gp_GetLastVertex(theGraph) ((theGraph)->N)
+#define gp_VertexInRange(theGraph, v) ((v) <= (theGraph)->N)
+#define gp_VertexInRangeDescending(theGraph, v) (v)
+
+#define gp_PrimaryVertexIndexBound(theGraph) (gp_GetFirstVertex(theGraph) + (theGraph)->N)
+#define gp_VertexIndexBound(theGraph) (gp_PrimaryVertexIndexBound(theGraph) + (theGraph)->N)
+
+#define gp_IsVirtualVertex(theGraph, v) ((v) > theGraph->N)
+#define gp_IsNotVirtualVertex(theGraph, v) ((v) <= theGraph->N)
+#define gp_VirtualVertexInUse(theGraph, virtualVertex) (gp_IsArc(gp_GetFirstArc(theGraph, virtualVertex)))
+#define gp_VirtualVertexNotInUse(theGraph, virtualVertex) (gp_IsNotArc(gp_GetFirstArc(theGraph, virtualVertex)))
+#define gp_GetFirstVirtualVertex(theGraph) (theGraph->N + 1)
+#define gp_GetLastVirtualVertex(theGraph) (theGraph->N + theGraph->NV)
+#define gp_VirtualVertexInRange(theGraph, v) ((v) <= theGraph->N + theGraph->NV)
 #endif
 
 #define gp_GetRootFromDFSChild(theGraph, c) ((c) + theGraph->N)

--- a/c/graphLib/graphUtils.c
+++ b/c/graphLib/graphUtils.c
@@ -274,7 +274,11 @@ int _InitGraph(graphP theGraph, int N)
  ********************************************************************/
 void _InitVertices(graphP theGraph)
 {
-#ifdef ZEROBASED
+#ifdef USE_FASTER_1BASEDARRAYS
+    memset(theGraph->V, NIL_CHAR, gp_VertexIndexBound(theGraph) * sizeof(vertexRec));
+    memset(theGraph->VI, NIL_CHAR, gp_PrimaryVertexIndexBound(theGraph) * sizeof(vertexInfo));
+    memset(theGraph->extFace, NIL_CHAR, gp_VertexIndexBound(theGraph) * sizeof(extFaceLinkRec));
+#else
     int v;
 
     memset(theGraph->V, NIL_CHAR, gp_VertexIndexBound(theGraph) * sizeof(vertexRec));
@@ -282,11 +286,7 @@ void _InitVertices(graphP theGraph)
     memset(theGraph->extFace, NIL_CHAR, gp_VertexIndexBound(theGraph) * sizeof(extFaceLinkRec));
 
     for (v = gp_GetFirstVertex(theGraph); gp_VertexInRange(theGraph, v); v++)
-        gp_InitVertexFlags(theGraph, v);
-#else
-    memset(theGraph->V, NIL_CHAR, gp_VertexIndexBound(theGraph) * sizeof(vertexRec));
-    memset(theGraph->VI, NIL_CHAR, gp_PrimaryVertexIndexBound(theGraph) * sizeof(vertexInfo));
-    memset(theGraph->extFace, NIL_CHAR, gp_VertexIndexBound(theGraph) * sizeof(extFaceLinkRec));
+        gp_InitVertexFlags(theGraph, v);    
 #endif
     // N.B. This is the legacy API-based approach to initializing the vertices
     // int v;
@@ -314,7 +314,9 @@ void _InitVertices(graphP theGraph)
  ********************************************************************/
 void _InitEdges(graphP theGraph)
 {
-#ifdef ZEROBASED
+#ifdef USE_FASTER_1BASEDARRAYS
+    memset(theGraph->E, NIL_CHAR, gp_EdgeIndexBound(theGraph) * sizeof(edgeRec));
+#else
     int e, Esize;
 
     memset(theGraph->E, NIL_CHAR, gp_EdgeIndexBound(theGraph) * sizeof(edgeRec));
@@ -322,8 +324,6 @@ void _InitEdges(graphP theGraph)
     Esize = gp_EdgeIndexBound(theGraph);
     for (e = gp_GetFirstEdge(theGraph); e < Esize; e++)
         gp_InitEdgeFlags(theGraph, e);
-#else
-    memset(theGraph->E, NIL_CHAR, gp_EdgeIndexBound(theGraph) * sizeof(edgeRec));
 #endif
     // N.B. This is the legacy API-based approach to initializing the edges
     // int e, Esize;
@@ -1789,11 +1789,11 @@ int gp_DeleteEdge(graphP theGraph, int e, int nextLink)
 
     // Clear the two edge records
     // (the bit twiddle (e & ~1) chooses the lesser of e and its twin arc)
-#ifdef ZEROBASED
+#ifdef USE_FASTER_1BASEDARRAYS
+    memset(theGraph->E + (e & ~1), NIL_CHAR, sizeof(edgeRec) << 1);
+#else
     _InitEdgeRec(theGraph, e);
     _InitEdgeRec(theGraph, gp_GetTwinArc(theGraph, e));
-#else
-    memset(theGraph->E + (e & ~1), NIL_CHAR, sizeof(edgeRec) << 1);
 #endif
 
     // Now we reduce the number of edges in the data structure

--- a/c/graphLib/graphUtils.c
+++ b/c/graphLib/graphUtils.c
@@ -274,11 +274,7 @@ int _InitGraph(graphP theGraph, int N)
  ********************************************************************/
 void _InitVertices(graphP theGraph)
 {
-#if NIL == 0
-    memset(theGraph->V, NIL_CHAR, gp_VertexIndexBound(theGraph) * sizeof(vertexRec));
-    memset(theGraph->VI, NIL_CHAR, gp_PrimaryVertexIndexBound(theGraph) * sizeof(vertexInfo));
-    memset(theGraph->extFace, NIL_CHAR, gp_VertexIndexBound(theGraph) * sizeof(extFaceLinkRec));
-#elif NIL == -1
+#ifdef ZEROBASED
     int v;
 
     memset(theGraph->V, NIL_CHAR, gp_VertexIndexBound(theGraph) * sizeof(vertexRec));
@@ -287,27 +283,30 @@ void _InitVertices(graphP theGraph)
 
     for (v = gp_GetFirstVertex(theGraph); gp_VertexInRange(theGraph, v); v++)
         gp_InitVertexFlags(theGraph, v);
-
 #else
-    int v;
-
-    // Initialize primary vertices
-    for (v = gp_GetFirstVertex(theGraph); gp_VertexInRange(theGraph, v); v++)
-    {
-        _InitVertexRec(theGraph, v);
-        _InitVertexInfo(theGraph, v);
-        gp_SetExtFaceVertex(theGraph, v, 0, NIL);
-        gp_SetExtFaceVertex(theGraph, v, 1, NIL);
-    }
-
-    // Initialize virtual vertices
-    for (v = gp_GetFirstVirtualVertex(theGraph); gp_VirtualVertexInRange(theGraph, v); v++)
-    {
-        _InitVertexRec(theGraph, v);
-        gp_SetExtFaceVertex(theGraph, v, 0, NIL);
-        gp_SetExtFaceVertex(theGraph, v, 1, NIL);
-    }
+    memset(theGraph->V, NIL_CHAR, gp_VertexIndexBound(theGraph) * sizeof(vertexRec));
+    memset(theGraph->VI, NIL_CHAR, gp_PrimaryVertexIndexBound(theGraph) * sizeof(vertexInfo));
+    memset(theGraph->extFace, NIL_CHAR, gp_VertexIndexBound(theGraph) * sizeof(extFaceLinkRec));
 #endif
+    // N.B. This is the legacy API-based approach to initializing the vertices
+    // int v;
+
+    // // Initialize primary vertices
+    // for (v = gp_GetFirstVertex(theGraph); gp_VertexInRange(theGraph, v); v++)
+    // {
+    //     _InitVertexRec(theGraph, v);
+    //     _InitVertexInfo(theGraph, v);
+    //     gp_SetExtFaceVertex(theGraph, v, 0, NIL);
+    //     gp_SetExtFaceVertex(theGraph, v, 1, NIL);
+    // }
+
+    // // Initialize virtual vertices
+    // for (v = gp_GetFirstVirtualVertex(theGraph); gp_VirtualVertexInRange(theGraph, v); v++)
+    // {
+    //     _InitVertexRec(theGraph, v);
+    //     gp_SetExtFaceVertex(theGraph, v, 0, NIL);
+    //     gp_SetExtFaceVertex(theGraph, v, 1, NIL);
+    // }
 }
 
 /********************************************************************
@@ -315,9 +314,7 @@ void _InitVertices(graphP theGraph)
  ********************************************************************/
 void _InitEdges(graphP theGraph)
 {
-#if NIL == 0
-    memset(theGraph->E, NIL_CHAR, gp_EdgeIndexBound(theGraph) * sizeof(edgeRec));
-#elif NIL == -1
+#ifdef ZEROBASED
     int e, Esize;
 
     memset(theGraph->E, NIL_CHAR, gp_EdgeIndexBound(theGraph) * sizeof(edgeRec));
@@ -325,14 +322,15 @@ void _InitEdges(graphP theGraph)
     Esize = gp_EdgeIndexBound(theGraph);
     for (e = gp_GetFirstEdge(theGraph); e < Esize; e++)
         gp_InitEdgeFlags(theGraph, e);
-
 #else
-    int e, Esize;
-
-    Esize = gp_EdgeIndexBound(theGraph);
-    for (e = gp_GetFirstEdge(theGraph); e < Esize; e++)
-        _InitEdgeRec(theGraph, e);
+    memset(theGraph->E, NIL_CHAR, gp_EdgeIndexBound(theGraph) * sizeof(edgeRec));
 #endif
+    // N.B. This is the legacy API-based approach to initializing the edges
+    // int e, Esize;
+
+    // Esize = gp_EdgeIndexBound(theGraph);
+    // for (e = gp_GetFirstEdge(theGraph); e < Esize; e++)
+    //     _InitEdgeRec(theGraph, e);
 }
 
 /********************************************************************
@@ -1791,11 +1789,11 @@ int gp_DeleteEdge(graphP theGraph, int e, int nextLink)
 
     // Clear the two edge records
     // (the bit twiddle (e & ~1) chooses the lesser of e and its twin arc)
-#if NIL == 0
-    memset(theGraph->E + (e & ~1), NIL_CHAR, sizeof(edgeRec) << 1);
-#else
+#ifdef ZEROBASED
     _InitEdgeRec(theGraph, e);
     _InitEdgeRec(theGraph, gp_GetTwinArc(theGraph, e));
+#else
+    memset(theGraph->E + (e & ~1), NIL_CHAR, sizeof(edgeRec) << 1);
 #endif
 
     // Now we reduce the number of edges in the data structure

--- a/c/graphLib/homeomorphSearch/graphK33Search_Extensions.c
+++ b/c/graphLib/homeomorphSearch/graphK33Search_Extensions.c
@@ -219,23 +219,22 @@ int _K33Search_CreateStructures(K33SearchContext *context)
  ********************************************************************/
 int _K33Search_InitStructures(K33SearchContext *context)
 {
-#if NIL == 0 || NIL == -1
     memset(context->VI, NIL_CHAR, gp_PrimaryVertexIndexBound(context->theGraph) * sizeof(K33Search_VertexInfo));
     memset(context->E, NIL_CHAR, gp_EdgeIndexBound(context->theGraph) * sizeof(K33Search_EdgeRec));
-#else
-    graphP theGraph = context->theGraph;
-    int v, e, Esize;
+    // N.B. This is the legacy API-based approach to initializing the structures
+    // required for the K_{3, 3} search graph algorithm extension.
+    // graphP theGraph = context->theGraph;
+    // int v, e, Esize;
 
-    if (theGraph->N <= 0)
-        return OK;
+    // if (theGraph->N <= 0)
+    //     return OK;
 
-    for (v = gp_GetFirstVertex(theGraph); gp_VertexInRange(theGraph, v); v++)
-        _K33Search_InitVertexInfo(context, v);
+    // for (v = gp_GetFirstVertex(theGraph); gp_VertexInRange(theGraph, v); v++)
+    //     _K33Search_InitVertexInfo(context, v);
 
-    Esize = gp_EdgeIndexBound(theGraph);
-    for (e = gp_GetFirstEdge(theGraph); e < Esize; e++)
-        _K33Search_InitEdgeRec(context, e);
-#endif
+    // Esize = gp_EdgeIndexBound(theGraph);
+    // for (e = gp_GetFirstEdge(theGraph); e < Esize; e++)
+    //     _K33Search_InitEdgeRec(context, e);
 
     return OK;
 }

--- a/c/graphLib/homeomorphSearch/graphK4Search_Extensions.c
+++ b/c/graphLib/homeomorphSearch/graphK4Search_Extensions.c
@@ -188,15 +188,14 @@ int _K4Search_CreateStructures(K4SearchContext *context)
  ********************************************************************/
 int _K4Search_InitStructures(K4SearchContext *context)
 {
-#if NIL == 0 || NIL == -1
     memset(context->E, NIL_CHAR, gp_EdgeIndexBound(context->theGraph) * sizeof(K4Search_EdgeRec));
-#else
-    int e, Esize;
+    // N.B. This is the legacy API-based approach to initializing the structures
+    // required for the K_4 search graph algorithm extension.
+    // int e, Esize;
 
-    Esize = gp_EdgeIndexBound(context->theGraph);
-    for (e = gp_GetFirstEdge(context->theGraph); e < Esize; e++)
-        _K4Search_InitEdgeRec(context, e);
-#endif
+    // Esize = gp_EdgeIndexBound(context->theGraph);
+    // for (e = gp_GetFirstEdge(context->theGraph); e < Esize; e++)
+    //     _K4Search_InitEdgeRec(context, e);
 
     return OK;
 }

--- a/c/graphLib/io/strOrFile.c
+++ b/c/graphLib/io/strOrFile.c
@@ -5,6 +5,7 @@ See the LICENSE.TXT file for licensing information.
 */
 
 #include <ctype.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>

--- a/c/graphLib/lowLevelUtils/appconst.h
+++ b/c/graphLib/lowLevelUtils/appconst.h
@@ -74,15 +74,20 @@ extern int debugNOTOK(void);
 #endif
 
 /* Array indices are used as pointers, and NIL means bad pointer */
+#define USE_FASTER_1BASEDARRAYS
 
-#ifdef ZEROBASED
-// This definition is used with 0-based array indexing
-#define NIL -1
-#define NIL_CHAR 0xFF
-#else
+#ifdef USE_0BASEDARRAYS
+#undef USE_FASTER_1BASEDARRAYS
+#endif
+
+#ifdef USE_FASTER_1BASEDARRAYS
 // This definition is used with 1-based array indexing
 #define NIL 0
 #define NIL_CHAR 0x00
+#else
+// This definition is used with 0-based array indexing
+#define NIL -1
+#define NIL_CHAR 0xFF
 #endif
 
 /********************************************************************

--- a/c/graphLib/lowLevelUtils/appconst.h
+++ b/c/graphLib/lowLevelUtils/appconst.h
@@ -75,13 +75,15 @@ extern int debugNOTOK(void);
 
 /* Array indices are used as pointers, and NIL means bad pointer */
 
+#ifdef ZEROBASED
+// This definition is used with 0-based array indexing
+#define NIL -1
+#define NIL_CHAR 0xFF
+#else
 // This definition is used with 1-based array indexing
 #define NIL 0
 #define NIL_CHAR 0x00
-
-// This definition is used in combination with 0-based array indexing
-// #define NIL      -1
-// #define NIL_CHAR 0xFF
+#endif
 
 /********************************************************************
  A few simple integer selection macros

--- a/c/graphLib/planarityRelated/graphDrawPlanar_Extensions.c
+++ b/c/graphLib/planarityRelated/graphDrawPlanar_Extensions.c
@@ -221,7 +221,10 @@ int _DrawPlanar_CreateStructures(DrawPlanarContext *context)
  ********************************************************************/
 int _DrawPlanar_InitStructures(DrawPlanarContext *context)
 {
-#ifdef ZEROBASED
+#ifdef USE_FASTER_1BASEDARRAYS
+    memset(context->VI, NIL_CHAR, gp_PrimaryVertexIndexBound(context->theGraph) * sizeof(DrawPlanar_VertexInfo));
+    memset(context->E, NIL_CHAR, gp_EdgeIndexBound(context->theGraph) * sizeof(DrawPlanar_EdgeRec));
+#else
     int v, e, Esize;
     graphP theGraph = context->theGraph;
 
@@ -234,9 +237,6 @@ int _DrawPlanar_InitStructures(DrawPlanarContext *context)
     Esize = gp_EdgeIndexBound(theGraph);
     for (e = gp_GetFirstEdge(theGraph); e < Esize; e++)
         _DrawPlanar_InitEdgeRec(context, e);
-#else
-    memset(context->VI, NIL_CHAR, gp_PrimaryVertexIndexBound(context->theGraph) * sizeof(DrawPlanar_VertexInfo));
-    memset(context->E, NIL_CHAR, gp_EdgeIndexBound(context->theGraph) * sizeof(DrawPlanar_EdgeRec));
 #endif
 
     return OK;

--- a/c/graphLib/planarityRelated/graphDrawPlanar_Extensions.c
+++ b/c/graphLib/planarityRelated/graphDrawPlanar_Extensions.c
@@ -221,10 +221,7 @@ int _DrawPlanar_CreateStructures(DrawPlanarContext *context)
  ********************************************************************/
 int _DrawPlanar_InitStructures(DrawPlanarContext *context)
 {
-#if NIL == 0
-    memset(context->VI, NIL_CHAR, gp_PrimaryVertexIndexBound(context->theGraph) * sizeof(DrawPlanar_VertexInfo));
-    memset(context->E, NIL_CHAR, gp_EdgeIndexBound(context->theGraph) * sizeof(DrawPlanar_EdgeRec));
-#else
+#ifdef ZEROBASED
     int v, e, Esize;
     graphP theGraph = context->theGraph;
 
@@ -237,6 +234,9 @@ int _DrawPlanar_InitStructures(DrawPlanarContext *context)
     Esize = gp_EdgeIndexBound(theGraph);
     for (e = gp_GetFirstEdge(theGraph); e < Esize; e++)
         _DrawPlanar_InitEdgeRec(context, e);
+#else
+    memset(context->VI, NIL_CHAR, gp_PrimaryVertexIndexBound(context->theGraph) * sizeof(DrawPlanar_VertexInfo));
+    memset(context->E, NIL_CHAR, gp_EdgeIndexBound(context->theGraph) * sizeof(DrawPlanar_EdgeRec));
 #endif
 
     return OK;

--- a/c/planarityApp/planarityCommandLine.c
+++ b/c/planarityApp/planarityCommandLine.c
@@ -194,8 +194,8 @@ int runSpecificGraphTests(char *samplesDir)
         }
     }
 
-#if NIL == 0
-    Message("Starting NIL == 0 Tests\n");
+#ifndef ZEROBASED
+    Message("\n\tStarting Zero-based Array Index Tests\n\n");
 
     if (runSpecificGraphTest("-p", "maxPlanar5.txt", TRUE) < 0)
     {
@@ -245,7 +245,7 @@ int runSpecificGraphTests(char *samplesDir)
         Message("K_4 search on Petersen.txt failed.\n");
     }
 
-    Message("Finished NIL == 0 Tests.\n\n");
+    Message("\tFinished Zero-based Array Index Tests.\n\n");
 #endif
 
     if (runSpecificGraphTest("-p", "maxPlanar5.0-based.txt", FALSE) < 0)

--- a/c/planarityApp/planarityCommandLine.c
+++ b/c/planarityApp/planarityCommandLine.c
@@ -194,8 +194,8 @@ int runSpecificGraphTests(char *samplesDir)
         }
     }
 
-#ifndef ZEROBASED
-    Message("\n\tStarting Zero-based Array Index Tests\n\n");
+#ifdef USE_FASTER_1BASEDARRAYS
+    Message("\n\tStarting 1-based Array Index Tests\n\n");
 
     if (runSpecificGraphTest("-p", "maxPlanar5.txt", TRUE) < 0)
     {
@@ -245,7 +245,7 @@ int runSpecificGraphTests(char *samplesDir)
         Message("K_4 search on Petersen.txt failed.\n");
     }
 
-    Message("\tFinished Zero-based Array Index Tests.\n\n");
+    Message("\tFinished 1-based Array Index Tests.\n\n");
 #endif
 
     if (runSpecificGraphTest("-p", "maxPlanar5.0-based.txt", FALSE) < 0)

--- a/devEnvSetupAndDefaults/.vscode/tasks.json
+++ b/devEnvSetupAndDefaults/.vscode/tasks.json
@@ -7,6 +7,7 @@
             "args": [
                 "-fdiagnostics-color=always",
                 "-DDEBUG", // Added so that _DEBUG is defined; see appconst.h
+                //"-DZEROBASED", // Uncomment if you wish to use (slow) 0-based array indexing
                 "-Wall",
                 // "-Wextra",
                 "-g",
@@ -62,6 +63,7 @@
             "command": "C:\\msys64\\ucrt64\\bin\\gcc.exe",
             "args": [
                 "-O3",
+                //"-DZEROBASED", // Uncomment if you wish to use (slow) 0-based array indexing
                 "-Wall",
                 // "-Wextra",
                 "-g",
@@ -118,6 +120,7 @@
             "args": [
                 "-fdiagnostics-color=always",
                 "-DDEBUG", // Added so that _DEBUG is defined; see appconst.h
+                //"-DZEROBASED", // Uncomment if you wish to use (slow) 0-based array indexing
                 "-Wall",
                 // "-Wextra",
                 "-g",
@@ -146,6 +149,7 @@
             "command": "/usr/bin/gcc",
             "args": [
                 "-O3",
+                //"-DZEROBASED", // Uncomment if you wish to use (slow) 0-based array indexing
                 "-Wall",
                 // "-Wextra",
                 "-g",
@@ -178,6 +182,7 @@
                 "/EHsc",
                 "/nologo",
                 "/DDEBUG", // Added so that _DEBUG is defined; see appconst.h
+                //"/DZEROBASED", // Uncomment if you wish to use (slow) 0-based array indexing
                 "/Wall",
                 "/wd4464", // Ignore warnings about relative paths
                 "/wd4710", // Ignore warnings about not inlining scanf, sprintf, printf, fprintf, etc.
@@ -214,6 +219,7 @@
             "args": [
                 "/O2", // This is the maximum optimization level available for MSVC cl
                 "/nologo",
+                //"/DZEROBASED", // Uncomment if you wish to use (slow) 0-based array indexing
                 "/Wall",
                 "/wd4464", // Ignore warnings about relative paths
                 "/wd4710", // Ignore warnings about not inlining scanf, sprintf, printf, fprintf, etc.
@@ -250,9 +256,10 @@
             "args": [
                 "-fcolor-diagnostics",
                 "-fansi-escape-codes",
+                "-DDEBUG", // Added so that _DEBUG is defined; see appconst.h
+                //"-DZEROBASED", // Uncomment if you wish to use (slow) 0-based array indexing
                 "-Wall",
                 // "-Wextra",
-                "-DDEBUG", // Added so that _DEBUG is defined; see appconst.h
                 "-g",
                 "${workspaceFolder}/c/planarityApp/**.c",
                 "${workspaceFolder}/c/graphLib/**.c",
@@ -279,6 +286,7 @@
             "command": "clang",
             "args": [
                 "-O3",
+                //"-DZEROBASED", // Uncomment if you wish to use (slow) 0-based array indexing
                 "-Wall",
                 // "-Wextra",
                 "-g",

--- a/devEnvSetupAndDefaults/.vscode/tasks.json
+++ b/devEnvSetupAndDefaults/.vscode/tasks.json
@@ -7,7 +7,7 @@
             "args": [
                 "-fdiagnostics-color=always",
                 "-DDEBUG", // Added so that _DEBUG is defined; see appconst.h
-                //"-DZEROBASED", // Uncomment if you wish to use (slow) 0-based array indexing
+                //"-DUSE_0BASEDARRAYS", // Commented out to use faster 1-based array indexing
                 "-Wall",
                 // "-Wextra",
                 "-g",
@@ -63,7 +63,7 @@
             "command": "C:\\msys64\\ucrt64\\bin\\gcc.exe",
             "args": [
                 "-O3",
-                //"-DZEROBASED", // Uncomment if you wish to use (slow) 0-based array indexing
+                //"-DUSE_0BASEDARRAYS", // Commented out to use faster 1-based array indexing
                 "-Wall",
                 // "-Wextra",
                 "-g",
@@ -120,7 +120,7 @@
             "args": [
                 "-fdiagnostics-color=always",
                 "-DDEBUG", // Added so that _DEBUG is defined; see appconst.h
-                //"-DZEROBASED", // Uncomment if you wish to use (slow) 0-based array indexing
+                //"-DUSE_0BASEDARRAYS", // Commented out to use faster 1-based array indexing
                 "-Wall",
                 // "-Wextra",
                 "-g",
@@ -149,7 +149,7 @@
             "command": "/usr/bin/gcc",
             "args": [
                 "-O3",
-                //"-DZEROBASED", // Uncomment if you wish to use (slow) 0-based array indexing
+                //"-DUSE_0BASEDARRAYS", // Commented out to use faster 1-based array indexing
                 "-Wall",
                 // "-Wextra",
                 "-g",
@@ -182,7 +182,7 @@
                 "/EHsc",
                 "/nologo",
                 "/DDEBUG", // Added so that _DEBUG is defined; see appconst.h
-                //"/DZEROBASED", // Uncomment if you wish to use (slow) 0-based array indexing
+                //"/DUSE_0BASEDARRAYS", // Commented out to use faster 1-based array indexing
                 "/Wall",
                 "/wd4464", // Ignore warnings about relative paths
                 "/wd4710", // Ignore warnings about not inlining scanf, sprintf, printf, fprintf, etc.
@@ -219,7 +219,7 @@
             "args": [
                 "/O2", // This is the maximum optimization level available for MSVC cl
                 "/nologo",
-                //"/DZEROBASED", // Uncomment if you wish to use (slow) 0-based array indexing
+                //"/DUSE_0BASEDARRAYS", // Commented out to use faster 1-based array indexing
                 "/Wall",
                 "/wd4464", // Ignore warnings about relative paths
                 "/wd4710", // Ignore warnings about not inlining scanf, sprintf, printf, fprintf, etc.
@@ -257,7 +257,7 @@
                 "-fcolor-diagnostics",
                 "-fansi-escape-codes",
                 "-DDEBUG", // Added so that _DEBUG is defined; see appconst.h
-                //"-DZEROBASED", // Uncomment if you wish to use (slow) 0-based array indexing
+                //"-DUSE_0BASEDARRAYS", // Commented out to use faster 1-based array indexing
                 "-Wall",
                 // "-Wextra",
                 "-g",
@@ -286,7 +286,7 @@
             "command": "clang",
             "args": [
                 "-O3",
-                //"-DZEROBASED", // Uncomment if you wish to use (slow) 0-based array indexing
+                //"-DUSE_0BASEDARRAYS", // Commented out to use faster 1-based array indexing
                 "-Wall",
                 // "-Wextra",
                 "-g",


### PR DESCRIPTION
Resolves #24

Updated [1. Project Overview - Optimization of 1-Based Array Indexing](https://github.com/graph-algorithms/edge-addition-planarity-suite/wiki/1.-Project-Overview#optimization-of-1-based-array-indexing) to reflect the change to how we manage 0-based vs. 1-based array indexing using the `-DUSE_0BASEDARRAYS`/`/D USE_0BASEDARRAYS` compiler option controlling the preprocessor.

## Updated
### Necessary bugfix
* `c/graphLib/io/strOrFile.c` - need to `#include <stdint.h>` for the definitions for `INT32_MIN`/`MAX`; this was not discovered during #140, although tests were performed on a MacBook pro with `clang`. I found a [StackOverflow response](https://stackoverflow.com/a/19440917) suggesting that perhaps `clang`'s `stdlib.h` includes `stdint.h` for internal purposes, which *might* have been why compilation/running didn't fail on MacOS but *did* on Windows without this include, but I couldn't manually divine the appropriate chain of `#include`s to have given `stdint.h` for free while surfing through the `clang` `stdlib.h` and `string.h` headers :(

### Changes pertaining to Issue #24 
* `c/graphLib/`
    * `graphStructures.h` - instead of conditioning on the value of `NIL`, now check whether `#ifdef USE_FASTER_1BASEDARRAYS`, and no longer need the `#else #error`.
    * `graphUtils.c` - instead of conditioning on the value of `NIL`, now check whether `#ifdef USE_FASTER_1BASEDARRAYS` for how to `_InitVertices()`; the legacy API-based approach to initialize vertices has been commented-out for future reference.
    * `homeomorphSearch/`
        * `graphK33Search_Extensions.c` - Previously, when `NIL` was either 0 or 1, we always performed the same `memset()`s, so the `#if` guard has been removed. The legacy API-based approach to initializing the structures required for K<sub>3, 3</sub> search has been commented-out for future reference.
        * `graphK4Search_Extensions.c` -  Previously, when `NIL` was either 0 or 1, we always performed the same `memset()`s, so the `#if` guard has been removed. The legacy API-based approach to initializing the structures required for K<sub>4</sub> search has been commented-out for future reference.
    * `lowLevelUtils/appconst.h` - definition of `NIL` and `NIL_CHAR` now depend on whether or not `USE_FASTER_1BASEDARRAYS` is defined. If the user compiles with the `-DUSE_0BASEDARRAYS`/`/DUSE_0BASEDARRAYS` compiler option to control the preprocessor, then we `#undef USE_FASTER_1BASEDARRAYS`, which means that `NIL` is set to `-1` and `NIL_CHAR` is set to `0xFF`. Otherwise, if this compiler option is not set, then the default 1-based values for `NIL` (i.e. `0`) and `NIL_CHAR` (i.e. `0x00`) are used.
    * `planarityRelated/graphDrawPlanar_Extensions.c` - now condition on whether `#ifdef USE_FASTER_1BASEDARRAYS` rather than `#ifdef NIL == 0` when we `_DrawPlanar_InitStructures()`
 * `c/planarityApp/planarityCommandLine.c` - Updated `Message()` contents to better indicate these are 1-based array index tests
* `devEnvSetupAndDefaults/.vscode/tasks.json` - added (commented out) compiler preprocessor option for defining `USE_0BASEDARRAYS` to all build configurations.