### PR TITLE
Issue #161 - Introduce G6ReadIteratorP and G6WriteIteratorP typedefs and update function signatures+statements that use G6ReadIterator * and G6WriteIterator *

### DIFF
--- a/c/graphLib/io/g6-read-iterator.c
+++ b/c/graphLib/io/g6-read-iterator.c
@@ -10,7 +10,7 @@ See the LICENSE.TXT file for licensing information.
 #include "g6-read-iterator.h"
 #include "g6-api-utilities.h"
 
-int allocateG6ReadIterator(G6ReadIterator **ppG6ReadIterator, graphP pGraph)
+int allocateG6ReadIterator(G6ReadIteratorP *ppG6ReadIterator, graphP pGraph)
 {
     int exitCode = OK;
 
@@ -22,7 +22,7 @@ int allocateG6ReadIterator(G6ReadIterator **ppG6ReadIterator, graphP pGraph)
 
     // numGraphsRead, graphOrder, numCharsForGraphOrder,
     // numCharsForGraphEncoding, and currGraphBuffSize all set to 0
-    (*ppG6ReadIterator) = (G6ReadIterator *)calloc(1, sizeof(G6ReadIterator));
+    (*ppG6ReadIterator) = (G6ReadIteratorP)calloc(1, sizeof(G6ReadIterator));
 
     if ((*ppG6ReadIterator) == NULL)
     {
@@ -49,7 +49,7 @@ int allocateG6ReadIterator(G6ReadIterator **ppG6ReadIterator, graphP pGraph)
     return exitCode;
 }
 
-bool _isG6ReadIteratorAllocated(G6ReadIterator *pG6ReadIterator)
+bool _isG6ReadIteratorAllocated(G6ReadIteratorP pG6ReadIterator)
 {
     bool g6ReadIteratorIsAllocated = true;
 
@@ -61,7 +61,7 @@ bool _isG6ReadIteratorAllocated(G6ReadIterator *pG6ReadIterator)
     return g6ReadIteratorIsAllocated;
 }
 
-int getNumGraphsRead(G6ReadIterator *pG6ReadIterator, int *pNumGraphsRead)
+int getNumGraphsRead(G6ReadIteratorP pG6ReadIterator, int *pNumGraphsRead)
 {
     if (pG6ReadIterator == NULL)
     {
@@ -74,7 +74,7 @@ int getNumGraphsRead(G6ReadIterator *pG6ReadIterator, int *pNumGraphsRead)
     return OK;
 }
 
-int getOrderOfGraphToRead(G6ReadIterator *pG6ReadIterator, int *pGraphOrder)
+int getOrderOfGraphToRead(G6ReadIteratorP pG6ReadIterator, int *pGraphOrder)
 {
     if (pG6ReadIterator == NULL)
     {
@@ -87,7 +87,7 @@ int getOrderOfGraphToRead(G6ReadIterator *pG6ReadIterator, int *pGraphOrder)
     return OK;
 }
 
-int getPointerToGraphReadIn(G6ReadIterator *pG6ReadIterator, graphP *ppGraph)
+int getPointerToGraphReadIn(G6ReadIteratorP pG6ReadIterator, graphP *ppGraph)
 {
     if (pG6ReadIterator == NULL)
     {
@@ -100,7 +100,7 @@ int getPointerToGraphReadIn(G6ReadIterator *pG6ReadIterator, graphP *ppGraph)
     return OK;
 }
 
-int beginG6ReadIterationFromG6StrOrFile(G6ReadIterator *pG6ReadIterator, strOrFileP g6InputContainer)
+int beginG6ReadIterationFromG6StrOrFile(G6ReadIteratorP pG6ReadIterator, strOrFileP g6InputContainer)
 {
     if (
         sf_ValidateStrOrFile(g6InputContainer) != OK ||
@@ -115,7 +115,7 @@ int beginG6ReadIterationFromG6StrOrFile(G6ReadIterator *pG6ReadIterator, strOrFi
     return _beginG6ReadIteration(pG6ReadIterator);
 }
 
-int _beginG6ReadIteration(G6ReadIterator *pG6ReadIterator)
+int _beginG6ReadIteration(G6ReadIteratorP pG6ReadIterator)
 {
     int exitCode = OK;
     char charConfirmation = EOF;
@@ -234,9 +234,9 @@ int _processAndCheckHeader(strOrFileP g6Input)
         return NOTOK;
     }
 
-    char const*correctG6Header = ">>graph6<<";
-    char const*sparse6Header = ">>sparse6<";
-    char const*digraph6Header = ">>digraph6";
+    char const *correctG6Header = ">>graph6<<";
+    char const *sparse6Header = ">>sparse6<";
+    char const *digraph6Header = ">>digraph6";
 
     char headerCandidateChars[11];
     headerCandidateChars[0] = '\0';
@@ -329,7 +329,7 @@ int _getGraphOrder(strOrFileP g6Input, int *graphOrder)
     return exitCode;
 }
 
-int readGraphUsingG6ReadIterator(G6ReadIterator *pG6ReadIterator)
+int readGraphUsingG6ReadIterator(G6ReadIteratorP pG6ReadIterator)
 {
     int exitCode = OK;
 
@@ -593,7 +593,7 @@ int _decodeGraph(char *graphBuff, const int graphOrder, const int numChars, grap
     return exitCode;
 }
 
-int endG6ReadIteration(G6ReadIterator *pG6ReadIterator)
+int endG6ReadIteration(G6ReadIteratorP pG6ReadIterator)
 {
     int exitCode = OK;
 
@@ -612,7 +612,7 @@ int endG6ReadIteration(G6ReadIterator *pG6ReadIterator)
     return exitCode;
 }
 
-int freeG6ReadIterator(G6ReadIterator **ppG6ReadIterator)
+int freeG6ReadIterator(G6ReadIteratorP *ppG6ReadIterator)
 {
     int exitCode = OK;
 
@@ -641,7 +641,7 @@ int freeG6ReadIterator(G6ReadIterator **ppG6ReadIterator)
 
 int _ReadGraphFromG6FilePath(graphP pGraphToRead, char *pathToG6File)
 {
-    char const*messageFormat = NULL;
+    char const *messageFormat = NULL;
     char messageContents[MAXLINE + 1];
     messageContents[MAXLINE] = '\0';
     int charsAvailForStr = 0;
@@ -682,7 +682,7 @@ int _ReadGraphFromG6StrOrFile(graphP pGraphToRead, strOrFileP g6InputContainer)
 {
     int exitCode = OK;
 
-    G6ReadIterator *pG6ReadIterator = NULL;
+    G6ReadIteratorP pG6ReadIterator = NULL;
 
     if (sf_ValidateStrOrFile(g6InputContainer) != OK)
     {

--- a/c/graphLib/io/g6-read-iterator.h
+++ b/c/graphLib/io/g6-read-iterator.h
@@ -32,27 +32,29 @@ extern "C"
         graphP currGraph;
     } G6ReadIterator;
 
-    int allocateG6ReadIterator(G6ReadIterator **, graphP);
-    bool _isG6ReadIteratorAllocated(G6ReadIterator *);
+    typedef G6ReadIterator *G6ReadIteratorP;
 
-    int getNumGraphsRead(G6ReadIterator *, int *);
-    int getOrderOfGraphToRead(G6ReadIterator *, int *);
-    int getPointerToGraphReadIn(G6ReadIterator *, graphP *);
+    int allocateG6ReadIterator(G6ReadIteratorP *, graphP);
+    bool _isG6ReadIteratorAllocated(G6ReadIteratorP);
 
-    int beginG6ReadIterationFromG6StrOrFile(G6ReadIterator *, strOrFileP);
-    int _beginG6ReadIteration(G6ReadIterator *);
+    int getNumGraphsRead(G6ReadIteratorP, int *);
+    int getOrderOfGraphToRead(G6ReadIteratorP, int *);
+    int getPointerToGraphReadIn(G6ReadIteratorP, graphP *);
+
+    int beginG6ReadIterationFromG6StrOrFile(G6ReadIteratorP, strOrFileP);
+    int _beginG6ReadIteration(G6ReadIteratorP);
     int _processAndCheckHeader(strOrFileP);
     bool _firstCharIsValid(char, const int);
     int _getGraphOrder(strOrFileP, int *);
 
-    int readGraphUsingG6ReadIterator(G6ReadIterator *);
+    int readGraphUsingG6ReadIterator(G6ReadIteratorP);
     int _checkGraphOrder(char *, int);
     int _validateGraphEncoding(char *, const int, const int);
     int _decodeGraph(char *, const int, const int, graphP);
 
-    int endG6ReadIteration(G6ReadIterator *);
+    int endG6ReadIteration(G6ReadIteratorP);
 
-    int freeG6ReadIterator(G6ReadIterator **);
+    int freeG6ReadIterator(G6ReadIteratorP *);
 
     int _ReadGraphFromG6FilePath(graphP, char *);
     int _ReadGraphFromG6String(graphP, char *);

--- a/c/graphLib/io/g6-write-iterator.c
+++ b/c/graphLib/io/g6-write-iterator.c
@@ -10,7 +10,7 @@ See the LICENSE.TXT file for licensing information.
 #include "g6-write-iterator.h"
 #include "g6-api-utilities.h"
 
-int allocateG6WriteIterator(G6WriteIterator **ppG6WriteIterator, graphP pGraph)
+int allocateG6WriteIterator(G6WriteIteratorP *ppG6WriteIterator, graphP pGraph)
 {
     int exitCode = OK;
 
@@ -22,7 +22,7 @@ int allocateG6WriteIterator(G6WriteIterator **ppG6WriteIterator, graphP pGraph)
 
     // numGraphsWritten, graphOrder, numCharsForGraphOrder,
     // numCharsForGraphEncoding, and currGraphBuffSize all set to 0
-    (*ppG6WriteIterator) = (G6WriteIterator *)calloc(1, sizeof(G6WriteIterator));
+    (*ppG6WriteIterator) = (G6WriteIteratorP)calloc(1, sizeof(G6WriteIterator));
 
     if ((*ppG6WriteIterator) == NULL)
     {
@@ -49,7 +49,7 @@ int allocateG6WriteIterator(G6WriteIterator **ppG6WriteIterator, graphP pGraph)
     return exitCode;
 }
 
-bool _isG6WriteIteratorAllocated(G6WriteIterator *pG6WriteIterator)
+bool _isG6WriteIteratorAllocated(G6WriteIteratorP pG6WriteIterator)
 {
     bool G6WriteIteratorIsAllocated = true;
 
@@ -59,7 +59,7 @@ bool _isG6WriteIteratorAllocated(G6WriteIterator *pG6WriteIterator)
     return G6WriteIteratorIsAllocated;
 }
 
-int getNumGraphsWritten(G6WriteIterator *pG6WriteIterator, int *pNumGraphsRead)
+int getNumGraphsWritten(G6WriteIteratorP pG6WriteIterator, int *pNumGraphsRead)
 {
     if (pG6WriteIterator == NULL)
     {
@@ -72,7 +72,7 @@ int getNumGraphsWritten(G6WriteIterator *pG6WriteIterator, int *pNumGraphsRead)
     return OK;
 }
 
-int getOrderOfGraphToWrite(G6WriteIterator *pG6WriteIterator, int *pGraphOrder)
+int getOrderOfGraphToWrite(G6WriteIteratorP pG6WriteIterator, int *pGraphOrder)
 {
     if (pG6WriteIterator == NULL)
     {
@@ -85,7 +85,7 @@ int getOrderOfGraphToWrite(G6WriteIterator *pG6WriteIterator, int *pGraphOrder)
     return OK;
 }
 
-int getPointerToGraphToWrite(G6WriteIterator *pG6WriteIterator, graphP *ppGraph)
+int getPointerToGraphToWrite(G6WriteIteratorP pG6WriteIterator, graphP *ppGraph)
 {
     if (pG6WriteIterator == NULL)
     {
@@ -98,7 +98,7 @@ int getPointerToGraphToWrite(G6WriteIterator *pG6WriteIterator, graphP *ppGraph)
     return OK;
 }
 
-int getGraphBuff(G6WriteIterator *pG6WriteIterator, char **ppCurrGraphBuff)
+int getGraphBuff(G6WriteIteratorP pG6WriteIterator, char **ppCurrGraphBuff)
 {
     if (pG6WriteIterator == NULL)
     {
@@ -111,7 +111,7 @@ int getGraphBuff(G6WriteIterator *pG6WriteIterator, char **ppCurrGraphBuff)
     return OK;
 }
 
-int beginG6WriteIterationToG6StrOrFile(G6WriteIterator *pG6WriteIterator, strOrFileP outputContainer)
+int beginG6WriteIterationToG6StrOrFile(G6WriteIteratorP pG6WriteIterator, strOrFileP outputContainer)
 {
     int exitCode = OK;
 
@@ -131,7 +131,7 @@ int beginG6WriteIterationToG6StrOrFile(G6WriteIterator *pG6WriteIterator, strOrF
     return exitCode;
 }
 
-int _beginG6WriteIteration(G6WriteIterator *pG6WriteIterator)
+int _beginG6WriteIteration(G6WriteIteratorP pG6WriteIterator)
 {
     int exitCode = OK;
 
@@ -183,7 +183,7 @@ void _precomputeColumnOffsets(int *columnOffsets, int graphOrder)
         columnOffsets[i] = columnOffsets[i - 1] + (i - 1);
 }
 
-int writeGraphUsingG6WriteIterator(G6WriteIterator *pG6WriteIterator)
+int writeGraphUsingG6WriteIterator(G6WriteIteratorP pG6WriteIterator)
 {
     int exitCode = OK;
 
@@ -208,7 +208,7 @@ int writeGraphUsingG6WriteIterator(G6WriteIterator *pG6WriteIterator)
     return exitCode;
 }
 
-int _encodeAdjMatAsG6(G6WriteIterator *pG6WriteIterator)
+int _encodeAdjMatAsG6(G6WriteIteratorP pG6WriteIterator)
 {
     int exitCode = OK;
 
@@ -381,7 +381,7 @@ int _getNextInUseEdge(graphP theGraph, int *e, int *u, int *v)
     return exitCode;
 }
 
-int _printEncodedGraph(G6WriteIterator *pG6WriteIterator)
+int _printEncodedGraph(G6WriteIteratorP pG6WriteIterator)
 {
     int exitCode = OK;
 
@@ -412,7 +412,7 @@ int _printEncodedGraph(G6WriteIterator *pG6WriteIterator)
     return exitCode;
 }
 
-int endG6WriteIteration(G6WriteIterator *pG6WriteIterator)
+int endG6WriteIteration(G6WriteIteratorP pG6WriteIterator)
 {
     int exitCode = OK;
 
@@ -437,7 +437,7 @@ int endG6WriteIteration(G6WriteIterator *pG6WriteIterator)
     return exitCode;
 }
 
-int freeG6WriteIterator(G6WriteIterator **ppG6WriteIterator)
+int freeG6WriteIterator(G6WriteIteratorP *ppG6WriteIterator)
 {
     int exitCode = OK;
 
@@ -499,7 +499,7 @@ int _WriteGraphToG6StrOrFile(graphP pGraph, strOrFileP outputContainer, char **o
 {
     int exitCode = OK;
 
-    G6WriteIterator *pG6WriteIterator = NULL;
+    G6WriteIteratorP pG6WriteIterator = NULL;
 
     if (sf_ValidateStrOrFile(outputContainer) != OK)
     {

--- a/c/graphLib/io/g6-write-iterator.h
+++ b/c/graphLib/io/g6-write-iterator.h
@@ -34,33 +34,35 @@ extern "C"
         graphP currGraph;
     } G6WriteIterator;
 
-    int allocateG6WriteIterator(G6WriteIterator **, graphP);
-    bool _isG6WriteIteratorAllocated(G6WriteIterator *);
+    typedef G6WriteIterator *G6WriteIteratorP;
 
-    int getNumGraphsWritten(G6WriteIterator *, int *);
-    int getOrderOfGraphToWrite(G6WriteIterator *, int *);
-    int getPointerToGraphToWrite(G6WriteIterator *, graphP *);
+    int allocateG6WriteIterator(G6WriteIteratorP *, graphP);
+    bool _isG6WriteIteratorAllocated(G6WriteIteratorP);
 
-    int beginG6WriteIterationToG6StrOrFile(G6WriteIterator *pG6WriteIterator, strOrFileP outputContainer);
-    int _beginG6WriteIteration(G6WriteIterator *pG6WriteIterator);
+    int getNumGraphsWritten(G6WriteIteratorP, int *);
+    int getOrderOfGraphToWrite(G6WriteIteratorP, int *);
+    int getPointerToGraphToWrite(G6WriteIteratorP, graphP *);
+
+    int beginG6WriteIterationToG6StrOrFile(G6WriteIteratorP, strOrFileP);
+    int _beginG6WriteIteration(G6WriteIteratorP);
     void _precomputeColumnOffsets(int *, int);
 
-    int writeGraphUsingG6WriteIterator(G6WriteIterator *);
+    int writeGraphUsingG6WriteIterator(G6WriteIteratorP);
 
-    int _encodeAdjMatAsG6(G6WriteIterator *);
+    int _encodeAdjMatAsG6(G6WriteIteratorP);
     int _getFirstEdge(graphP, int *, int *, int *);
     int _getNextEdge(graphP, int *, int *, int *);
-    int _getNextInUseEdge(graphP theGraph, int *e, int *u, int *v);
+    int _getNextInUseEdge(graphP, int *, int *, int *);
 
-    int _printEncodedGraph(G6WriteIterator *);
+    int _printEncodedGraph(G6WriteIteratorP);
 
-    int endG6WriteIteration(G6WriteIterator *);
+    int endG6WriteIteration(G6WriteIteratorP);
 
-    int freeG6WriteIterator(G6WriteIterator **);
+    int freeG6WriteIterator(G6WriteIteratorP *);
 
-    int _WriteGraphToG6FilePath(graphP pGraph, char *g6OutputFilename);
-    int _WriteGraphToG6String(graphP pGraph, char **g6OutputStr);
-    int _WriteGraphToG6StrOrFile(graphP pGraph, strOrFileP outputContainer, char **outputStr);
+    int _WriteGraphToG6FilePath(graphP, char *);
+    int _WriteGraphToG6String(graphP, char **);
+    int _WriteGraphToG6StrOrFile(graphP, strOrFileP, char **);
 
 #ifdef __cplusplus
 }

--- a/c/planarityApp/planarityRandomGraphs.c
+++ b/c/planarityApp/planarityRandomGraphs.c
@@ -56,7 +56,7 @@ int RandomGraphs(char command, int NumGraphs, int SizeOfGraphs, char *outfileNam
     for (K = 0; K < NUM_MINORS; K++)
         ObstructionMinorFreqs[K] = 0;
 
-    G6WriteIterator *pG6WriteIterator = NULL;
+    G6WriteIteratorP pG6WriteIterator = NULL;
     if (outfileName != NULL || (tolower(OrigOut) == 'y' && tolower(OrigOutFormat) == 'g'))
     {
         if (allocateG6WriteIterator(&pG6WriteIterator, theGraph) != OK)

--- a/c/planarityApp/planarityTestAllGraphs.c
+++ b/c/planarityApp/planarityTestAllGraphs.c
@@ -34,7 +34,7 @@ int TestAllGraphs(char *commandString, char *infileName, char *outfileName, char
     platform_time start, end;
 
     int charsAvailForFilename = 0;
-    char const*messageFormat = NULL;
+    char const *messageFormat = NULL;
     char messageContents[MAXLINE + 1];
     messageContents[MAXLINE] = '\0';
 
@@ -128,7 +128,7 @@ int testAllGraphs(graphP theGraph, char command, strOrFileP inputContainer, test
 {
     int Result = OK;
 
-    char const*messageFormat = NULL;
+    char const *messageFormat = NULL;
     char messageContents[MAXLINE + 1];
     messageContents[MAXLINE] = '\0';
 
@@ -136,7 +136,7 @@ int testAllGraphs(graphP theGraph, char command, strOrFileP inputContainer, test
     int embedFlags = GetEmbedFlags(command);
     int numOK = 0, numNONEMBEDDABLE = 0, errorFlag = FALSE;
 
-    G6ReadIterator *pG6ReadIterator = NULL;
+    G6ReadIteratorP pG6ReadIterator = NULL;
     Result = allocateG6ReadIterator(&pG6ReadIterator, theGraph);
 
     if (Result != OK)
@@ -267,7 +267,7 @@ int outputTestAllGraphsResults(char command, testAllStatsP stats, char *infileNa
     char *finalSlash = strrchr(infileName, FILE_DELIMITER);
     char *infileBasename = finalSlash ? (finalSlash + 1) : infileName;
 
-    char const*headerFormat = "FILENAME=\"%s\" DURATION=\"%.3lf\"\n";
+    char const *headerFormat = "FILENAME=\"%s\" DURATION=\"%.3lf\"\n";
     char *headerStr = (char *)malloc(
         (
             strlen(headerFormat) +


### PR DESCRIPTION
Resolves #161 

Added `G6ReadIteratorP` and `G6WriteIteratorP` `typedef`s, updated all function signatures to use these new aliases, and ensure all declarations use these rather than `G6ReadIterator *` and `G6WriteIterator *` (used regex `\bG6(Read|Write)Iterator\s+\*\b` to verify).

To verify that using the new `G6ReadIteratorP` and `G6WriteIteratorP` `typedef`s in `graphLib` function signatures didn't cause backwards compatibility issues with the `planarity` wrapper executable, I performed the following steps:
1. Switched to `master` branch
2. Added `printf()` statements to the wrapper application layer (i.e. within `SpecificGraph()`, `RandomGraphs()`, and `TestAllGraphs()`) and also within the relevant code from the library layer (i.e. within the functions of `g6-read-iterator.c` and `g6-write-iterator.c`) that indicated "I am the version of this code from `master`"
3. Followed [`README.md` - Making the Distribution](https://github.com/graph-algorithms/edge-addition-planarity-suite?tab=readme-ov-file#making-the-distribution) to build the `planarity-4.0.0.0.tar.gz` (Which I renamed to  `planarity-4.0.0.0-master.tar.gz`).
4. Switched branches to this feature branch (i.e. `Issue161-G6IteratorPTypedefRefactor`), performed `git clean` (excluding `planarity-4.0.0.0-master.tar.gz` using `-e`), and added the same print statements I had added to from `master`, except indicating "I am the version of this code from `Issue161-G6IteratorPTypedefRefactor`"
5. Repeated the process from 3. and renamed the resulting tarball `planarity-4.0.0.0-Issue161.tar.gz`
6. Ran 
    ```
    tar xvf planarity-4.0.0.0-master.tar.gz -C planarity-4.0.0.0-master --strip-components=1
    tar xvf planarity-4.0.0.0-Issue161.tar.gz -C planarity-4.0.0.0-Issue161 --strip-components=1
    ```
7. Changed directories into `planarity-4.0.0.0-master`, then followed the steps from [`README.md` - Making and Running the Software from the Distribution](https://github.com/graph-algorithms/edge-addition-planarity-suite?tab=readme-ov-file#making-and-running-the-software-from-the-distribution), then did the same after `cd ../planarity-4.0.0.0-Issue161`
8. Changed directories back into `planarity-4.0.0.0-Issue161`, and made a copy of `.libs/planarity.exe` called `.libs/planarity-Issue161.exe`
9. Copied `planarity-4.0.0.0-master/.libs/planarity.exe` into `planarity-4.0.0.0-Issue161/.libs`
10. Verified that the `planarity` wrapper executable generated from the `planarityApp` layer as of the `HEAD` of `master` was able to call functions from `libplanarity` generated from the `Issue161-G6IteratorPTypedefRefactor` branch