### PR TITLE
Issue #160 - restore `beginG6(Read|Write)Iteration(From|To)G6(String|FilePath)` helper functions, and update `planarityApp` layer to leverage these functions

### DIFF
--- a/c/graphLib/graphLib.h
+++ b/c/graphLib/graphLib.h
@@ -37,7 +37,7 @@ extern "C"
 
 #define GP_PROJECTVERSION_MAJOR 4
 #define GP_PROJECTVERSION_MINOR 0
-#define GP_PROJECTVERSION_MAINT 0
+#define GP_PROJECTVERSION_MAINT 1
 #define GP_PROJECTVERSION_TWEAK 0
 
     char *gp_GetProjectVersionFull(void);
@@ -46,9 +46,9 @@ extern "C"
 // shared library version numbers below.
 //
 // See configure.ac for how to update these version numbers
-#define GP_LIBPLANARITYVERSION_CURRENT 2
+#define GP_LIBPLANARITYVERSION_CURRENT 3
 #define GP_LIBPLANARITYVERSION_REVISION 0
-#define GP_LIBPLANARITYVERSION_AGE 0
+#define GP_LIBPLANARITYVERSION_AGE 1
 
     char *gp_GetLibPlanarityVersionFull(void);
 

--- a/c/graphLib/io/g6-read-iterator.c
+++ b/c/graphLib/io/g6-read-iterator.c
@@ -102,14 +102,16 @@ int getPointerToGraphReadIn(G6ReadIteratorP pG6ReadIterator, graphP *ppGraph)
 
 int beginG6ReadIterationFromG6String(G6ReadIteratorP pG6ReadIterator, char *inputString)
 {
-    strOrFileP inputContainer = sf_New(inputString, NULL, READTEXT);
-    return beginG6ReadIterationFromG6StrOrFile(pG6ReadIterator, inputContainer);
+    return beginG6ReadIterationFromG6StrOrFile(
+        pG6ReadIterator,
+        sf_New(inputString, NULL, READTEXT));
 }
 
 int beginG6ReadIterationFromG6FilePath(G6ReadIteratorP pG6ReadIterator, char *infileName)
 {
-    strOrFileP inputContainer = sf_New(NULL, infileName, READTEXT);
-    return beginG6ReadIterationFromG6StrOrFile(pG6ReadIterator, inputContainer);
+    return beginG6ReadIterationFromG6StrOrFile(
+        pG6ReadIterator,
+        sf_New(NULL, infileName, READTEXT));
 }
 
 int beginG6ReadIterationFromG6StrOrFile(G6ReadIteratorP pG6ReadIterator, strOrFileP g6InputContainer)

--- a/c/graphLib/io/g6-read-iterator.c
+++ b/c/graphLib/io/g6-read-iterator.c
@@ -100,6 +100,18 @@ int getPointerToGraphReadIn(G6ReadIteratorP pG6ReadIterator, graphP *ppGraph)
     return OK;
 }
 
