### PR TITLE
VSCode Release build configurations should make generating debug symbols optional

### DIFF
--- a/devEnvSetupAndDefaults/.vscode/tasks.json
+++ b/devEnvSetupAndDefaults/.vscode/tasks.json
@@ -10,7 +10,7 @@
                 //"-DUSE_0BASEDARRAYS", // Commented out to use faster 1-based array indexing
                 "-Wall",
                 // "-Wextra",
-                "-g",
+                "-g", // Generate debug symbols
                 "${workspaceFolder}\\c\\planarityApp\\planarity.c",
                 "${workspaceFolder}\\c\\planarityApp\\planarityCommandLine.c",
                 "${workspaceFolder}\\c\\planarityApp\\planarityHelp.c",
@@ -66,7 +66,7 @@
                 //"-DUSE_0BASEDARRAYS", // Commented out to use faster 1-based array indexing
                 "-Wall",
                 // "-Wextra",
-                "-g",
+                // "-g", // Uncomment to generate debug symbols for Release build and debug with VSCode
                 "${workspaceFolder}\\c\\planarityApp\\planarity.c",
                 "${workspaceFolder}\\c\\planarityApp\\planarityCommandLine.c",
                 "${workspaceFolder}\\c\\planarityApp\\planarityHelp.c",
@@ -123,7 +123,7 @@
                 //"-DUSE_0BASEDARRAYS", // Commented out to use faster 1-based array indexing
                 "-Wall",
                 // "-Wextra",
-                "-g",
+                "-g", // Generate debug symbols
                 "${workspaceFolder}/c/planarityApp/**.c",
                 "${workspaceFolder}/c/graphLib/**.c",
                 "${workspaceFolder}/c/graphLib/extensionSystem/**.c",
@@ -152,7 +152,7 @@
                 //"-DUSE_0BASEDARRAYS", // Commented out to use faster 1-based array indexing
                 "-Wall",
                 // "-Wextra",
-                "-g",
+                // "-g", // Uncomment to generate debug symbols for Release build and debug with VSCode
                 "${workspaceFolder}/c/planarityApp/**.c",
                 "${workspaceFolder}/c/graphLib/**.c",
                 "${workspaceFolder}/c/graphLib/extensionSystem/**.c",
@@ -178,7 +178,7 @@
             "command": "cl.exe",
             "args": [
                 "/Od", // Disables optimization, which speeds compilation and simplifies debugging
-                "/Zi",
+                "/Zi", // Generate debug symbols
                 "/EHsc",
                 "/nologo",
                 "/DDEBUG", // Added so that _DEBUG is defined; see appconst.h
@@ -260,7 +260,7 @@
                 //"-DUSE_0BASEDARRAYS", // Commented out to use faster 1-based array indexing
                 "-Wall",
                 // "-Wextra",
-                "-g",
+                "-g", // Generate debug symbols
                 "${workspaceFolder}/c/planarityApp/**.c",
                 "${workspaceFolder}/c/graphLib/**.c",
                 "${workspaceFolder}/c/graphLib/extensionSystem/**.c",
@@ -289,7 +289,7 @@
                 //"-DUSE_0BASEDARRAYS", // Commented out to use faster 1-based array indexing
                 "-Wall",
                 // "-Wextra",
-                "-g",
+                // "-g", // Uncomment to generate debug symbols for Release build and debug with VSCode
                 "${workspaceFolder}/c/planarityApp/**.c",
                 "${workspaceFolder}/c/graphLib/**.c",
                 "${workspaceFolder}/c/graphLib/extensionSystem/**.c",


### PR DESCRIPTION
I discovered a `.dSYM` Archived Debug Symbols file was being generated alongside the `Release` executable on MacOS using `clang`. A [StackOverflow reply](https://stackoverflow.com/a/76328264) has revealed that this is due to including `-g` flag in the `devEnvSetupAndDefaults/.vscode/tasks.json` default build configuration, which means that debug artifacts will be built to accompany both `Debug` *and* `Release` builds. I just verified that I’m able to hit a breakpoint in the `Release` executable when the `-g` flag is used to compile the executable, and that I fail to hit any breakpoint when `-g` is absent (no `.dSYM` debug symbols generated).

Looking at the size of `Release` executables produced, it's probably worthwhile to show users how to produce a leaner `Release` build using VSCode if they don't want to use the `autotools` build process (i.e. [`README.md` - Making the Distribution](https://github.com/graph-algorithms/edge-addition-planarity-suite?tab=readme-ov-file#making-the-distribution)):

| System + compiler toolchain + debug symbol flag | Size |
|---|---|
| `Release` executable built with `clang` on MacOS *with* `-g`| 245K |
| `Release` executable built with `clang` on MacOS *without* `-g` | 209K |
| `Release` executable built with MinGW-w64 UCRT `gcc` on Windows *with* `-g`| 887 KB |
| `Release` executable built with MinGW-w64 UCRT `gcc` on Windows *without* `-g` | 328KB |
| `Release` executable built with `gcc` on Debian Linux *with* `-g`| 680K |
| `Release` executable built with `gcc` on Debian Linux*without* `-g` | 203K |

## Updated
* `devEnvSetupAndDefaults/.vscode/tasks.json` - comment-out the lines containing `"-g"," in the `Release` default build configurations for `clang` on MacOS, `gcc` on Linux, and MinGW-w64 UCRT `gcc` on Windows so that users can choose whether they want to generate debug symbols for `Release` build for their development platform in order to be able to debug that executable with VSCode
    * __**N.B.**__ There's nothing to comment-out from the MSVC `cl` `Release` executable build configuration, because *it* doesn't include the [`/Zi`](https://learn.microsoft.com/en-us/cpp/build/reference/z7-zi-zi-debug-information-format?view=msvc-170) flag!