### PR TITLE
Add some continuous integration checks

### DIFF
--- a/.github/workflows/compile-warnings.yml
+++ b/.github/workflows/compile-warnings.yml
@@ -1,0 +1,33 @@
+name: Compiler warnings
+on: [pull_request, workflow_dispatch]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: ${{ matrix.compiler }}
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    env:
+      CC: ${{ matrix.compiler }}
+      CFLAGS: -Werror
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [clang-18, gcc-14]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compiler information . . .
+        run: $CC --version
+        # TODO: Add --enable-compile-warnings to ./configure when available
+      - name: Configure . . .
+        run: |
+          mkdir -p m4
+          autoreconf -if
+          ./configure CC="$CC" CFLAGS="$CFLAGS"
+      - name: Build . . .
+        run: make -j4
+        # We don't run the tests, since in this job we are only checking for
+        # compiler warnings

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -1,0 +1,52 @@
+name: Compilers
+on: [pull_request, workflow_dispatch]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: ${{ matrix.sys.compiler }}-${{ matrix.sys.version }}
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sys:
+          - { compiler: gcc, version: 9 }
+          - { compiler: gcc, version: 10 }
+          - { compiler: gcc, version: 11 }
+          - { compiler: gcc, version: 12 }
+          - { compiler: gcc, version: 13 }
+          - { compiler: gcc, version: 14 }
+          - { compiler: clang, version: 14 }
+          - { compiler: clang, version: 15 }
+          - { compiler: clang, version: 16 }
+          - { compiler: clang, version: 17 }
+          - { compiler: clang, version: 18 }
+          - { compiler: clang, version: 19 }
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup compiler . . .
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa -y
+          sudo apt-get --yes update
+          sudo apt-get install ${{ matrix.sys.compiler }}-${{ matrix.sys.version }}
+          CC=${{ matrix.sys.compiler }}-${{ matrix.sys.version }}
+          echo "CC=$CC" >> $GITHUB_ENV
+      - name: Compiler information
+        run: |
+          echo $CC
+          $CC --version
+      - name: Configure . . .
+        env:
+          CC: ${{ env.CC }}
+        run: |
+          mkdir -p m4
+          autoreconf -if 
+          ./configure CC="$CC"
+      - name: Build . . .
+        run: make -j4
+      - name: Run the tests . . .
+        run: ./test-samples.sh

--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -1,0 +1,101 @@
+name: OS
+on: [pull_request, workflow_dispatch]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  alpine:
+    name: Alpine
+    defaults:
+      run:
+        shell: alpine.sh {0}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jirutka/setup-alpine@v1
+        with:
+          branch: v3.15
+      - name: Alpine/musl versions . . .
+        run: |
+          cat /etc/alpine-release
+          apk info musl
+      - name: Install autotools etc . . .
+        run: |
+          apk add build-base autoconf automake libtool
+        shell: alpine.sh --root {0}
+      - name: Configure . . .
+        run: autoreconf -if && ./configure
+      - name: Build . . .
+        run: make -j4
+      - name: Run the tests . . .
+        run: ./test-samples.sh
+  cygwin:
+    name: Cygwin
+    defaults:
+      run:
+        shell: C:\cygwin64\bin\bash.exe --login -o igncr '{0}'
+    timeout-minutes: 60
+    runs-on: windows-latest
+    env:
+      CHERE_INVOKING: 1
+    steps:
+      - uses: gap-actions/setup-cygwin@v1
+      - uses: actions/checkout@v4
+      - name: Configure . . .
+        run: autoreconf -if && ./configure
+      - name: Build . . .
+        run: make -j4
+      - name: Run the tests . . .
+        run: ./test-samples.sh
+  macos:
+    name: macOS
+    timeout-minutes: 60
+    runs-on: macOS-latest
+    env:
+      CC: clang
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies . . .
+        run: brew install autoconf automake libtool
+      - name: Clang version . . .
+        run: clang --version
+      - name: Configure . . .
+        run: |
+          mkdir -p m4
+          autoreconf -if
+          ./configure CC="$CC"
+      - name: Build . . .
+        run: make -j4
+      - name: Run the tests . . .
+        run: ./test-samples.sh
+  arm:
+    name: Ubuntu-arm
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install autotools etc . . .
+        run: sudo apt-get install autoconf automake libtool
+      - name: Configure . . .
+        run: autoreconf -if && ./configure
+      - name: Build . . .
+        run: make -j4
+      - name: Run the tests . . .
+        run: ./test-samples.sh
+  aarch64:
+    name: Ubuntu-aarch64
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - uses: uraimo/run-on-arch-action@v3
+        with:
+          arch: aarch64
+          distro: ubuntu22.04
+          run: |
+            apt-get --yes update
+            apt-get install autoconf automake libtool build-essential --yes
+            gcc --version
+            autoreconf -if && ./configure
+            make -j4
+            ./test-samples.sh

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -1,0 +1,48 @@
+name: Tests
+on: [pull_request, workflow_dispatch]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  basic-tests:
+    name: ${{ matrix.compiler }}
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    env:
+      CC: ${{ matrix.compiler }}
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [clang, gcc]
+    steps:
+      - uses: actions/checkout@v4
+      - name: test
+        run: |
+          echo ${{ github.event_name }}
+          echo ${{ github.event_name == 'pull_request' }}
+      - name: Configure . . .
+        run: |
+          mkdir -p m4
+          autoreconf -if 
+          ./configure CC="$CC"
+      - name: Build . . .
+        run: make -j4
+      - name: Run the tests . . .
+        run: ./test-samples.sh
+  distcheck:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+    env:
+      CC: gcc
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure . . .
+        run: |
+          mkdir -p m4 
+          autoreconf -if 
+          ./configure CC="$CC"
+      - name: make distcheck . . .
+        run: make distcheck -j4

