### PR TITLE
In `graphK33Search.c`, enclose `extern` declaration of `_IsolateMinorE2()` with `#ifndef USE_MERGEBLOCKER`

### DIFF
--- a/c/graphLib/homeomorphSearch/graphK33Search.c
+++ b/c/graphLib/homeomorphSearch/graphK33Search.c
@@ -50,7 +50,11 @@ extern int _AddAndMarkEdge(graphP theGraph, int ancestor, int descendant);
 extern int _DeleteUnmarkedVerticesAndEdges(graphP theGraph);
 
 extern int _IsolateMinorE1(graphP theGraph);
-// extern int  _IsolateMinorE2(graphP theGraph);
+
+#ifndef USE_MERGEBLOCKER
+extern int _IsolateMinorE2(graphP theGraph);
+#endif
+
 extern int _IsolateMinorE3(graphP theGraph);
 extern int _IsolateMinorE4(graphP theGraph);
 


### PR DESCRIPTION
If one comments out line 237 (i.e. `#define USE_MERGEBLOCKER`), then when one compiles, one gets the error:

```
call to undeclared function '_IsolateMinorE2'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
```

This is because the `extern` (defined in `graphIsolator.c`) was simply commented out:

```
// extern int _IsolateMinorE2(graphP theGraph);
```

Rather than enclosed in `#ifndef USE_MERGEBLOCKER` (since the calling code in `_RunExtraK33Tests()` is run only when `USE_MERGEBLOCKER` is not defined)

---

On a related note, there are other `extern`s that are commented out that might require review:
* `// extern int K33SEARCH_ID;`
* `// extern void _ClearVisitedFlags(graphP);`
* `// extern int  _GetBicompSize(graphP theGraph, int BicompRoot);`
* `// extern void _InvertVertex(graphP theGraph, int V);`