### PR TITLE
Issue # 205 - Refactor `testAllGraphs()` flow for ensuring edge capacity and extension of graph to embed 

### DIFF
--- a/c/graphLib/io/g6-api-utilities.c
+++ b/c/graphLib/io/g6-api-utilities.c
@@ -89,15 +89,15 @@ int _g6_ValidateOrderOfEncodedGraph(char *graphBuff, int order)
         n = currChar - 63;
     else
     {
-        ErrorMessage("Character doesn't correspond to a printable ASCII character.\n");
+        ErrorMessage("Character doesn't correspond to a printable ASCII "
+                     "character.\n");
         return NOTOK;
     }
 
     if (n != order)
     {
-        char messageContents[MAXLINE + 1];
-        sprintf(messageContents, "Graph order %d doesn't match expected graph order %d", n, order);
-        ErrorMessage(messageContents);
+        ErrorMessage("Graph order %d doesn't match expected graph order %d",
+                     n, order);
         return NOTOK;
     }
 
@@ -114,7 +114,7 @@ int _g6_ValidateGraphEncoding(char *graphBuff, const int order, const int numCha
 
     if (graphBuff == NULL || strlen(graphBuff) == 0)
     {
-        ErrorMessage("Invalid encoding: graphBuff is NULL or has no content.\n");
+        ErrorMessage("Invalid encoding: graphBuff is NULL or empty.\n");
         return NOTOK;
     }
 
@@ -129,10 +129,9 @@ int _g6_ValidateGraphEncoding(char *graphBuff, const int order, const int numCha
 
     if (expectedNumChars != numCharsForGraphEncoding)
     {
-        char messageContents[MAXLINE + 1];
-        messageContents[0] = '\0';
-        sprintf(messageContents, "Invalid number of bytes for graph of order %d; got %d but expected %d\n", order, numCharsForGraphEncoding, expectedNumChars);
-        ErrorMessage(messageContents);
+        ErrorMessage("Invalid number of bytes for graph of order %d; got %d "
+                     "but expected %d\n",
+                     order, numCharsForGraphEncoding, expectedNumChars);
         return NOTOK;
     }
 
@@ -141,10 +140,8 @@ int _g6_ValidateGraphEncoding(char *graphBuff, const int order, const int numCha
     {
         if (graphBuff[i] < 63 || graphBuff[i] > 126)
         {
-            char messageContents[MAXLINE + 1];
-            messageContents[0] = '\0';
-            sprintf(messageContents, "Invalid character at index %d: \"%c\"\n", i, graphBuff[i]);
-            ErrorMessage(messageContents);
+            ErrorMessage("Invalid character at index %d: \"%c\"\n",
+                         i, graphBuff[i]);
             return NOTOK;
         }
     }
@@ -161,10 +158,8 @@ int _g6_ValidateGraphEncoding(char *graphBuff, const int order, const int numCha
 
     if (numPaddingZeroes != expectedNumPaddingZeroes)
     {
-        char messageContents[MAXLINE + 1];
-        messageContents[0] = '\0';
-        sprintf(messageContents, "Expected %d padding zeroes, but got %d.\n", expectedNumPaddingZeroes, numPaddingZeroes);
-        ErrorMessage(messageContents);
+        ErrorMessage("Expected %d padding zeroes, but got %d.\n",
+                     expectedNumPaddingZeroes, numPaddingZeroes);
         exitCode = NOTOK;
     }
 

--- a/c/graphLib/io/g6-read-iterator.c
+++ b/c/graphLib/io/g6-read-iterator.c
@@ -320,8 +320,6 @@ int _g6_InitReader(G6ReadIteratorP theG6ReadIterator)
     int lineNum = 1;
     int order = NIL;
     strOrFileP inputContainer = theG6ReadIterator->inputContainer;
-    char messageContents[MAXLINE + 1];
-    messageContents[0] = '\0';
 
     if ((firstChar = sf_getc(inputContainer)) == EOF)
     {
@@ -367,8 +365,9 @@ int _g6_InitReader(G6ReadIteratorP theG6ReadIterator)
     // in practice n will be limited such that an integer will suffice in storing it.
     if (_g6_DetermineOrderFromInput(inputContainer, &order) != OK)
     {
-        sprintf(messageContents, "Unable to initialize reader due to invalid graph order on line %d of .g6 file.\n", lineNum);
-        ErrorMessage(messageContents);
+        ErrorMessage("Unable to initialize reader due to invalid graph order "
+                     "on line %d of .g6 file.\n",
+                     lineNum);
         return NOTOK;
     }
 
@@ -376,8 +375,10 @@ int _g6_InitReader(G6ReadIteratorP theG6ReadIterator)
     {
         if (gp_InitGraph(theG6ReadIterator->currGraph, order) != OK)
         {
-            sprintf(messageContents, "Unable to initialize reader due to failure initializing graph datastructure with order %d for graph on line %d of the .g6 file.\n", order, lineNum);
-            ErrorMessage(messageContents);
+            ErrorMessage("Unable to initialize reader due to failure "
+                         "initializing graph datastructure with order %d for "
+                         "graph on line %d of the .g6 file.\n",
+                         order, lineNum);
             return NOTOK;
         }
 
@@ -388,11 +389,10 @@ int _g6_InitReader(G6ReadIteratorP theG6ReadIterator)
         if (gp_GetN(theG6ReadIterator->currGraph) != order)
         {
             ErrorMessage("Unable to initialize reader, as graph datastructure "
-                         "passed in was already initialized ");
-            sprintf(messageContents, "with graph order %d,\n", gp_GetN(theG6ReadIterator->currGraph));
-            ErrorMessage(messageContents);
-            sprintf(messageContents, "\twhich doesn't match the graph order %d specified in the file.\n", order);
-            ErrorMessage(messageContents);
+                         "passed in was already initialized with graph order "
+                         "%d,\n\twhich doesn't match the graph order %d "
+                         "specified in the file.\n",
+                         gp_GetN(theG6ReadIterator->currGraph), order);
             return NOTOK;
         }
         else
@@ -461,9 +461,9 @@ int _g6_ValidateFirstChar(char c, const int lineNum)
 {
     if (strchr(":;&", c) != NULL)
     {
-        char messageContents[MAXLINE + 1];
-        sprintf(messageContents, "Invalid first character on line %d, i.e. one of ':', ';', or '&'; aborting.\n", lineNum);
-        ErrorMessage(messageContents);
+        ErrorMessage("Invalid first character on line %d, i.e. one of ':', "
+                     "';', or '&'; aborting.\n",
+                     lineNum);
 
         return NOTOK;
     }
@@ -505,7 +505,8 @@ int _g6_DetermineOrderFromInput(strOrFileP inputContainer, int *order)
 
         if (n > 100000)
         {
-            ErrorMessage("Graph order is too large; we only support n <= 100000.\n");
+            ErrorMessage("Graph order is too large; we only support n <= "
+                         "100000.\n");
             return NOTOK;
         }
     }
@@ -535,8 +536,6 @@ int g6_ReadGraph(G6ReadIteratorP theG6ReadIterator)
     const int numCharsForOrder = theG6ReadIterator == NULL ? 0 : theG6ReadIterator->numCharsForOrder;
     const int numCharsForGraphEncoding = theG6ReadIterator == NULL ? 0 : theG6ReadIterator->numCharsForGraphEncoding;
     const int currGraphBuffSize = theG6ReadIterator == NULL ? 0 : theG6ReadIterator->currGraphBuffSize;
-    char messageContents[MAXLINE + 1];
-    messageContents[0] = '\0';
 
     if (!_g6_IsReaderInitialized(theG6ReadIterator, true))
     {
@@ -566,8 +565,8 @@ int g6_ReadGraph(G6ReadIteratorP theG6ReadIterator)
         // longer than the line should have been, i.e. orderOffset + numCharsForGraphRepr
         if ((int)strlen(currGraphBuff) != (((numGraphsRead == 1) ? 0 : numCharsForOrder) + numCharsForGraphEncoding))
         {
-            sprintf(messageContents, "Invalid line length read on line %d\n", numGraphsRead);
-            ErrorMessage(messageContents);
+            ErrorMessage("Invalid line length read on line %d\n",
+                         numGraphsRead);
             return NOTOK;
         }
 
@@ -575,8 +574,8 @@ int g6_ReadGraph(G6ReadIteratorP theG6ReadIterator)
         {
             if (_g6_ValidateOrderOfEncodedGraph(currGraphBuff, order) != OK)
             {
-                sprintf(messageContents, "Order of graph on line %d is incorrect.\n", numGraphsRead);
-                ErrorMessage(messageContents);
+                ErrorMessage("Order of graph on line %d is incorrect.\n",
+                             numGraphsRead);
                 return NOTOK;
             }
         }
@@ -589,8 +588,7 @@ int g6_ReadGraph(G6ReadIteratorP theG6ReadIterator)
 
         if (_g6_ValidateGraphEncoding(graphEncodingChars, order, numCharsForGraphEncoding) != OK)
         {
-            sprintf(messageContents, "Graph on line %d is invalid.", numGraphsRead);
-            ErrorMessage(messageContents);
+            ErrorMessage("Graph on line %d is invalid.", numGraphsRead);
             return NOTOK;
         }
 
@@ -603,8 +601,9 @@ int g6_ReadGraph(G6ReadIteratorP theG6ReadIterator)
 
         if (_g6_DecodeGraph(graphEncodingChars, order, numCharsForGraphEncoding, currGraph) != OK)
         {
-            sprintf(messageContents, "Unable to interpret bits on line %d to populate adjacency matrix.\n", numGraphsRead);
-            ErrorMessage(messageContents);
+            ErrorMessage("Unable to interpret bits on line %d to populate "
+                         "adjacency matrix.\n",
+                         numGraphsRead);
             return NOTOK;
         }
 
@@ -637,19 +636,20 @@ int _g6_DecodeGraph(char *graphBuff, const int order, const int numChars, graphP
 
     if (theGraph == NULL)
     {
-        ErrorMessage("Must initialize graph datastructure before decoding the graph representation.\n");
+        ErrorMessage("Must initialize graph datastructure before decoding the "
+                     "graph representation.\n");
         return NOTOK;
     }
 
     for (int i = 0; i < numChars; i++)
     {
         currByte = graphBuff[i] - 63;
-        // j corresponds to the number of places one must bitshift the byte by to read
-        // the next bit in the byte
+        // j corresponds to the number of places one must bitshift the byte by
+        // to read the next bit in the byte
         for (int j = sizeof(char) * 5; j >= 0; j--)
         {
-            // If we are on the final byte, we know that the final numPaddingZeroes bits
-            // can be ignored, so we break out of the loop
+            // If we are on the final byte, we know that the final
+            // numPaddingZeroes bits can be ignored, so we break out of the loop
             if ((i == numChars) && j == numPaddingZeroes - 1)
                 break;
 
@@ -662,7 +662,9 @@ int _g6_DecodeGraph(char *graphBuff, const int order, const int numChars, graphP
             bitValue = ((currByte >> j) & 1u) ? 1 : 0;
             if (bitValue == 1)
             {
-                // Add gp_GetFirstVertex(theGraph), which is 1 if NIL == 0 (i.e. internal 1-based labelling) and 0 if NIL == -1 (internally 0-based)
+                // Add gp_GetFirstVertex(theGraph), which is 1 if NIL == 0 (i.e.
+                // internal 1-based labelling) and 0 if NIL == -1 (internally
+                // 0-based)
                 if (gp_DynamicAddEdge(theGraph, row + gp_GetFirstVertex(theGraph), 0, col + gp_GetFirstVertex(theGraph), 0) != OK)
                     return NOTOK;
             }
@@ -699,9 +701,6 @@ void g6_FreeReader(G6ReadIteratorP *pG6ReadIterator)
 
 int _g6_ReadGraphFromFile(graphP theGraph, char *pathToG6File)
 {
-    char const *messageFormat = NULL;
-    int charsAvailForStr = 0;
-
     strOrFileP inputContainer = NULL;
 
     if (pathToG6File == NULL || strlen(pathToG6File) == 0)
@@ -714,15 +713,9 @@ int _g6_ReadGraphFromFile(graphP theGraph, char *pathToG6File)
 
     if ((inputContainer = sf_NewInputContainer(NULL, pathToG6File)) == NULL)
     {
-        char messageContents[MAXLINE + 1];
-        messageContents[0] = '\0';
-        messageFormat = "Unable to allocate strOrFile container for infile \"%.*s\".\n";
-        charsAvailForStr = (int)(MAXLINE - strlen(messageFormat));
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-        sprintf(messageContents, messageFormat, charsAvailForStr, pathToG6File);
-#pragma GCC diagnostic pop
-        ErrorMessage(messageContents);
+        ErrorMessage("Unable to allocate strOrFile container for infile "
+                     "\"%.*s\".\n",
+                     FILENAME_MAX, pathToG6File);
 
         return NOTOK;
     }

--- a/c/graphLib/lowLevelUtils/apiutils.c
+++ b/c/graphLib/lowLevelUtils/apiutils.c
@@ -24,20 +24,26 @@ void setQuietModeSetting(int newQuietModeSetting)
     quietMode = newQuietModeSetting;
 }
 
-void Message(char const *message)
+void Message(char const *message, ...)
 {
+    va_list args;
     if (!getQuietModeSetting())
     {
-        fprintf(stdout, "%s", message);
+        va_start(args, message);
+        vfprintf(stdout, message, args);
+        va_end(args);
         fflush(stdout);
     }
 }
 
-void ErrorMessage(char const *message)
+void ErrorMessage(char const *message, ...)
 {
+    va_list args;
     if (!getQuietModeSetting())
     {
-        fprintf(stderr, "%s", message);
+        va_start(args, message);
+        vfprintf(stderr, message, args);
+        va_end(args);
         fflush(stderr);
     }
 }

--- a/c/graphLib/lowLevelUtils/apiutils.h
+++ b/c/graphLib/lowLevelUtils/apiutils.h
@@ -29,8 +29,8 @@ extern "C"
     extern int getQuietModeSetting(void);
     extern void setQuietModeSetting(int);
 
-    extern void Message(char const *message);
-    extern void ErrorMessage(char const *message);
+    extern void Message(char const *message, ...) __attribute__((format(printf, 1, 2)));
+    extern void ErrorMessage(char const *message, ...) __attribute__((format(printf, 1, 2)));
 
     int GetNumCharsToReprInt(int theNum, int *numCharsRequired);
 #ifdef __cplusplus

--- a/c/planarityApp/planarity.h
+++ b/c/planarityApp/planarity.h
@@ -57,7 +57,6 @@ extern "C"
     /* Low-level Utilities */
     int GetLineFromStdin(char *lineBuff, int lineBuffSize);
     void FlushConsole(FILE *f);
-    void Prompt(char const *message);
 
     void SaveAsciiGraph(graphP theGraph, char *filename);
 

--- a/c/planarityApp/planarityCommandLine.c
+++ b/c/planarityApp/planarityCommandLine.c
@@ -118,15 +118,8 @@ int legacyCommandLine(int argc, char *argv[])
         Result = gp_Read(theGraph, argv[1]);
         if (Result != OK)
         {
-            char const *messageFormat = "Failed to read graph \"%.*s\"";
-            char messageContents[MAXLINE + 1];
-            int charsAvailForFilename = (int)(MAXLINE - strlen(messageFormat));
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-            sprintf(messageContents, messageFormat, charsAvailForFilename, argv[1]);
-#pragma GCC diagnostic pop
-            ErrorMessage(messageContents);
-
+            ErrorMessage("Failed to read graph \"%.*s\"",
+                         FILENAME_MAX, argv[1]);
             Result = NOTOK;
         }
     }
@@ -641,11 +634,6 @@ int runGraphTransformationTest(char const *command, char const *infileName, int 
         else
         {
             char *expectedOutfileName = NULL;
-            char const *messageFormat = NULL;
-            int charsAvailForFilename = 0;
-            char messageContents[MAXLINE + 1];
-            messageContents[0] = '\0';
-
             // Final arg is baseFlag, which is dependent on whether the FLAGS_ZEROBASEDIO is set in a graph's graphFlags
             Result = ConstructTransformationExpectedResultFilename(infileName, &expectedOutfileName, transformationCode, zeroBasedOutputFlag ? 0 : 1);
 
@@ -661,25 +649,18 @@ int runGraphTransformationTest(char const *command, char const *infileName, int 
 
                 if (Result == TRUE)
                 {
-                    messageFormat = "For the transformation %s on file \"%.*s\", actual output matched expected output file.\n";
-                    charsAvailForFilename = (int)(MAXLINE - strlen(messageFormat));
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-                    sprintf(messageContents, messageFormat, command, charsAvailForFilename, infileName);
-#pragma GCC diagnostic pop
-                    Message(messageContents);
+                    Message("For the transformation %s on file \"%.*s\", "
+                            "actual output matched expected output file.\n",
+                            command, FILENAME_MAX, infileName);
 
                     Result = OK;
                 }
                 else
                 {
-                    messageFormat = "For the transformation %s on file \"%.*s\", actual output did not match expected output file.\n";
-                    charsAvailForFilename = (int)(MAXLINE - strlen(messageFormat));
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-                    sprintf(messageContents, messageFormat, command, charsAvailForFilename, infileName);
-#pragma GCC diagnostic pop
-                    ErrorMessage(messageContents);
+                    ErrorMessage("For the transformation %s on file \"%.*s\", "
+                                 "actual output did not match expected output "
+                                 "file.\n",
+                                 command, FILENAME_MAX, infileName);
 
                     Result = NOTOK;
                 }

--- a/c/planarityApp/planarityHelp.c
+++ b/c/planarityApp/planarityHelp.c
@@ -30,7 +30,7 @@ char const *GetProjectTitle(void)
 
 int helpMessage(char *param)
 {
-    Message(GetProjectTitle());
+    Message("%s", GetProjectTitle());
 
     if (param == NULL)
     {
@@ -95,7 +95,7 @@ int helpMessage(char *param)
 
         Message("-q is for quiet mode (no messages to stdout and stderr)\n\n");
 
-        Message(GetAlgorithmFlags());
+        Message( "%s", GetAlgorithmFlags());
 
         Message(
             "K = # of graphs to randomly generate\n"

--- a/c/planarityApp/planarityMenu.c
+++ b/c/planarityApp/planarityMenu.c
@@ -56,9 +56,9 @@ int menu(void)
 
         while (1)
         {
-            Message(GetProjectTitle());
+            Message("%s", GetProjectTitle());
 
-            Message(GetAlgorithmSpecifiers());
+            Message("%s", GetAlgorithmSpecifiers());
 
             Message(
                 "X. Transform single graph in supported file to .g6, adjacency list, or adjacency matrix\n"
@@ -68,7 +68,7 @@ int menu(void)
                 "Q. Quit\n"
                 "\n");
 
-            Prompt("Enter Choice: ");
+            Message("Enter Choice: ");
 
             if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
             {
@@ -162,7 +162,7 @@ int menu(void)
                 }
             }
 
-            Prompt("\nPress return key to continue...");
+            Message("\nPress return key to continue...");
             if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
             {
                 ErrorMessage("Unable to fetch from stdin; exiting.\n");
@@ -231,7 +231,7 @@ int TransformGraphMenu(void)
 
     while (1)
     {
-        Prompt("Enter input filename:\n");
+        Message("Enter input filename:\n");
         if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
         {
             ErrorMessage("Unable to read input filename from stdin.\n");
@@ -261,7 +261,7 @@ int TransformGraphMenu(void)
     {
         while (1)
         {
-            Prompt("Enter output filename, or type \"stdout\" to output to console:\n");
+            Message("Enter output filename, or type \"stdout\" to output to console:\n");
             if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
             {
                 ErrorMessage("Unable to read output filename from stdin.\n");
@@ -287,8 +287,8 @@ int TransformGraphMenu(void)
     {
         while (1)
         {
-            Message(GetSupportedOutputChoices());
-            Prompt("Enter output format: ");
+            Message("%s", GetSupportedOutputChoices());
+            Message("Enter output format: ");
             if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
             {
                 ErrorMessage("Unable to read output format from stdin.\n");
@@ -403,7 +403,7 @@ int TestAllGraphsMenu(void)
 
     while (1)
     {
-        Prompt("Enter input filename:\n");
+        Message("Enter input filename:\n");
         if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
         {
             ErrorMessage("Unable to read input filename from stdin.\n");
@@ -433,7 +433,7 @@ int TestAllGraphsMenu(void)
     {
         while (1)
         {
-            Prompt("Enter output filename, or type \"stdout\" to output to console:\n");
+            Message("Enter output filename, or type \"stdout\" to output to console:\n");
             if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
             {
                 ErrorMessage("Unable to read output filename from stdin.\n");
@@ -459,8 +459,8 @@ int TestAllGraphsMenu(void)
     {
         while (1)
         {
-            Message(GetAlgorithmSpecifiers());
-            Prompt("Enter algorithm specifier (with optional modifier): ");
+            Message("%s", GetAlgorithmSpecifiers());
+            Message("Enter algorithm specifier (with optional modifier): ");
             if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
             {
                 ErrorMessage("Unable to read command and optional modifier from stdin.\n");

--- a/c/planarityApp/planarityMenu.c
+++ b/c/planarityApp/planarityMenu.c
@@ -497,5 +497,5 @@ int TestAllGraphsMenu(void)
         fileNameFormat = NULL;
     }
 
-    return OK ? (Result == OK || Result == NONEMBEDDABLE) : NOTOK;
+    return (Result == OK) ? OK : NOTOK;
 }

--- a/c/planarityApp/planarityRandomGraphs.c
+++ b/c/planarityApp/planarityRandomGraphs.c
@@ -41,36 +41,39 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
 
     G6WriteIteratorP theG6WriteIterator = NULL;
 
-    int charsAvailForStr = 0;
-    char const *messageFormat = NULL;
-    char messageContents[MAXLINE + 1];
+    char const g6WriterInitializationErrorMessage[] = "Unable to write random graphs to G6 outfile \"%.*s\" due to failure initializing G6WriteIterator.\n";
+    char const writeErrorMessage[] = "Failed to write graph \"%.*s\".\nMake the directory if not present\n";
+
     char theFileName[FILENAMEMAXLENGTH + 1];
 
     memset(ObstructionMinorFreqs, 0, NUM_MINORS * sizeof(int));
-    memset(messageContents, '\0', (MAXLINE + 1));
     memset(theFileName, '\0', (FILENAMEMAXLENGTH + 1));
 
     if ((Result = GetCommandAndOptionalModifier(commandString, &command, &modifier)) != OK)
     {
-        ErrorMessage("Unable to extract command and optional modifier character from commandString.\n");
+        ErrorMessage("Unable to extract command and optional modifier "
+                     "character from commandString.\n");
         return Result;
     }
 
     if ((Result = GetEmbedFlags(command, modifier, &embedFlags)) != OK)
     {
-        ErrorMessage("Unable to derive embedFlags from command and optional modifier character.\n");
+        ErrorMessage("Unable to derive embedFlags from command and optional "
+                     "modifier character.\n");
         return Result;
     }
 
     if ((Result = GetNumberIfZero(&NumGraphs, "Enter number of graphs to generate:", 1, 1000000000)) != OK)
     {
-        ErrorMessage("Encountered unrecoverable error when prompting for NumGraphs.\n");
+        ErrorMessage("Encountered unrecoverable error when prompting for "
+                     "NumGraphs.\n");
         return Result;
     }
 
     if ((Result = GetNumberIfZero(&SizeOfGraphs, "Enter size of graphs:", 1, 10000)) != OK)
     {
-        ErrorMessage("Encountered unrecoverable error when prompting for SizeOfGraphs.\n");
+        ErrorMessage("Encountered unrecoverable error when prompting for "
+                     "SizeOfGraphs.\n");
         return Result;
     }
 
@@ -78,7 +81,8 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
     origGraph = MakeGraph(SizeOfGraphs, command);
     if (theGraph == NULL || origGraph == NULL)
     {
-        ErrorMessage("Unable to allocate and initialize graph datastructures to contain randomly generated graphs.\n");
+        ErrorMessage("Unable to allocate and initialize graph datastructures "
+                     "to contain randomly generated graphs.\n");
 
         gp_Free(&theGraph);
         gp_Free(&origGraph);
@@ -99,17 +103,11 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
         }
     }
 
-    messageFormat = "Unable to write random graphs to G6 outfile \"%.*s\" due to failure initializing G6WriteIterator.\n";
-    charsAvailForStr = (int)(MAXLINE - strlen(messageFormat));
     if (outfileName != NULL)
     {
         if (g6_InitWriterWithFileName(theG6WriteIterator, outfileName) != OK)
         {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-            sprintf(messageContents, messageFormat, charsAvailForStr, outfileName);
-#pragma GCC diagnostic pop
-            ErrorMessage(messageContents);
+            ErrorMessage(g6WriterInitializationErrorMessage, FILENAME_MAX, outfileName);
 
             g6_FreeWriter((&theG6WriteIterator));
             gp_Free(&theGraph);
@@ -126,16 +124,10 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
         sprintf(theFileName, "random%cn%d.k%d.g6", FILE_DELIMITER, SizeOfGraphs, NumGraphs);
         if (g6_InitWriterWithFileName(theG6WriteIterator, theFileName) != OK)
         {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-            sprintf(messageContents, messageFormat, charsAvailForStr, theFileName);
-#pragma GCC diagnostic pop
-            ErrorMessage(messageContents);
-
+            ErrorMessage(g6WriterInitializationErrorMessage, FILENAME_MAX, theFileName);
             g6_FreeWriter((&theG6WriteIterator));
             gp_Free(&theGraph);
             gp_Free(&origGraph);
-
             return NOTOK;
         }
     }
@@ -160,8 +152,6 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
     // Start the timer
     platform_GetTime(start);
 
-    messageFormat = "Failed to write graph \"%.*s\".\nMake the directory if not present\n";
-    charsAvailForStr = (int)(MAXLINE - strlen(messageFormat));
     // Generate and process the number of graphs requested
     for (K = 0; K < NumGraphs; K++)
     {
@@ -171,11 +161,10 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
             {
                 if ((writeResult = g6_WriteGraph(theG6WriteIterator)) != OK)
                 {
-                    sprintf(messageContents, "Unable to write graph number %d using G6WriteIterator.\n", K);
-                    ErrorMessage(messageContents);
-
+                    ErrorMessage("Unable to write graph number %d using "
+                                 "G6WriteIterator.\n",
+                                 K);
                     Result = writeResult;
-
                     break;
                 }
             }
@@ -184,27 +173,20 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
                 sprintf(theFileName, "random%c%d.txt", FILE_DELIMITER, K % 10);
                 if ((writeResult = gp_Write(theGraph, theFileName, WRITE_ADJLIST)) != OK)
                 {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-                    sprintf(messageContents, messageFormat, charsAvailForStr, theFileName);
-#pragma GCC diagnostic pop
-                    ErrorMessage(messageContents);
-
+                    ErrorMessage(writeErrorMessage, FILENAME_MAX, theFileName);
                     Result = writeResult;
-
                     break;
                 }
             }
 
             if ((Result = gp_CopyGraph(origGraph, theGraph)) != OK)
             {
-                sprintf(messageContents, "Unable to make a copy of graph number %d before embedding.\n", K);
-                ErrorMessage(messageContents);
-
+                ErrorMessage("Unable to make a copy of graph number %d before "
+                             "embedding.\n",
+                             K);
                 gp_Free(&theGraph);
                 gp_Free(&origGraph);
                 g6_FreeWriter((&theG6WriteIterator));
-
                 return Result;
             }
 
@@ -223,12 +205,8 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
 
                     if ((writeResult = gp_Write(theGraph, theFileName, WRITE_ADJMATRIX)) != OK)
                     {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-                        sprintf(messageContents, messageFormat, charsAvailForStr, theFileName);
-#pragma GCC diagnostic pop
-                        ErrorMessage(messageContents);
-
+                        ErrorMessage(writeErrorMessage,
+                                     FILENAME_MAX, theFileName);
                         Result = writeResult;
                     }
                 }
@@ -239,12 +217,8 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
 
                     if ((writeResult = gp_Write(theGraph, theFileName, WRITE_ADJLIST)) != OK)
                     {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-                        sprintf(messageContents, messageFormat, charsAvailForStr, theFileName);
-#pragma GCC diagnostic pop
-                        ErrorMessage(messageContents);
-
+                        ErrorMessage(writeErrorMessage,
+                                     FILENAME_MAX, theFileName);
                         Result = writeResult;
                     }
                 }
@@ -279,12 +253,8 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
 
                         if ((writeResult = gp_Write(theGraph, theFileName, WRITE_ADJMATRIX)) != OK)
                         {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-                            sprintf(messageContents, messageFormat, charsAvailForStr, theFileName);
-#pragma GCC diagnostic pop
-                            ErrorMessage(messageContents);
-
+                            ErrorMessage(writeErrorMessage,
+                                         FILENAME_MAX, theFileName);
                             Result = writeResult;
                         }
                     }
@@ -297,12 +267,7 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
                 sprintf(theFileName, "error%c%d.txt", FILE_DELIMITER, K % 10);
                 if ((writeResult = gp_Write(origGraph, theFileName, WRITE_ADJLIST)) != OK)
                 {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-                    sprintf(messageContents, messageFormat, charsAvailForStr, theFileName);
-#pragma GCC diagnostic pop
-                    ErrorMessage(messageContents);
-
+                    ErrorMessage(writeErrorMessage, FILENAME_MAX, theFileName);
                     Result = writeResult;
                 }
             }
@@ -312,9 +277,7 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
         if (Result != OK && Result != NONEMBEDDABLE)
         {
             ErrorMessage("\nError found\n");
-
             Result = NOTOK;
-
             break;
         }
 
@@ -336,8 +299,7 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
     fprintf(stdout, "%d\n", NumGraphs);
     fflush(stdout);
 
-    sprintf(messageContents, "\nDone (%.3lf seconds).\n", platform_GetDuration(start, end));
-    Message(messageContents);
+    Message("\nDone (%.3lf seconds).\n", platform_GetDuration(start, end));
 
     // Print some demographic results
     if (Result == OK || Result == NONEMBEDDABLE)
@@ -346,8 +308,7 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
         // Report statistics for planar or outerplanar embedding
         if (embedFlags == EMBEDFLAGS_PLANAR || embedFlags == EMBEDFLAGS_OUTERPLANAR)
         {
-            sprintf(messageContents, "Num Embedded=%d.\n", MainStatistic);
-            Message(messageContents);
+            Message("Num Embedded=%d.\n", MainStatistic);
 
             for (K = 0; K < 5; K++)
             {
@@ -355,19 +316,18 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
                 if (embedFlags == EMBEDFLAGS_OUTERPLANAR && (K == 2 || K == 3))
                     continue;
 
-                sprintf(messageContents, "Minor %c = %d\n", K + 'A', ObstructionMinorFreqs[K]);
-                Message(messageContents);
+                Message("Minor %c = %d\n", K + 'A', ObstructionMinorFreqs[K]);
             }
 
             if (!(embedFlags & ~EMBEDFLAGS_PLANAR))
             {
-                sprintf(messageContents, "\nNote: E1 are added to C, E2 are added to A, and E=E3+E4+K5 homeomorphs.\n");
-                Message(messageContents);
+                Message("\nNote: E1 are added to C, E2 are added to A, and "
+                        "E=E3+E4+K5 homeomorphs.\n");
 
                 for (K = 5; K < NUM_MINORS; K++)
                 {
-                    sprintf(messageContents, "Minor E%d = %d\n", K - 4, ObstructionMinorFreqs[K]);
-                    Message(messageContents);
+                    Message("Minor E%d = %d\n",
+                            K - 4, ObstructionMinorFreqs[K]);
                 }
             }
         }
@@ -375,25 +335,27 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
         // Report statistics for graph drawing
         else if (embedFlags == EMBEDFLAGS_DRAWPLANAR)
         {
-            sprintf(messageContents, "Num Graphs Embedded and Drawn=%d.\n", MainStatistic);
-            Message(messageContents);
+            Message("Num Graphs Embedded and Drawn=%d.\n", MainStatistic);
         }
 
         // Report statistics for subgraph homeomorphism algorithms
         else if (embedFlags == EMBEDFLAGS_SEARCHFORK23)
         {
-            sprintf(messageContents, "Of the generated graphs, %d did not contain a K_{2,3} homeomorph as a subgraph.\n", MainStatistic);
-            Message(messageContents);
+            Message("Of the generated graphs, %d did not contain a K_{2,3} "
+                    "homeomorph as a subgraph.\n",
+                    MainStatistic);
         }
         else if (embedFlags == EMBEDFLAGS_SEARCHFORK33)
         {
-            sprintf(messageContents, "Of the generated graphs, %d did not contain a K_{3,3} homeomorph as a subgraph.\n", MainStatistic);
-            Message(messageContents);
+            Message("Of the generated graphs, %d did not contain a K_{3,3} "
+                    "homeomorph as a subgraph.\n",
+                    MainStatistic);
         }
         else if (embedFlags == EMBEDFLAGS_SEARCHFORK4)
         {
-            sprintf(messageContents, "Of the generated graphs, %d did not contain a K_4 homeomorph as a subgraph.\n", MainStatistic);
-            Message(messageContents);
+            Message("Of the generated graphs, %d did not contain a K_4 "
+                    "homeomorph as a subgraph.\n",
+                    MainStatistic);
         }
     }
 
@@ -437,7 +399,7 @@ int GetNumberIfZero(int *pNum, char const *prompt, int min, int max)
 
     while (*pNum == 0)
     {
-        Prompt(prompt);
+        Message("%s", prompt);
         if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
         {
             ErrorMessage("Unable to read integer choice from stdin.\n");
@@ -459,11 +421,9 @@ int GetNumberIfZero(int *pNum, char const *prompt, int min, int max)
 
     if (*pNum < min || *pNum > max)
     {
-        char messageContents[MAXLINE + 1];
-        messageContents[0] = '\0';
         *pNum = (max + min) / 2;
-        sprintf(messageContents, "Number out of range [%d, %d]; changed to %d\n", min, max, *pNum);
-        ErrorMessage(messageContents);
+        ErrorMessage("Number out of range [%d, %d]; changed to %d\n",
+                     min, max, *pNum);
     }
 
     return OK;
@@ -478,9 +438,6 @@ int GetNumberIfZero(int *pNum, char const *prompt, int min, int max)
 graphP MakeGraph(int Size, char command)
 {
     graphP theGraph = NULL;
-    char messageContents[MAXLINE + 1];
-
-    memset(messageContents, '\0', (MAXLINE + 1));
 
     if ((theGraph = gp_New()) == NULL || gp_InitGraph(theGraph, Size) != OK)
     {
@@ -491,8 +448,7 @@ graphP MakeGraph(int Size, char command)
 
     if (ExtendGraph(theGraph, command) != OK)
     {
-        sprintf(messageContents, "Unable to extend graph based on command '%c'\n", command);
-        ErrorMessage(messageContents);
+        ErrorMessage("Unable to extend graph based on command '%c'\n", command);
         gp_Free(&theGraph);
     }
 
@@ -529,25 +485,25 @@ int RandomGraph(char const *const commandString, int extraEdges, int numVertices
     graphP theGraph = NULL, origGraph = NULL;
     int embedFlags = 0;
     char command = '\0', modifier = '\0';
-    char messageContents[MAXLINE + 1];
-
-    memset(messageContents, '\0', (MAXLINE + 1));
 
     if ((Result = GetCommandAndOptionalModifier(commandString, &command, &modifier)) != OK)
     {
-        ErrorMessage("Unable to extract command and optional modifier character from commandString.\n");
+        ErrorMessage("Unable to extract command and optional modifier "
+                     "character from commandString.\n");
         return Result;
     }
 
     if ((Result = GetEmbedFlags(command, modifier, &embedFlags)) != OK)
     {
-        ErrorMessage("Unable to derive embedFlags from command and optional modifier character.\n");
+        ErrorMessage("Unable to derive embedFlags from command and optional "
+                     "modifier character.\n");
         return Result;
     }
 
     if ((Result = GetNumberIfZero(&numVertices, "Enter number of vertices:", 1, 1000000) != OK))
     {
-        ErrorMessage("Encountered unrecoverable error when prompting for numVertices.\n");
+        ErrorMessage("Encountered unrecoverable error when prompting for "
+                     "numVertices.\n");
         return Result;
     }
 
@@ -567,16 +523,16 @@ int RandomGraph(char const *const commandString, int extraEdges, int numVertices
     }
     platform_GetTime(end);
 
-    sprintf(messageContents, "Created random graph with %d edges in %.3lf seconds. ", gp_GetM(theGraph), platform_GetDuration(start, end));
-    Message(messageContents);
-    FlushConsole(stdout);
+    Message("Created random graph with %d edges in %.3lf seconds.",
+            gp_GetM(theGraph), platform_GetDuration(start, end));
 
     // The user may have requested a copy of the random graph before processing
     if (outfile2Name != NULL)
     {
         if (gp_Write(theGraph, outfile2Name, WRITE_ADJLIST) != OK)
         {
-            ErrorMessage("Unable to write generated random graph before embedding.\n");
+            ErrorMessage("Unable to write generated random graph before "
+                         "embedding.\n");
             gp_Free(&theGraph);
             return NOTOK;
         }
@@ -584,7 +540,8 @@ int RandomGraph(char const *const commandString, int extraEdges, int numVertices
 
     if ((origGraph = gp_DupGraph(theGraph)) == NULL)
     {
-        ErrorMessage("Unable to create copy of generated random graph before embedding.\n");
+        ErrorMessage("Unable to create copy of generated random graph before "
+                     "embedding.\n");
         gp_Free(&theGraph);
         return NOTOK;
     }
@@ -629,13 +586,15 @@ int RandomGraph(char const *const commandString, int extraEdges, int numVertices
     {
         if (outfileName != NULL && gp_Write(theGraph, outfileName, WRITE_ADJLIST) != OK)
         {
-            ErrorMessage("Unable to write graph as adjacency list after successful gp_Embed() and gp_TestEmbedResultIntegrity().\n");
+            ErrorMessage("Unable to write graph as adjacency list after "
+                         "successful gp_Embed() and gp_TestEmbedResultIntegrity().\n");
             Result = NOTOK;
         }
 
         if (Result == OK && !getQuietModeSetting() && WriteEdgeListFormat(theGraph, origGraph, extraEdges) != OK)
         {
-            ErrorMessage("Encountered an error when attempting to write graph to edge list format.\n");
+            ErrorMessage("Encountered an error when attempting to write graph "
+                         "to edge list format.\n");
             Result = NOTOK;
         }
     }
@@ -653,29 +612,28 @@ int RandomGraph(char const *const commandString, int extraEdges, int numVertices
 int WriteEdgeListFormat(graphP theGraph, graphP origGraph, int extraEdges)
 {
     char saveEdgeListFormat = '\0';
-    int charsAvailForStr = 0;
-    char const *messageFormat = NULL;
-    char messageContents[MAXLINE + 1];
     char theFileName[MAXLINE + 1];
     char lineBuff[MAXLINE + 1];
 
-    memset(messageContents, '\0', (MAXLINE + 1));
     memset(theFileName, '\0', (MAXLINE + 1));
     memset(lineBuff, '\0', (MAXLINE + 1));
 
     while (1)
     {
-        Prompt("Do you want to save the generated graph in edge list format (y/n)? ");
+        Message("Do you want to save the generated graph in edge list format "
+                "(y/n)? ");
         if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
         {
-            ErrorMessage("Unable to read user input to indicate whether to save edge list format from stdin.\n");
+            ErrorMessage("Unable to read user input to indicate whether to "
+                         "save edge list format from stdin.\n");
             return NOTOK;
         }
 
         if (strlen(lineBuff) != 1 ||
             sscanf(lineBuff, " %c", &saveEdgeListFormat) != 1 ||
             !strchr(YESNOCHOICECHARS, saveEdgeListFormat))
-            ErrorMessage("Invalid choice whether to save graph in edge list format.\n");
+            ErrorMessage("Invalid choice whether to save graph in edge list "
+                         "format.\n");
         else
         {
             saveEdgeListFormat = (char)tolower(saveEdgeListFormat);
@@ -688,23 +646,13 @@ int WriteEdgeListFormat(graphP theGraph, graphP origGraph, int extraEdges)
     else
         strcpy(theFileName, "maxPlanarEdgeList.txt");
 
-    messageFormat = "Saving edge list format of original graph to \"%.*s\"\n";
-    charsAvailForStr = (int)(MAXLINE - strlen(messageFormat));
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-    sprintf(messageContents, messageFormat, charsAvailForStr, theFileName);
-#pragma GCC diagnostic pop
-    Message(messageContents);
+    Message("Saving edge list format of original graph to \"%.*s\"\n",
+            FILENAME_MAX, theFileName);
     SaveAsciiGraph(origGraph, theFileName);
 
     strcat(theFileName, ".out.txt");
-    messageFormat = "Saving edge list format of result to \"%.*s\"\n";
-    charsAvailForStr = (int)(MAXLINE - strlen(messageFormat));
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-    sprintf(messageContents, messageFormat, charsAvailForStr, theFileName);
-#pragma GCC diagnostic pop
-    Message(messageContents);
+    Message("Saving edge list format of result to \"%.*s\"\n",
+            FILENAME_MAX, theFileName);
     SaveAsciiGraph(theGraph, theFileName);
 
     return OK;

--- a/c/planarityApp/planarityTestAllGraphs.c
+++ b/c/planarityApp/planarityTestAllGraphs.c
@@ -113,8 +113,9 @@ int TestAllGraphs(char const *const commandString, char const *const infileName,
 int testAllGraphs(char command, char modifier, char const *const infileName, testAllStatsP stats)
 {
     int Result = OK;
-    graphP theGraph = NULL;
-    graphP copyOfOrigGraph = NULL;
+
+    graphP origGraphRead = NULL;
+    graphP graphForEmbedding = NULL;
     int embedFlags = 0, numOK = 0, numNONEMBEDDABLE = 0, errorFlag = FALSE;
 
     G6ReadIteratorP theG6ReadIterator = NULL;
@@ -132,9 +133,9 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
         return Result;
     }
 
-    theGraph = gp_New();
+    origGraphRead = gp_New();
 
-    if (theGraph == NULL)
+    if (origGraphRead == NULL)
     {
         ErrorMessage("Unable to allocate graph.\n");
 
@@ -143,11 +144,11 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
         return NOTOK;
     }
 
-    if ((Result = g6_NewReader((&theG6ReadIterator), theGraph)) != OK)
+    if ((Result = g6_NewReader((&theG6ReadIterator), origGraphRead)) != OK)
     {
         ErrorMessage("Unable to allocate G6ReadIterator.\n");
 
-        gp_Free(&theGraph);
+        gp_Free(&origGraphRead);
         stats->errorFlag = TRUE;
 
         return Result;
@@ -159,38 +160,77 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
                      "G6ReadIterator.\n");
 
         g6_FreeReader((&theG6ReadIterator));
-        gp_Free(&theGraph);
+        gp_Free(&origGraphRead);
         stats->errorFlag = TRUE;
 
         return Result;
     }
 
-    order = gp_GetN(theGraph);
+    order = gp_GetN(origGraphRead);
+
+    graphForEmbedding = gp_New();
+    if (graphForEmbedding == NULL)
+    {
+        ErrorMessage("Unable to allocate graph to store copy of original graph before embedding.\n");
+
+        g6_FreeReader((&theG6ReadIterator));
+        gp_Free(&origGraphRead);
+        stats->errorFlag = TRUE;
+
+        return NOTOK;
+    }
+
+    if (gp_InitGraph(graphForEmbedding, order) != OK)
+    {
+        ErrorMessage("Unable to initialize graph datastructure to store copy of original graph before embedding.\n");
+
+        g6_FreeReader((&theG6ReadIterator));
+        gp_Free(&origGraphRead);
+        gp_Free(&graphForEmbedding);
+        stats->errorFlag = TRUE;
+
+        return Result;
+    }
+
     // We have to set the maximum edge capacity (i.e. (N * (N - 1) / 2)) because some of the test files
     // can contain complete graphs, and the graph drawing, K_{3, 3} search, and K_4 search extensions
     // don't support expanding the edge capacity after being attached.
-    if (strchr("d34", command) != NULL)
+    if ((Result = gp_EnsureEdgeCapacity(graphForEmbedding, (order * (order - 1) / 2))) != OK)
     {
-        if ((Result = gp_EnsureEdgeCapacity(theGraph, (order * (order - 1) / 2))) != OK)
-        {
-            ErrorMessage("Unable to ensure sufficient edge capacity of the G6ReadIterator's graph struct.\n");
+        ErrorMessage("Unable to ensure sufficient edge capacity of the graph for embedding.\n");
 
-            g6_FreeReader((&theG6ReadIterator));
-            gp_Free(&theGraph);
-            stats->errorFlag = TRUE;
+        g6_FreeReader((&theG6ReadIterator));
+        gp_Free(&origGraphRead);
+        gp_Free(&graphForEmbedding);
+        stats->errorFlag = TRUE;
 
-            return Result;
-        }
+        return Result;
+    }
+    // We have to set the maximum edge capacity because otherwise gp_CopyGraph()
+    // will fail due to the destination graph (graphForEmbedding) having a greater
+    // edge capacity than the source graph (origGraphRead)
+    if ((Result = gp_EnsureEdgeCapacity(origGraphRead, (order * (order - 1) / 2))) != OK)
+    {
+        ErrorMessage("Unable to ensure sufficient edge capacity of the original graph read.\n");
+
+        g6_FreeReader((&theG6ReadIterator));
+        gp_Free(&origGraphRead);
+        gp_Free(&graphForEmbedding);
+        stats->errorFlag = TRUE;
+
+        return Result;
     }
 
-    if ((Result = ExtendGraph(theGraph, command)) != OK)
+    // We must extend the original graph so that in the loop body when we
+    // gp_CopyGraph(), the extension structures will be copied over.
+    if ((Result = ExtendGraph(origGraphRead, command)) != OK)
     {
         char commandStr[3];
         commandStr[0] = command;
         commandStr[1] = modifier;
         commandStr[2] = '\0';
 
-        messageFormat = "Unable to extend graph with command %s\n";
+        messageFormat = "Unable to extend graph for embedding with command %s\n";
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
         sprintf(messageContents, messageFormat, commandStr);
@@ -199,31 +239,8 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
         ErrorMessage(messageContents);
 
         g6_FreeReader(&theG6ReadIterator);
-        gp_Free(&theGraph);
-        stats->errorFlag = TRUE;
-
-        return Result;
-    }
-
-    copyOfOrigGraph = gp_New();
-    if (copyOfOrigGraph == NULL)
-    {
-        ErrorMessage("Unable to allocate graph to store copy of original graph before embedding.\n");
-
-        g6_FreeReader((&theG6ReadIterator));
-        gp_Free(&theGraph);
-        stats->errorFlag = TRUE;
-
-        return NOTOK;
-    }
-
-    if (gp_InitGraph(copyOfOrigGraph, order) != OK)
-    {
-        ErrorMessage("Unable to initialize graph datastructure to store copy of original graph before embedding.\n");
-
-        g6_FreeReader((&theG6ReadIterator));
-        gp_Free(&theGraph);
-        gp_Free(&copyOfOrigGraph);
+        gp_Free(&origGraphRead);
+        gp_Free(&graphForEmbedding);
         stats->errorFlag = TRUE;
 
         return Result;
@@ -248,9 +265,13 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
         if (g6_EndReached(theG6ReadIterator))
             break;
 
-        gp_CopyGraph(copyOfOrigGraph, theGraph);
+        // NOTE: This will gp_CopyExtensions() from the origGraphRead to the
+        // graphForEmbedding, which will free any existing extensions on the
+        // graphForEmbedding before malloc and populating with the extensions
+        // from the origGraphRead
+        gp_CopyGraph(graphForEmbedding, origGraphRead);
 
-        Result = gp_Embed(theGraph, embedFlags);
+        Result = gp_Embed(graphForEmbedding, embedFlags);
         if (Result != OK && Result != NONEMBEDDABLE)
         {
             messageFormat = "Failed to embed graph on line %d for command '%c'.\n";
@@ -265,7 +286,7 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
             break;
         }
 
-        if (gp_TestEmbedResultIntegrity(theGraph, copyOfOrigGraph, Result) != Result)
+        if (gp_TestEmbedResultIntegrity(graphForEmbedding, origGraphRead, Result) != Result)
         {
             messageFormat = "Embed integrity check failed for graph on line %d for command '%c'.\n";
 #pragma GCC diagnostic push
@@ -316,8 +337,8 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
     stats->errorFlag = errorFlag;
 
     g6_FreeReader((&theG6ReadIterator));
-    gp_Free(&theGraph);
-    gp_Free(&copyOfOrigGraph);
+    gp_Free(&origGraphRead);
+    gp_Free(&graphForEmbedding);
 
     return Result;
 }

--- a/c/planarityApp/planarityTestAllGraphs.c
+++ b/c/planarityApp/planarityTestAllGraphs.c
@@ -47,15 +47,14 @@ int TestAllGraphs(char const *const commandString, char const *const infileName,
 
     if (GetCommandAndOptionalModifier(commandString, &command, &modifier) != OK)
     {
-        ErrorMessage("Unable to determine command (and optional modifier) from command string.\n");
-
+        ErrorMessage("Unable to determine command (and optional modifier) from "
+                     "command string.\n");
         return NOTOK;
     }
 
     if (infileName == NULL)
     {
         ErrorMessage("No input file provided.\n");
-
         return NOTOK;
     }
 
@@ -85,7 +84,6 @@ int TestAllGraphs(char const *const commandString, char const *const infileName,
         sprintf(messageContents, messageFormat, command, charsAvailForFilename, infileName);
 #pragma GCC diagnostic pop
         ErrorMessage(messageContents);
-
         Result = NOTOK;
     }
     else
@@ -103,7 +101,6 @@ int TestAllGraphs(char const *const commandString, char const *const infileName,
         sprintf(messageContents, messageFormat, command, charsAvailForFilename, infileName);
 #pragma GCC diagnostic pop
         ErrorMessage(messageContents);
-
         Result = NOTOK;
     }
 
@@ -117,133 +114,90 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
     graphP origGraphRead = NULL;
     graphP graphForEmbedding = NULL;
     int embedFlags = 0, numOK = 0, numNONEMBEDDABLE = 0, errorFlag = FALSE;
+    int order = 0, maxNumEdgesForOrder = 0;
 
     G6ReadIteratorP theG6ReadIterator = NULL;
     char const *messageFormat = NULL;
-    int order = 0;
     char messageContents[MAXLINE + 1];
     messageContents[MAXLINE] = '\0';
 
-    if ((Result = GetEmbedFlags(command, modifier, &embedFlags)) != OK)
+    if (GetEmbedFlags(command, modifier, &embedFlags) != OK)
     {
-        ErrorMessage("Unable to derive embedFlags from command and modifier characters.\n");
-
+        ErrorMessage("Unable to derive embedFlags from command and modifier "
+                     "characters.\n");
         stats->errorFlag = TRUE;
-
-        return Result;
+        return NOTOK;
     }
 
-    origGraphRead = gp_New();
-
-    if (origGraphRead == NULL)
+    if ((origGraphRead = gp_New()) == NULL)
     {
         ErrorMessage("Unable to allocate graph.\n");
-
         stats->errorFlag = TRUE;
-
         return NOTOK;
     }
 
-    if ((Result = g6_NewReader((&theG6ReadIterator), origGraphRead)) != OK)
+    if (
+        g6_NewReader((&theG6ReadIterator), origGraphRead) != OK ||
+        g6_InitReaderWithFileName(theG6ReadIterator, infileName) != OK)
     {
-        ErrorMessage("Unable to allocate G6ReadIterator.\n");
-
+        ErrorMessage("Unable to test all graphs due to failure to allocate or "
+                     "initialize G6ReadIterator.\n");
         gp_Free(&origGraphRead);
-        stats->errorFlag = TRUE;
-
-        return Result;
-    }
-
-    if ((Result = g6_InitReaderWithFileName(theG6ReadIterator, infileName)) != OK)
-    {
-        ErrorMessage("Unable to test all graphs due to failure to initialize"
-                     "G6ReadIterator.\n");
-
         g6_FreeReader((&theG6ReadIterator));
-        gp_Free(&origGraphRead);
         stats->errorFlag = TRUE;
-
-        return Result;
+        return NOTOK;
     }
 
+    // The order of the graphs in the G6 source file or string was determined by
+    // g6_InitReaderWithFileName() and we obtain it to initialize the graph for
+    // embedding
     order = gp_GetN(origGraphRead);
 
-    graphForEmbedding = gp_New();
-    if (graphForEmbedding == NULL)
+    if (
+        (graphForEmbedding = gp_New()) == NULL ||
+        gp_InitGraph(graphForEmbedding, order) != OK)
     {
-        ErrorMessage("Unable to allocate graph to store copy of original graph before embedding.\n");
-
+        ErrorMessage("Unable to allocate or initialize graph for embedding "
+                     "operation.\n");
         g6_FreeReader((&theG6ReadIterator));
         gp_Free(&origGraphRead);
+        gp_Free(&graphForEmbedding);
         stats->errorFlag = TRUE;
-
         return NOTOK;
     }
 
-    if (gp_InitGraph(graphForEmbedding, order) != OK)
+    maxNumEdgesForOrder = (order * (order - 1)) / 2;
+    // We have to set the maximum edge capacity (i.e. (N * (N - 1) / 2)) because
+    // some of the test files contain graphs with an edge count greater than the
+    // default of 3 * N.
+    // Additionally, we have to set the maximum edge capacity because otherwise
+    // gp_CopyGraph() will fail due to the destination graph (graphForEmbedding)
+    // having a greater edge capacity than the source graph (origGraphRead)
+    if (
+        gp_EnsureEdgeCapacity(origGraphRead, (order * (order - 1) / 2)) != OK ||
+        gp_EnsureEdgeCapacity(graphForEmbedding, maxNumEdgesForOrder) != OK)
     {
-        ErrorMessage("Unable to initialize graph datastructure to store copy of original graph before embedding.\n");
-
+        ErrorMessage("Unable to ensure sufficient edge capacity of the "
+                     "original graph read or the graph for embedding.\n");
         g6_FreeReader((&theG6ReadIterator));
         gp_Free(&origGraphRead);
         gp_Free(&graphForEmbedding);
         stats->errorFlag = TRUE;
-
-        return Result;
-    }
-
-    // We have to set the maximum edge capacity (i.e. (N * (N - 1) / 2)) because some of the test files
-    // can contain complete graphs, and the graph drawing, K_{3, 3} search, and K_4 search extensions
-    // don't support expanding the edge capacity after being attached.
-    if ((Result = gp_EnsureEdgeCapacity(graphForEmbedding, (order * (order - 1) / 2))) != OK)
-    {
-        ErrorMessage("Unable to ensure sufficient edge capacity of the graph for embedding.\n");
-
-        g6_FreeReader((&theG6ReadIterator));
-        gp_Free(&origGraphRead);
-        gp_Free(&graphForEmbedding);
-        stats->errorFlag = TRUE;
-
-        return Result;
-    }
-    // We have to set the maximum edge capacity because otherwise gp_CopyGraph()
-    // will fail due to the destination graph (graphForEmbedding) having a greater
-    // edge capacity than the source graph (origGraphRead)
-    if ((Result = gp_EnsureEdgeCapacity(origGraphRead, (order * (order - 1) / 2))) != OK)
-    {
-        ErrorMessage("Unable to ensure sufficient edge capacity of the original graph read.\n");
-
-        g6_FreeReader((&theG6ReadIterator));
-        gp_Free(&origGraphRead);
-        gp_Free(&graphForEmbedding);
-        stats->errorFlag = TRUE;
-
-        return Result;
+        return NOTOK;
     }
 
     // We must extend the original graph so that in the loop body when we
     // gp_CopyGraph(), the extension structures will be copied over.
-    if ((Result = ExtendGraph(origGraphRead, command)) != OK)
+    if (ExtendGraph(origGraphRead, command) != OK ||
+        ExtendGraph(graphForEmbedding, command) != OK)
     {
-        char commandStr[3];
-        commandStr[0] = command;
-        commandStr[1] = modifier;
-        commandStr[2] = '\0';
-
-        messageFormat = "Unable to extend graph for embedding with command %s\n";
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-        sprintf(messageContents, messageFormat, commandStr);
-#pragma GCC diagnostic pop
-
-        ErrorMessage(messageContents);
-
+        ErrorMessage("Unable to extend graph to support requested graph "
+                     "embedding operation.");
         g6_FreeReader(&theG6ReadIterator);
         gp_Free(&origGraphRead);
         gp_Free(&graphForEmbedding);
         stats->errorFlag = TRUE;
-
-        return Result;
+        return NOTOK;
     }
 
     while (true)
@@ -256,20 +210,22 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
             sprintf(messageContents, messageFormat, theG6ReadIterator->numGraphsRead + 1);
 #pragma GCC diagnostic pop
             ErrorMessage(messageContents);
-
             errorFlag = TRUE;
-
+            Result = NOTOK;
             break;
         }
 
         if (g6_EndReached(theG6ReadIterator))
             break;
 
-        // NOTE: This will gp_CopyExtensions() from the origGraphRead to the
-        // graphForEmbedding, which will free any existing extensions on the
-        // graphForEmbedding before malloc and populating with the extensions
-        // from the origGraphRead
-        gp_CopyGraph(graphForEmbedding, origGraphRead);
+        if (gp_CopyGraph(graphForEmbedding, origGraphRead) != OK)
+        {
+            ErrorMessage("Unable to copy graph read into graph for "
+                         "embedding.\n");
+            errorFlag = TRUE;
+            Result = NOTOK;
+            break;
+        }
 
         Result = gp_Embed(graphForEmbedding, embedFlags);
         if (Result != OK && Result != NONEMBEDDABLE)
@@ -280,9 +236,8 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
             sprintf(messageContents, messageFormat, theG6ReadIterator->numGraphsRead + 1, command);
 #pragma GCC diagnostic pop
             ErrorMessage(messageContents);
-
             errorFlag = TRUE;
-
+            Result = NOTOK;
             break;
         }
 
@@ -294,9 +249,7 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
             sprintf(messageContents, messageFormat, theG6ReadIterator->numGraphsRead + 1, command);
 #pragma GCC diagnostic pop
             ErrorMessage(messageContents);
-
             errorFlag = TRUE;
-
             Result = NOTOK;
             break;
         }
@@ -324,9 +277,8 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
 #pragma GCC diagnostic pop
             }
             ErrorMessage(messageContents);
-
             errorFlag = TRUE;
-
+            Result = NOTOK;
             break;
         }
     }
@@ -367,7 +319,6 @@ int outputTestAllGraphsResults(char command, char modifier, testAllStatsP stats,
     if (headerStr == NULL)
     {
         ErrorMessage("Unable allocate memory for output file header.\n");
-
         return NOTOK;
     }
 
@@ -380,14 +331,13 @@ int outputTestAllGraphsResults(char command, char modifier, testAllStatsP stats,
         GetNumCharsToReprInt(stats->numOK, &numCharsToReprNumOK) != OK ||
         GetNumCharsToReprInt(stats->numNONEMBEDDABLE, &numCharsToReprNumNONEMBEDDABLE) != OK)
     {
-        ErrorMessage("Unable to determine the number of characters required to represent testAllGraphs stat values.\n");
-
+        ErrorMessage("Unable to determine the number of characters required to "
+                     "represent testAllGraphs stat values.\n");
         if (headerStr != NULL)
         {
             free(headerStr);
             headerStr = NULL;
         }
-
         return NOTOK;
     }
 
@@ -411,13 +361,11 @@ int outputTestAllGraphsResults(char command, char modifier, testAllStatsP stats,
     if (resultsStr == NULL)
     {
         ErrorMessage("Unable allocate memory for results string.\n");
-
         if (headerStr != NULL)
         {
             free(headerStr);
             headerStr = NULL;
         }
-
         return NOTOK;
     }
 
@@ -436,18 +384,16 @@ int outputTestAllGraphsResults(char command, char modifier, testAllStatsP stats,
     {
         if (pOutputStr == NULL)
         {
-            ErrorMessage(
-                "Unable to create output container for TestAllGraphs output, "
-                "as both output filename and pointer to output string are "
-                "NULL.\n");
+            ErrorMessage("Unable to create output container for TestAllGraphs "
+                         "output, as both output filename and pointer to "
+                         "output string are NULL.\n");
         }
         else
         {
             if ((*pOutputStr) != NULL)
-                ErrorMessage(
-                    "Unable to create output container for TestAllGraphs "
-                    "output, since the memory to which pOutputStr points is "
-                    "not NULL.\n");
+                ErrorMessage("Unable to create output container for "
+                             "TestAllGraphs output, since the memory to which "
+                             "pOutputStr points is not NULL.\n");
             else
             {
                 testOutput = sf_NewOutputContainer(pOutputStr, NULL);
@@ -457,9 +403,8 @@ int outputTestAllGraphsResults(char command, char modifier, testAllStatsP stats,
 
     if (testOutput == NULL)
     {
-        ErrorMessage(
-            "Unable to set up output container for TestAllGraphs output.\n");
-
+        ErrorMessage("Unable to set up output container for TestAllGraphs "
+                     "output.\n");
         Result = NOTOK;
     }
 
@@ -468,7 +413,6 @@ int outputTestAllGraphsResults(char command, char modifier, testAllStatsP stats,
         if (sf_fputs(headerStr, testOutput) < 0)
         {
             ErrorMessage("Unable to write headerStr to output container.\n");
-
             Result = NOTOK;
         }
 
@@ -476,9 +420,8 @@ int outputTestAllGraphsResults(char command, char modifier, testAllStatsP stats,
         {
             if (sf_fputs(resultsStr, testOutput) < 0)
             {
-                ErrorMessage(
-                    "Unable to write resultsStr to output container.\n");
-
+                ErrorMessage("Unable to write resultsStr to output "
+                             "container.\n");
                 Result = NOTOK;
             }
         }

--- a/c/planarityApp/planarityTestAllGraphs.c
+++ b/c/planarityApp/planarityTestAllGraphs.c
@@ -65,7 +65,7 @@ int TestAllGraphs(char const *const commandString, char const *const infileName,
     platform_GetTime(end);
     stats.duration = platform_GetDuration(start, end);
 
-    if (Result != OK && Result != NONEMBEDDABLE)
+    if (Result != OK)
     {
         ErrorMessage("\nEncountered error while running command '%c' on all "
                      "graphs in \"%.*s\".\n",
@@ -94,7 +94,7 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
 
     graphP origGraphRead = NULL;
     graphP graphForEmbedding = NULL;
-    int embedFlags = 0, numOK = 0, numNONEMBEDDABLE = 0, errorFlag = FALSE;
+    int embedFlags = 0, numOK = 0, numNONEMBEDDABLE = 0;
     int order = 0, maxNumEdgesForOrder = 0;
 
     G6ReadIteratorP theG6ReadIterator = NULL;
@@ -164,8 +164,6 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
         return NOTOK;
     }
 
-    // We must extend the original graph so that in the loop body when we
-    // gp_CopyGraph(), the extension structures will be copied over.
     if (ExtendGraph(origGraphRead, command) != OK ||
         ExtendGraph(graphForEmbedding, command) != OK)
     {
@@ -185,7 +183,6 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
             ErrorMessage("Unable to read graph on line %d from .g6 read "
                          "iterator.\n",
                          theG6ReadIterator->numGraphsRead + 1);
-            errorFlag = TRUE;
             Result = NOTOK;
             break;
         }
@@ -197,7 +194,6 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
         {
             ErrorMessage("Unable to copy graph read into graph for "
                          "embedding.\n");
-            errorFlag = TRUE;
             Result = NOTOK;
             break;
         }
@@ -207,9 +203,7 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
         {
             ErrorMessage("Failed to embed graph on line %d for command '%c'.\n",
                          theG6ReadIterator->numGraphsRead + 1, command);
-            errorFlag = TRUE;
             Result = NOTOK;
-            break;
         }
 
         if (gp_TestEmbedResultIntegrity(graphForEmbedding, origGraphRead, Result) != Result)
@@ -217,15 +211,18 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
             ErrorMessage("Embed integrity check failed for graph on line %d "
                          "for command '%c'.\n",
                          theG6ReadIterator->numGraphsRead + 1, command);
-            errorFlag = TRUE;
             Result = NOTOK;
-            break;
         }
 
         if (Result == OK)
             numOK++;
         else if (Result == NONEMBEDDABLE)
+        {
             numNONEMBEDDABLE++;
+            // Now that we've processed the NONEMBEDDABLE result, we set the
+            // Result to OK so that we exit the loop with an OK or NOTOK only
+            Result = OK;
+        }
         else
         {
             if (modifier == '\0')
@@ -241,7 +238,6 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
                              command, modifier,
                              theG6ReadIterator->numGraphsRead + 1);
             }
-            errorFlag = TRUE;
             Result = NOTOK;
             break;
         }
@@ -250,7 +246,7 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
     stats->numGraphsRead = theG6ReadIterator->numGraphsRead;
     stats->numOK = numOK;
     stats->numNONEMBEDDABLE = numNONEMBEDDABLE;
-    stats->errorFlag = errorFlag;
+    stats->errorFlag = (Result == OK) ? FALSE : TRUE;
 
     g6_FreeReader((&theG6ReadIterator));
     gp_Free(&origGraphRead);

--- a/c/planarityApp/planarityTestAllGraphs.c
+++ b/c/planarityApp/planarityTestAllGraphs.c
@@ -33,17 +33,11 @@ int TestAllGraphs(char const *const commandString, char const *const infileName,
 {
     int Result = OK;
 
-    platform_time start, end;
     char command = '\0', modifier = '\0';
-
-    int charsAvailForFilename = 0;
-    char const *messageFormat = NULL;
-    char messageContents[MAXLINE + 1];
-
+    platform_time start, end;
     testAllStats stats;
 
     memset(&stats, 0, sizeof(testAllStats));
-    messageContents[MAXLINE] = '\0';
 
     if (GetCommandAndOptionalModifier(commandString, &command, &modifier) != OK)
     {
@@ -58,13 +52,9 @@ int TestAllGraphs(char const *const commandString, char const *const infileName,
         return NOTOK;
     }
 
-    messageFormat = "Start testing all graphs in \"%.*s\".\n";
-    charsAvailForFilename = (int)(MAXLINE - strlen(messageFormat));
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-    sprintf(messageContents, messageFormat, charsAvailForFilename, infileName);
-#pragma GCC diagnostic pop
-    Message(messageContents);
+    Message("Start testing all graphs in \"%.*s\".\n",
+            FILENAME_MAX,
+            infileName);
 
     // Start the timer
     platform_GetTime(start);
@@ -77,30 +67,21 @@ int TestAllGraphs(char const *const commandString, char const *const infileName,
 
     if (Result != OK && Result != NONEMBEDDABLE)
     {
-        messageFormat = "\nEncountered error while running command '%c' on all graphs in \"%.*s\".\n";
-        charsAvailForFilename = (int)(MAXLINE - strlen(messageFormat));
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-        sprintf(messageContents, messageFormat, command, charsAvailForFilename, infileName);
-#pragma GCC diagnostic pop
-        ErrorMessage(messageContents);
+        ErrorMessage("\nEncountered error while running command '%c' on all "
+                     "graphs in \"%.*s\".\n",
+                     command, FILENAME_MAX, infileName);
         Result = NOTOK;
     }
     else
     {
-        sprintf(messageContents, "\nDone testing all graphs (%.3lf seconds).\n", stats.duration);
-        Message(messageContents);
+        Message("\nDone testing all graphs (%.3lf seconds).\n", stats.duration);
     }
 
     if (outputTestAllGraphsResults(command, modifier, &stats, infileName, outfileName, pOutputStr) != OK)
     {
-        messageFormat = "Error outputting results running command '%c' on all graphs in \"%.*s\".\n";
-        charsAvailForFilename = (int)(MAXLINE - strlen(messageFormat));
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-        sprintf(messageContents, messageFormat, command, charsAvailForFilename, infileName);
-#pragma GCC diagnostic pop
-        ErrorMessage(messageContents);
+        ErrorMessage("Error outputting results running command '%c' on all "
+                     "graphs in \"%.*s\".\n",
+                     command, FILENAME_MAX, infileName);
         Result = NOTOK;
     }
 
@@ -117,9 +98,6 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
     int order = 0, maxNumEdgesForOrder = 0;
 
     G6ReadIteratorP theG6ReadIterator = NULL;
-    char const *messageFormat = NULL;
-    char messageContents[MAXLINE + 1];
-    messageContents[MAXLINE] = '\0';
 
     if (GetEmbedFlags(command, modifier, &embedFlags) != OK)
     {
@@ -204,12 +182,9 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
     {
         if (g6_ReadGraph(theG6ReadIterator) != OK)
         {
-            messageFormat = "Unable to read graph on line %d from .g6 read iterator.\n";
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-            sprintf(messageContents, messageFormat, theG6ReadIterator->numGraphsRead + 1);
-#pragma GCC diagnostic pop
-            ErrorMessage(messageContents);
+            ErrorMessage("Unable to read graph on line %d from .g6 read "
+                         "iterator.\n",
+                         theG6ReadIterator->numGraphsRead + 1);
             errorFlag = TRUE;
             Result = NOTOK;
             break;
@@ -230,12 +205,8 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
         Result = gp_Embed(graphForEmbedding, embedFlags);
         if (Result != OK && Result != NONEMBEDDABLE)
         {
-            messageFormat = "Failed to embed graph on line %d for command '%c'.\n";
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-            sprintf(messageContents, messageFormat, theG6ReadIterator->numGraphsRead + 1, command);
-#pragma GCC diagnostic pop
-            ErrorMessage(messageContents);
+            ErrorMessage("Failed to embed graph on line %d for command '%c'.\n",
+                         theG6ReadIterator->numGraphsRead + 1, command);
             errorFlag = TRUE;
             Result = NOTOK;
             break;
@@ -243,12 +214,9 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
 
         if (gp_TestEmbedResultIntegrity(graphForEmbedding, origGraphRead, Result) != Result)
         {
-            messageFormat = "Embed integrity check failed for graph on line %d for command '%c'.\n";
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-            sprintf(messageContents, messageFormat, theG6ReadIterator->numGraphsRead + 1, command);
-#pragma GCC diagnostic pop
-            ErrorMessage(messageContents);
+            ErrorMessage("Embed integrity check failed for graph on line %d "
+                         "for command '%c'.\n",
+                         theG6ReadIterator->numGraphsRead + 1, command);
             errorFlag = TRUE;
             Result = NOTOK;
             break;
@@ -262,21 +230,17 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
         {
             if (modifier == '\0')
             {
-                messageFormat = "Error applying algorithm '%c' to graph on line %d.\n";
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-                sprintf(messageContents, messageFormat, command, theG6ReadIterator->numGraphsRead + 1);
-#pragma GCC diagnostic pop
+                ErrorMessage("Error applying algorithm '%c' to graph on line "
+                             "%d.\n",
+                             command, theG6ReadIterator->numGraphsRead + 1);
             }
             else
             {
-                messageFormat = "Error applying algorithm '%c' with modifier '%c' to graph on line %d.\n";
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-                sprintf(messageContents, messageFormat, command, modifier, theG6ReadIterator->numGraphsRead + 1);
-#pragma GCC diagnostic pop
+                ErrorMessage("Error applying algorithm '%c' with modifier '%c' "
+                             "to graph on line %d.\n",
+                             command, modifier,
+                             theG6ReadIterator->numGraphsRead + 1);
             }
-            ErrorMessage(messageContents);
             errorFlag = TRUE;
             Result = NOTOK;
             break;

--- a/c/planarityApp/planarityUtils.c
+++ b/c/planarityApp/planarityUtils.c
@@ -1012,31 +1012,31 @@ void WriteAlgorithmResults(graphP theGraph, int Result, char command, platform_t
     Message("The graph ");
     if (infileName)
     {
-        Message("\"%.*s\"", FILENAME_MAX, infileName);
+        Message("\"%.*s\" ", FILENAME_MAX, infileName);
     }
 
     switch (command)
     {
     case 'p':
-        Message(" is%s planar.\n", Result == OK ? "" : " not");
+        Message("is%s planar.\n", Result == OK ? "" : " not");
         break;
     case 'd':
-        Message(" is%s planar.\n", Result == OK ? "" : " not");
+        Message("is%s planar.\n", Result == OK ? "" : " not");
         break;
     case 'o':
-        Message(" is%s outerplanar.\n", Result == OK ? "" : " not");
+        Message("is%s outerplanar.\n", Result == OK ? "" : " not");
         break;
     case '2':
-        Message(" has %s subgraph homeomorphic to K_{2,3}.\n", Result == OK ? "no" : "a");
+        Message("has %s subgraph homeomorphic to K_{2,3}.\n", Result == OK ? "no" : "a");
         break;
     case '3':
-        Message(" has %s subgraph homeomorphic to K_{3,3}.\n", Result == OK ? "no" : "a");
+        Message("has %s subgraph homeomorphic to K_{3,3}.\n", Result == OK ? "no" : "a");
         break;
     case '4':
-        Message(" has %s subgraph homeomorphic to K_4.\n", Result == OK ? "no" : "a");
+        Message("has %s subgraph homeomorphic to K_4.\n", Result == OK ? "no" : "a");
         break;
     default:
-        Message(" has not been processed due to unrecognized command.\n");
+        Message("has not been processed due to unrecognized command.\n");
         break;
     }
 

--- a/c/planarityApp/planarityUtils.c
+++ b/c/planarityApp/planarityUtils.c
@@ -27,11 +27,11 @@ int Reconfigure(void)
 
     while (1)
     {
-        Prompt("\nDo you want to \n"
-               "  Randomly generate graphs (r),\n"
-               "  Specify a graph (s),\n"
-               "  Randomly generate a maximal planar graph (m), or\n"
-               "  Randomly generate a non-planar graph (n)?\n\t");
+        Message("\nDo you want to \n"
+                "  Randomly generate graphs (r),\n"
+                "  Specify a graph (s),\n"
+                "  Randomly generate a maximal planar graph (m), or\n"
+                "  Randomly generate a non-planar graph (n)?\n\t");
 
         if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
         {
@@ -57,7 +57,7 @@ int Reconfigure(void)
 
         while (1)
         {
-            Prompt("Do you want original graphs in directory 'random'? (y/n) ");
+            Message("Do you want original graphs in directory 'random'? (y/n) ");
             if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
             {
                 ErrorMessage("Unable to fetch choice from stdin.\n");
@@ -80,7 +80,7 @@ int Reconfigure(void)
         {
             while (1)
             {
-                Prompt("Do you want to output generated graphs to Adjacency List (last 10 only) or to G6 (all)? (a/g) ");
+                Message("Do you want to output generated graphs to Adjacency List (last 10 only) or to G6 (all)? (a/g) ");
                 if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
                 {
                     ErrorMessage("Unable to fetch choice from stdin.\n");
@@ -104,7 +104,7 @@ int Reconfigure(void)
         {
             while (1)
             {
-                Prompt("Do you want adj. matrix of embeddable graphs in directory 'embedded' (last 10 max))? (y/n) ");
+                Message("Do you want adj. matrix of embeddable graphs in directory 'embedded' (last 10 max))? (y/n) ");
                 if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
                 {
                     ErrorMessage("Unable to fetch choice from stdin.\n");
@@ -127,7 +127,7 @@ int Reconfigure(void)
         {
             while (1)
             {
-                Prompt("Do you want adj. matrix of obstructed graphs in directory 'obstructed' (last 10 max)? (y/n) ");
+                Message("Do you want adj. matrix of obstructed graphs in directory 'obstructed' (last 10 max)? (y/n) ");
                 if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
                 {
                     ErrorMessage("Unable to fetch choice from stdin.\n");
@@ -151,7 +151,7 @@ int Reconfigure(void)
         {
             while (1)
             {
-                Prompt("Do you want adjacency list format of embeddings in directory 'adjlist' (last 10 max)? (y/n) ");
+                Message("Do you want adjacency list format of embeddings in directory 'adjlist' (last 10 max)? (y/n) ");
                 if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
                 {
                     ErrorMessage("Unable to fetch choice from stdin.\n");
@@ -212,12 +212,6 @@ void FlushConsole(FILE *f)
     fflush(f);
 }
 
-void Prompt(char const *message)
-{
-    Message(message);
-    FlushConsole(stdout);
-}
-
 /****************************************************************************
  ****************************************************************************/
 
@@ -229,14 +223,9 @@ void SaveAsciiGraph(graphP theGraph, char *filename)
     // The filename may specify a directory that doesn't exist
     if (outfile == NULL)
     {
-        char messageContents[MAXLINE + 1];
-        char const *messageFormat = "Failed to write to \"%.*s\"\nMake the directory if not present\n";
-        int charsAvailForStrToInclude = (int)(MAXLINE - strlen(messageFormat));
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-        sprintf(messageContents, messageFormat, charsAvailForStrToInclude, filename);
-#pragma GCC diagnostic pop
-        ErrorMessage(messageContents);
+        ErrorMessage("Failed to write to \"%.*s\"\nMake the directory if not "
+                     "present\n",
+                     FILENAME_MAX, filename);
         return;
     }
 
@@ -830,7 +819,7 @@ char *ConstructInputFilename(char const *infileName)
     {
         while (1)
         {
-            Prompt("Enter graph file name: ");
+            Message("Enter graph file name: ");
             if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
             {
                 ErrorMessage("Unable to read graph file name from stdin.\n");
@@ -935,11 +924,6 @@ char *ConstructPrimaryOutputFilename(char const *infileName, char const *outfile
     {
         if (strlen(outfileName) > FILENAMEMAXLENGTH)
         {
-            char const *messageFormat = "Outfile filename is too long. Result placed in \"%.*s\"";
-            int charsAvailForStrToInclude = (int)(MAXLINE - strlen(messageFormat));
-            char messageContents[MAXLINE + 1];
-            messageContents[0] = '\0';
-
             // The output filename is based on the input filename
             if (theFileName != infileName)
                 strcpy(theFileName, infileName);
@@ -951,11 +935,7 @@ char *ConstructPrimaryOutputFilename(char const *infileName, char const *outfile
             }
             strcat(theFileName, ".out.txt");
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-            sprintf(messageContents, messageFormat, charsAvailForStrToInclude, theFileName);
-#pragma GCC diagnostic pop
-            ErrorMessage(messageContents);
+            ErrorMessage("Outfile filename is too long. Result placed in \"%.*s\"", FILENAME_MAX, theFileName);
         }
         else
         {
@@ -1029,52 +1009,37 @@ int ConstructTransformationExpectedResultFilename(char const *infileName, char *
 
 void WriteAlgorithmResults(graphP theGraph, int Result, char command, platform_time start, platform_time end, char const *infileName)
 {
-    char const *messageFormat = NULL;
-    char messageContents[MAXLINE + 1];
-    int charsAvailForStr = 0;
-
-    memset(messageContents, '\0', (MAXLINE + 1));
-
+    Message("The graph ");
     if (infileName)
     {
-        messageFormat = "The graph \"%.*s\" ";
-        charsAvailForStr = (int)(MAXLINE - strlen(messageFormat));
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-        sprintf(messageContents, messageFormat, charsAvailForStr, infileName);
-#pragma GCC diagnostic pop
+        Message("\"%.*s\"", FILENAME_MAX, infileName);
     }
-    else
-        sprintf(messageContents, "The graph ");
-    Message(messageContents);
 
     switch (command)
     {
     case 'p':
-        sprintf(messageContents, "is%s planar.\n", Result == OK ? "" : " not");
+        Message(" is%s planar.\n", Result == OK ? "" : " not");
         break;
     case 'd':
-        sprintf(messageContents, "is%s planar.\n", Result == OK ? "" : " not");
+        Message(" is%s planar.\n", Result == OK ? "" : " not");
         break;
     case 'o':
-        sprintf(messageContents, "is%s outerplanar.\n", Result == OK ? "" : " not");
+        Message(" is%s outerplanar.\n", Result == OK ? "" : " not");
         break;
     case '2':
-        sprintf(messageContents, "has %s subgraph homeomorphic to K_{2,3}.\n", Result == OK ? "no" : "a");
+        Message(" has %s subgraph homeomorphic to K_{2,3}.\n", Result == OK ? "no" : "a");
         break;
     case '3':
-        sprintf(messageContents, "has %s subgraph homeomorphic to K_{3,3}.\n", Result == OK ? "no" : "a");
+        Message(" has %s subgraph homeomorphic to K_{3,3}.\n", Result == OK ? "no" : "a");
         break;
     case '4':
-        sprintf(messageContents, "has %s subgraph homeomorphic to K_4.\n", Result == OK ? "no" : "a");
+        Message(" has %s subgraph homeomorphic to K_4.\n", Result == OK ? "no" : "a");
         break;
     default:
-        sprintf(messageContents, "has not been processed due to unrecognized command.\n");
+        Message(" has not been processed due to unrecognized command.\n");
         break;
     }
-    Message(messageContents);
 
-    sprintf(messageContents, "Algorithm '%s' executed in %.3lf seconds.\n",
+    Message("Algorithm '%s' executed in %.3lf seconds.\n",
             GetAlgorithmName(command), platform_GetDuration(start, end));
-    Message(messageContents);
 }


### PR DESCRIPTION
Resolves #205 

## Type of change

Please check only relevant options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes

### Added

* N/A

### Updated

* `c/planarityApp/planarityTestAllGraphs.c` - renamed `theGraph` to `origGraphRead` and `copyOfOrigGraph` to `graphForEmbedding`, then changed the flow so that now, the graph associated with the reader (`origGraphRead`) is that which is used for the embedding integrity check, and that we embed the copy of the graph (`graphForEmbedding`). We must `gp_EnsureEdgeCapacity()` of both the `origGraphRead` and `graphForEmbedding`, because if you try to `gp_EnsureEdgeCapacity()` of a graph after drawplanar, $K_{3,3}$ search, or $K_4$ search are attached, those extensions' overrides currently return `NOTOK`, and if the source graph (`origGraphRead`)'s edge capacity is less than the destination graph (`graphForEmbedding`), `gp_CopyGraph()` fails.

Sweeping changes to address the comment about getting rid of a lot of those pesky
```
#pragma GCC diagnostic push
#pragma GCC diagnostic ignored "-Wformat-nonliteral"
        ...
#pragma GCC diagnostic pop
```

* `c/graphLib/io/g6-api-utilities.c` - updated `ErrorMessage()` so that I pass a string literal and arguments to the updated `ErrorMessage()` function
* `c/graphLib/io/g6-read-iterator.c` - updated `ErrorMessage()` so that I pass a string literal and arguments to the updated `ErrorMessage()` function, and was able to get rid of `messageContents` and `charsAvailForStr` (typically use `FILENAME_MAX` from `stdio.h` when I need to limit the output for how long a filename should be)
* `c/graphLib/lowLevelUtils/apiutils.c`/`.h` - `Message()` and `ErrorMessage()` are now variadic functions, so that one may provide a format string and all arguments to populate that string
* `c/planarityApp/planarity.h` - removed `Prompt()`, since it was just a `Message()` with a `FlushConsole()` (which was already done in `Message()`
* `c/planarityApp/planarityCommandLine.c` - removed need for `messageFormat`, `messageContents`, `charsAvailForXXX` due to refactor with new variadic `Message()` and `ErrorMessage()`
* `c/planarityApp/planarityHelp.c` - To get around the compiler complaining that the string returned by `GetProjectTitle()`, `GetAlgorithmFlags()`, `GetAlgorithmSpecifiers()`, `GetSupportedOutputChoices()` being nonliteral, I created a format string that will just be populated with whatever is returned from these functions. Any `Prompt()` is now a `Message()`.
* `c/planarityApp/planarityCommandLine.c` - removed need for `messageFormat`, `messageContents`, `charsAvailForXXX` due to refactor with new variadic `Message()` and `ErrorMessage()`
* `c/planarityApp/planarityHelp.c` - To get around the compiler complaining that the string returned by `GetProjectTitle()`, I created a format string that will just be populated with whatever is returned from these functions.
* `c/planarityApp/planarityMenu.c` - To get around the compiler complaining that the string returned by `GetProjectTitle()`, `GetAlgorithmSpecifiers()`, and `GetSupportedOutputChoices()`, I created a format string that will just be populated with whatever is returned from these functions. All `Prompt()` are now `Message()`
* `c/planarityApp/planarityRandomGraphs.c` - removed need for `messageFormat`, `messageContents`, `charsAvailForXXX` due to refactor with new variadic `Message()` and `ErrorMessage()`
* `c/planarityApp/planarityTestAllGraphs.c` - In addition to the above changes, removed need for `messageFormat`, `messageContents`, `charsAvailForXXX` due to refactor with new variadic `Message()` and `ErrorMessage()`
* `c/planarityApp/planarityUtils.c` - All `Prompt()` are now `Message()`, removed `Prompt()` definition, and removed need for `messageFormat`, `messageContents`, `charsAvailForXXX` due to refactor with new variadic `Message()` and `ErrorMessage()`

### Removed

* N/A

## Testing

- [x] Re-ran `planarity_testAllGraphs_orchestrator.py` for `N=10` of VSCode Release build (1-based arrays) and verified that the `OK`/`NONEMBEDDABLE` counts did not change (observed a 1-2% slowdown, but without testing higher graph orders, this seems within a margin of error) 
- [ ] Upload logs or provide relevant snippets of terminal output to demo functionality

<details><summary>Replace with high-level description of log snippets</summary>

```
Paste terminal log snippets here
```

<details>