--- a/.github/workflows/sanitisers.yml
+++ b/.github/workflows/sanitisers.yml
@@ -1,0 +1,63 @@
+name: Sanitisers
+on: [pull_request, workflow_dispatch]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  sanitisers:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    env:
+      CC: clang
+      CFLAGS: -fno-omit-frame-pointer -g -O1
+    strategy:
+      matrix:
+        type: [address, undefined]
+        include:
+          - type: undefined
+            environment_variables: UBSAN_OPTIONS=log_path=ubsan.log
+      fail-fast: false
+    name: ${{ matrix.type }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure with -fsanitize=${{ matrix.type }} . . .
+        run: |
+          mkdir -p m4 && autoreconf -if
+          ./configure CC="$CC" CFLAGS="-fsanitize=${{ matrix.type }} $CFLAGS"
+      - name: Build . . .
+        run: make -j4
+      - name: Run tests . . .
+        run: ${{ matrix.environment_variables }} ./test-samples.sh
+      - name: Check log files
+        if: ${{ matrix.type == 'undefined' }}
+        run: |
+          if [ -f ubsan.log* ]; then
+            cat ubsan.log*
+            $(exit 1)
+          fi
+  valgrind:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc
+      CFLAGS: -g -O0
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies . . .
+        run: |
+          sudo apt-get --yes update
+          sudo apt-get install -y expect libc6-dbg libtool-bin valgrind
+      - name: Configure . . .
+        run: |
+          mkdir -p m4 && autoreconf -if
+          ./configure CC="$CC" CFLAGS="$CFLAGS"
+      - name: Build . . .
+        run: make -j4
+      - name: Run tests with valgrind . . .
+        run: |
+          valgrind --version
+          unbuffer libtool --mode=execute valgrind --leak-check=full ./test-samples.sh 2>&1 | tee valgrind.log
+          echo
+          ( ! grep -i "Invalid" valgrind.log )
+          ( ! grep -E "lost: [^0]" valgrind.log )

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -1,0 +1,9 @@
+name: Spelling
+on: [pull_request, workflow_dispatch]
+
+jobs:
+  codespell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: codespell-project/actions-codespell@v2


### PR DESCRIPTION
This pull request adds some continuous integration checks that will be triggered when new pull requests are made. In particular, the tests:
* check for compiler warnings;
* check that the tests pass using a variety of different clang and gcc versions;
* check that the tests pass on the systems Alpine, Cygwin, macOS, Ubuntu with aarch64, and Ubuntu with arm;
* run an address sanitizer, undefined behaviour sanitizer and valgrind; and
* checks for spelling mistakes.