### PR TITLE
Specify `pkgconfigdir` in `Makefile.am`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -90,4 +90,5 @@ TESTS = test-samples.sh
 docdir = @docdir@
 dist_doc_DATA = README.md LICENSE.TXT
 
-pkgconfig_DATA = libplanarity.pc
+pkgconfigdir	= $(libdir)/pkgconfig
+pkgconfig_DATA	= libplanarity.pc


### PR DESCRIPTION
When compiling on certain architectures, the following error message is produced:
```
Makefile.am:93: error: 'pkgconfig_DATA' is used but 'pkgconfigdir' is undefined
```

This pull request specifies the `pkgconfigdir` to address that error.