### PR TITLE
Issue #152 - Adding `--enable-compile-warnings` to `compile-warnings.yml` job step to run `./configure`

### DIFF
--- a/.github/workflows/compile-warnings.yml
+++ b/.github/workflows/compile-warnings.yml
@@ -21,12 +21,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Compiler information . . .
         run: $CC --version
-        # TODO: Add --enable-compile-warnings to ./configure when available
       - name: Configure . . .
         run: |
           mkdir -p m4
           autoreconf -if
-          ./configure CC="$CC" CFLAGS="$CFLAGS"
+          ./configure --enable-compile-warnings CC="$CC" CFLAGS="$CFLAGS"
       - name: Build . . .
         run: make -j4
         # We don't run the tests, since in this job we are only checking for


### PR DESCRIPTION
Contributes to #152 

Confirmed that I'm able to run the steps in `compile-warnings.yml` on my Windows box in MSYS2 UCRT terminal, i.e.

```
autoreconf -fi
./configure --enable-compile-warnings CC="$CC" CFLAGS="$CFLAGS"
make -j4
```