+int beginG6ReadIterationFromG6String(G6ReadIteratorP pG6ReadIterator, char *inputString)
+{
+    strOrFileP inputContainer = sf_New(inputString, NULL, READTEXT);
+    return beginG6ReadIterationFromG6StrOrFile(pG6ReadIterator, inputContainer);
+}
+
+int beginG6ReadIterationFromG6FilePath(G6ReadIteratorP pG6ReadIterator, char *infileName)
+{
+    strOrFileP inputContainer = sf_New(NULL, infileName, READTEXT);
+    return beginG6ReadIterationFromG6StrOrFile(pG6ReadIterator, inputContainer);
+}
+
 int beginG6ReadIterationFromG6StrOrFile(G6ReadIteratorP pG6ReadIterator, strOrFileP g6InputContainer)
 {
     if (

--- a/c/graphLib/io/g6-read-iterator.h
+++ b/c/graphLib/io/g6-read-iterator.h
@@ -41,6 +41,8 @@ extern "C"
     int getOrderOfGraphToRead(G6ReadIteratorP, int *);
     int getPointerToGraphReadIn(G6ReadIteratorP, graphP *);
 
+    int beginG6ReadIterationFromG6String(G6ReadIteratorP, char *);
+    int beginG6ReadIterationFromG6FilePath(G6ReadIteratorP, char *);
     int beginG6ReadIterationFromG6StrOrFile(G6ReadIteratorP, strOrFileP);
     int _beginG6ReadIteration(G6ReadIteratorP);
     int _processAndCheckHeader(strOrFileP);

--- a/c/graphLib/io/g6-write-iterator.c
+++ b/c/graphLib/io/g6-write-iterator.c
@@ -113,16 +113,16 @@ int getGraphBuff(G6WriteIteratorP pG6WriteIterator, char **ppCurrGraphBuff)
 
 int beginG6WriteIterationToG6String(G6WriteIteratorP pG6WriteIterator)
 {
-    strOrFileP outputContainer = sf_New(NULL, NULL, WRITETEXT);
-
-    return beginG6ReadIterationFromG6StrOrFile(pG6WriteIterator, outputContainer);
+    return beginG6WriteIterationToG6StrOrFile(
+        pG6WriteIterator,
+        sf_New(NULL, NULL, WRITETEXT));
 }
 
 int beginG6WriteIterationToG6FilePath(G6WriteIteratorP pG6WriteIterator, char *outputFilename)
 {
-    strOrFileP outputContainer = sf_New(NULL, outputFilename, WRITETEXT);
-
-    return beginG6ReadIterationFromG6StrOrFile(pG6WriteIterator, outputContainer);
+    return beginG6WriteIterationToG6StrOrFile(
+        pG6WriteIterator,
+        sf_New(NULL, outputFilename, WRITETEXT));
 }
 
 int beginG6WriteIterationToG6StrOrFile(G6WriteIteratorP pG6WriteIterator, strOrFileP outputContainer)
@@ -508,7 +508,7 @@ int _WriteGraphToG6String(graphP pGraph, char **g6OutputStr)
 
     // N.B. If g6OutputStr is a pointer to a pointer to a block of memory that
     // has been allocated, i.e. if g6OutputStr != NULL && (*g6OutputStr) != NULL
-    // then an error will be emitted.
+    // then an error will be emitted by _WriteGraphToG6StrOrFile().
     // N.B. Once the graph is successfully written, the string is taken from
     // the G6WriteIterator's outputContainer and assigned to (*g6OutputStr)
     // before ending G6 write iteration

--- a/c/graphLib/io/g6-write-iterator.c
+++ b/c/graphLib/io/g6-write-iterator.c
@@ -111,6 +111,20 @@ int getGraphBuff(G6WriteIteratorP pG6WriteIterator, char **ppCurrGraphBuff)
     return OK;
 }
 
+int beginG6WriteIterationToG6String(G6WriteIteratorP pG6WriteIterator)
+{
+    strOrFileP outputContainer = sf_New(NULL, NULL, WRITETEXT);
+
+    return beginG6ReadIterationFromG6StrOrFile(pG6WriteIterator, outputContainer);
+}
+
+int beginG6WriteIterationToG6FilePath(G6WriteIteratorP pG6WriteIterator, char *outputFilename)
+{
+    strOrFileP outputContainer = sf_New(NULL, outputFilename, WRITETEXT);
+
+    return beginG6ReadIterationFromG6StrOrFile(pG6WriteIterator, outputContainer);
+}
+
 int beginG6WriteIterationToG6StrOrFile(G6WriteIteratorP pG6WriteIterator, strOrFileP outputContainer)
 {
     int exitCode = OK;
@@ -135,7 +149,7 @@ int _beginG6WriteIteration(G6WriteIteratorP pG6WriteIterator)
 {
     int exitCode = OK;
 
-    char const*g6Header = ">>graph6<<";
+    char const *g6Header = ">>graph6<<";
     if (sf_fputs(g6Header, pG6WriteIterator->g6Output) < 0)
     {
         ErrorMessage("Unable to fputs header to g6Output.\n");
@@ -492,6 +506,12 @@ int _WriteGraphToG6String(graphP pGraph, char **g6OutputStr)
         return NOTOK;
     }
 
+    // N.B. If g6OutputStr is a pointer to a pointer to a block of memory that
+    // has been allocated, i.e. if g6OutputStr != NULL && (*g6OutputStr) != NULL
+    // then an error will be emitted.
+    // N.B. Once the graph is successfully written, the string is taken from
+    // the G6WriteIterator's outputContainer and assigned to (*g6OutputStr)
+    // before ending G6 write iteration
     return _WriteGraphToG6StrOrFile(pGraph, outputContainer, g6OutputStr);
 }
 

--- a/c/graphLib/io/g6-write-iterator.h
+++ b/c/graphLib/io/g6-write-iterator.h
@@ -43,6 +43,8 @@ extern "C"
     int getOrderOfGraphToWrite(G6WriteIteratorP, int *);
     int getPointerToGraphToWrite(G6WriteIteratorP, graphP *);
 
+    int beginG6WriteIterationToG6String(G6WriteIteratorP);
+    int beginG6WriteIterationToG6FilePath(G6WriteIteratorP, char *);
     int beginG6WriteIterationToG6StrOrFile(G6WriteIteratorP, strOrFileP);
     int _beginG6WriteIteration(G6WriteIteratorP);
     void _precomputeColumnOffsets(int *, int);

--- a/c/graphLib/io/graphIO.c
+++ b/c/graphLib/io/graphIO.c
@@ -399,7 +399,7 @@ int _ReadLEDAGraph(graphP theGraph, strOrFileP inputContainer)
  Returns: OK, NOTOK on internal error, NONEMBEDDABLE if too many edges
  ********************************************************************/
 
-int gp_Read(graphP theGraph, char const*FileName)
+int gp_Read(graphP theGraph, char const *FileName)
 {
     strOrFileP inputContainer = sf_New(NULL, FileName, READTEXT);
     if (inputContainer == NULL)
@@ -861,7 +861,7 @@ int _WriteDebugInfo(graphP theGraph, strOrFileP outputContainer)
  Returns NOTOK on error, OK on success.
  ********************************************************************/
 
-int gp_Write(graphP theGraph, char const*FileName, int Mode)
+int gp_Write(graphP theGraph, char const *FileName, int Mode)
 {
     int RetVal;
 
@@ -914,12 +914,13 @@ int gp_WriteToString(graphP theGraph, char **pOutputStr, int Mode)
     RetVal = _WriteGraph(theGraph, &outputContainer, pOutputStr, Mode);
 
     // N.B. Since we pass ownership of the outputContainer to the
-    // G6WriteIterator when we WRITE_G6, we make sure to take the string *before*
-    // we endG6WriteIteration(), since that calls sf_Free() on the g6Output
-    // (i.e. outputContainer) and therefore sb_Free() on theStr. This means
-    // that we need to make sure outputContainer and theStr it contains are
-    // both non-NULL before trying to take the string, as WRITE_ADJLIST,
-    // WRITE_ADJMATRIX, and WRITE_DEBUGINFO do *not* clean up the outputContainer.
+    // G6WriteIterator when we WRITE_G6, we make sure to take the string
+    // *before* we endG6WriteIteration(), since that calls sf_Free() on the
+    // g6Output (i.e. outputContainer) and therefore sb_Free() on theStr. This
+    // means that we need to make sure outputContainer and theStr it contains
+    // are both non-NULL before trying to take the string, as WRITE_ADJLIST,
+    // WRITE_ADJMATRIX, and WRITE_DEBUGINFO do *not* clean up the
+    // outputContainer.
     if (RetVal == OK && outputContainer != NULL)
     {
         (*pOutputStr) = sf_takeTheStr(outputContainer);
@@ -1009,7 +1010,7 @@ int _WritePostprocess(graphP theGraph, char **pExtraData)
  Call this method with NULL to close the log file.
  ********************************************************************/
 
-void _Log(char const*Str)
+void _Log(char const *Str)
 {
     static FILE *logfile = NULL;
 
@@ -1028,7 +1029,7 @@ void _Log(char const*Str)
         fclose(logfile);
 }
 
-void _LogLine(char const*Str)
+void _LogLine(char const *Str)
 {
     _Log(Str);
     _Log("\n");

--- a/c/graphLib/io/strOrFile.c
+++ b/c/graphLib/io/strOrFile.c
@@ -21,7 +21,7 @@ See the LICENSE.TXT file for licensing information.
  Returns the allocated string-or-file container, or NULL on error.
  ********************************************************************/
 
-strOrFileP sf_New(char const*theStr, char const*fileName, char const*ioMode)
+strOrFileP sf_New(char const *theStr, char const *fileName, char const *ioMode)
 {
     strOrFileP theStrOrFile;
     int containerType = 0;
@@ -113,6 +113,12 @@ strOrFileP sf_New(char const*theStr, char const*fileName, char const*ioMode)
             else if (strncmp(ioMode, WRITETEXT, strlen(WRITETEXT)) == 0)
                 containerType = OUTPUT_CONTAINER;
 
+            // N.B. If you're writing to string (since fileName == NULL), but
+            // theStr has already been assigned some pointer, the container is
+            // invalid. One must sf_New(NULL, NULL, WRITETEXT) before handing
+            // off ownership of the container; when processing is done, before
+            // you free the owner of the output container, you must
+            // sf_takeTheStr(theStrOrFile) and return that pointer to the caller
             if (containerType != INPUT_CONTAINER && theStr != NULL)
             {
                 sf_Free(&theStrOrFile);
@@ -585,7 +591,7 @@ char *sf_fgets(char *str, int count, strOrFileP theStrOrFile)
  On failure, returns EOF.
  ********************************************************************/
 
-int sf_fputs(char const*strToWrite, strOrFileP theStrOrFile)
+int sf_fputs(char const *strToWrite, strOrFileP theStrOrFile)
 {
     int outputLen = EOF;
 

--- a/c/planarityApp/planarityRandomGraphs.c
+++ b/c/planarityApp/planarityRandomGraphs.c
@@ -6,7 +6,7 @@ See the LICENSE.TXT file for licensing information.
 
 #include "planarity.h"
 
-void GetNumberIfZero(int *pNum, char const*prompt, int min, int max);
+void GetNumberIfZero(int *pNum, char const *prompt, int min, int max);
 void ReinitializeGraph(graphP *pGraph, int ReuseGraphs, char command);
 graphP MakeGraph(int Size, char command);
 
@@ -24,6 +24,8 @@ graphP MakeGraph(int Size, char command);
 int RandomGraphs(char command, int NumGraphs, int SizeOfGraphs, char *outfileName)
 {
     char theFileName[MAXLINE + 1];
+    theFileName[0] = '\0';
+
     strOrFileP outputContainer = NULL;
     int K, countUpdateFreq;
     int Result = OK, MainStatistic = 0;
@@ -37,7 +39,7 @@ int RandomGraphs(char command, int NumGraphs, int SizeOfGraphs, char *outfileNam
         writeErrorReported_AdjList = FALSE, writeErrorReported_Obstructed = FALSE,
         writeErrorReported_Error = FALSE;
 
-    char const*messageFormat = NULL;
+    char const *messageFormat = NULL;
     char messageContents[MAXLINE + 1];
     int charsAvailForStr = 0;
 
@@ -67,6 +69,12 @@ int RandomGraphs(char command, int NumGraphs, int SizeOfGraphs, char *outfileNam
         }
     }
 
+    // FIXME: I don't want to refactor this to use
+    // beginG6WriteIterationToG6FilePath(), because there's two possible ways to
+    // get an output filename: either you called planarity command line and
+    // passed the optional outfileName, or you are using the planarity menu
+    // system after you Reconfigure() to output to .g6 (in which case,
+    // theFileName is constructed).
     messageFormat = "Unable to allocate strOrFile container for outfile \"%.*s\".\n";
     charsAvailForStr = (int)(MAXLINE - strlen(messageFormat));
     if (outfileName != NULL)
@@ -369,7 +377,7 @@ int RandomGraphs(char command, int NumGraphs, int SizeOfGraphs, char *outfileNam
  it is not.
  ****************************************************************************/
 
-void GetNumberIfZero(int *pNum, char const*prompt, int min, int max)
+void GetNumberIfZero(int *pNum, char const *prompt, int min, int max)
 {
     if (*pNum == 0)
     {
@@ -461,7 +469,7 @@ int RandomGraph(char command, int extraEdges, int numVertices, char *outfileName
     int embedFlags = GetEmbedFlags(command);
     char saveEdgeListFormat;
 
-    char const*messageFormat = NULL;
+    char const *messageFormat = NULL;
     char messageContents[MAXLINE + 1];
     int charsAvailForStr = 0;
 

--- a/c/planarityApp/planarityRandomGraphs.c
+++ b/c/planarityApp/planarityRandomGraphs.c
@@ -69,18 +69,11 @@ int RandomGraphs(char command, int NumGraphs, int SizeOfGraphs, char *outfileNam
         }
     }
 
-    // FIXME: I don't want to refactor this to use
-    // beginG6WriteIterationToG6FilePath(), because there's two possible ways to
-    // get an output filename: either you called planarity command line and
-    // passed the optional outfileName, or you are using the planarity menu
-    // system after you Reconfigure() to output to .g6 (in which case,
-    // theFileName is constructed).
-    messageFormat = "Unable to allocate strOrFile container for outfile \"%.*s\".\n";
+    messageFormat = "Unable to begin writing random graphs to G6 outfile \"%.*s\".\n";
     charsAvailForStr = (int)(MAXLINE - strlen(messageFormat));
     if (outfileName != NULL)
     {
-        outputContainer = sf_New(NULL, outfileName, WRITETEXT);
-        if (outputContainer == NULL)
+        if (beginG6WriteIterationToG6FilePath(pG6WriteIterator, outfileName) != OK)
         {
             sprintf(messageContents, messageFormat, charsAvailForStr, outfileName);
             ErrorMessage(messageContents);
@@ -99,8 +92,7 @@ int RandomGraphs(char command, int NumGraphs, int SizeOfGraphs, char *outfileNam
         // output the generated random graphs to .g6 is if we Reconfigure() and
         // choose these options; in that case, need to set a default output filename.
         sprintf(theFileName, "random%cn%d.k%d.g6", FILE_DELIMITER, SizeOfGraphs, NumGraphs);
-        outputContainer = sf_New(NULL, theFileName, WRITETEXT);
-        if (outputContainer == NULL)
+        if (beginG6WriteIterationToG6FilePath(pG6WriteIterator, theFileName) != OK)
         {
             sprintf(messageContents, messageFormat, charsAvailForStr, theFileName);
             ErrorMessage(messageContents);
@@ -110,20 +102,6 @@ int RandomGraphs(char command, int NumGraphs, int SizeOfGraphs, char *outfileNam
 
             gp_Free(&theGraph);
 
-            return NOTOK;
-        }
-    }
-
-    if (pG6WriteIterator != NULL && outputContainer != NULL)
-    {
-        if (beginG6WriteIterationToG6StrOrFile(pG6WriteIterator, outputContainer) != OK)
-        {
-            ErrorMessage("Unable to begin writing random graphs to G6WriteIterator.\n");
-
-            if (freeG6WriteIterator(&pG6WriteIterator) != OK)
-                ErrorMessage("Unable to free G6WriteIterator.\n");
-
-            gp_Free(&theGraph);
             return NOTOK;
         }
     }

--- a/c/planarityApp/planarityTestAllGraphs.c
+++ b/c/planarityApp/planarityTestAllGraphs.c
@@ -17,7 +17,7 @@ typedef struct
 
 typedef testAllStats *testAllStatsP;
 
-int testAllGraphs(graphP theGraph, char command, strOrFileP inputContainer, testAllStatsP stats);
+int testAllGraphs(graphP theGraph, char command, char *infileName, testAllStatsP stats);
 int outputTestAllGraphsResults(char command, testAllStatsP stats, char *infileName, char *outfileName, char **outputStr);
 
 /****************************************************************************
@@ -62,24 +62,11 @@ int TestAllGraphs(char *commandString, char *infileName, char *outfileName, char
                 // Start the timer
                 platform_GetTime(start);
 
-                strOrFileP inputContainer = sf_New(NULL, infileName, READTEXT);
-                if (inputContainer == NULL)
-                {
-                    messageFormat = "Unable to open file \"%.*s\" for input.\n";
-                    charsAvailForFilename = (int)(MAXLINE - strlen(messageFormat));
-                    sprintf(messageContents, messageFormat, charsAvailForFilename, infileName);
-                    ErrorMessage(messageContents);
-
-                    gp_Free(&theGraph);
-
-                    return NOTOK;
-                }
-
                 testAllStats stats;
                 memset(&stats, 0, sizeof(testAllStats));
 
                 char command = commandString[1];
-                Result = testAllGraphs(theGraph, command, inputContainer, &stats);
+                Result = testAllGraphs(theGraph, command, infileName, &stats);
 
                 // Stop the timer
                 platform_GetTime(end);
@@ -124,7 +111,7 @@ int TestAllGraphs(char *commandString, char *infileName, char *outfileName, char
     return Result;
 }
 
-int testAllGraphs(graphP theGraph, char command, strOrFileP inputContainer, testAllStatsP stats)
+int testAllGraphs(graphP theGraph, char command, char *infileName, testAllStatsP stats)
 {
     int Result = OK;
 
@@ -146,7 +133,7 @@ int testAllGraphs(graphP theGraph, char command, strOrFileP inputContainer, test
         return Result;
     }
 
-    Result = beginG6ReadIterationFromG6StrOrFile(pG6ReadIterator, inputContainer);
+    Result = beginG6ReadIterationFromG6FilePath(pG6ReadIterator, infileName);
 
     if (Result != OK)
     {

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # The version number in the following line must be synchronized with 
 # the project version numbering in graphLib.h 
-AC_INIT([planarity],[4.0.0.0],[jboyer@acm.org])
+AC_INIT([planarity],[4.0.1.0],[jboyer@acm.org])
 AM_INIT_AUTOMAKE([subdir-objects] [foreign])
 AC_CONFIG_MACRO_DIRS([m4])
 AC_CONFIG_SRCDIR([c/])
@@ -19,9 +19,9 @@ AC_CONFIG_SRCDIR([c/])
 # revision to zero and increment age.
 # 3. If interfaces were removed (breaks backward compatibility): increment
 # current, and set both revision and age to zero.
-LT_CURRENT=2
+LT_CURRENT=3
 LT_REVISION=0
-LT_AGE=0
+LT_AGE=1
 AC_SUBST(LT_CURRENT)
 AC_SUBST(LT_REVISION)
 AC_SUBST(LT_AGE)


### PR DESCRIPTION
Follow up to #57 and #140

Resolves #160

## Updated

Bumping version numbers for planarity app and libraries; since this work will add interfaces, the following changes were made:

* `configure.ac` - `LT_CURRENT` and `LT_AGE` were incremented, and the `AC_INIT` was updated to match values in `c/graphLib.h`
* `c/graphLib.h` -  `GP_PROJECTVERSION_MAINT` was incremented (new interface), and the `GP_LIBPLANARITYVERSION_CURRENT` and `GP_LIBPLANARITYVERSION_AGE` were updated to match `configure.ac`

* Restoring `beginG6(Read|Write)Iteration(From|To)G6(String|FilePath)` functions in `g6-(read|write)-iterator.c`\`.h`, which create the appropriate `strOrFileP` and call `beginG6(Read|Write)Iteration(From|To)G6StrOrFile`.
    * The only notable difference is that `beginG6WriteIterationToString` now only has a single parameter, the `G6WriteIteratorP`; this is because we never want to pass a pointer-pointer to memory to use for the strOrFileP's internal theStr when `ioMode` is `WRITETEXT` - it should be allocated and owned by the `strOrFileP` entirely until you `sf_takeTheStr()`.
* `c/planarityApp/planarityTestAllGraphs.c` - updated `testAllGraphs()` so that it calls `beginG6ReadIterationFromG6FilePath()`
    * ensured that the tables produced don't change:
        ```
        python3.12 planarity_testAllGraphs_orchestrator.py -p ../../Release/planarity.exe -n 5

        python3.12 test_table_generator.py -n 5 -c (p|d|o|2|3|4)
        ```
* `c/planarityApp/planarityRandomGraphs.c` - updated `RandomGraphs()` so that we either `beginG6WriteIterationToG6FilePath()` for `outfileName` (if we get to `RandomGraphs()` via command-line, e.g. `planarity -r -p 100 1000 n100.k1000.g6`) or `theFileName` (if we get to `RandomGraphs()` via the menu-driven system after `Reconfigure()` to output all generated random graphs to `.g6`)