### PR TITLE
Fixes to hide internal data structures of G6 read and write iterators

### DIFF
--- a/c/graphLib/io/g6-read-iterator.c
+++ b/c/graphLib/io/g6-read-iterator.c
@@ -37,6 +37,32 @@ int _g6_DecodeGraph(char *graphBuff, const int order, const int numChars, graphP
 int _g6_ReadGraphFromFile(graphP theGraph, char *pathToG6File);
 int _g6_ReadGraphFromString(graphP theGraph, char *g6EncodedString);
 
+/********************************************************************
+ Package private structure declaration for read iterator
+ ********************************************************************/
+    typedef struct strOrFileStruct strOrFileStruct;
+    typedef strOrFileStruct *strOrFileP;
+
+    struct G6ReadIteratorStruct
+    {
+        strOrFileP inputContainer;
+        int numGraphsRead;
+
+        int order;
+        int numCharsForOrder;
+        size_t numCharsForGraphEncoding;
+        size_t currGraphBuffSize;
+        char *currGraphBuff;
+
+        graphP currGraph;
+
+        bool endReached;
+    };
+
+/********************************************************************
+ Public and package private method implementations for read iterator
+ ********************************************************************/
+
 int g6_NewReader(G6ReadIteratorP *pG6ReadIterator, graphP theGraph)
 {
     int exitCode = OK;
@@ -614,7 +640,6 @@ int g6_ReadGraph(G6ReadIteratorP theG6ReadIterator)
     }
     else
     {
-        theG6ReadIterator->currGraph = NULL;
         theG6ReadIterator->endReached = true;
     }
 

--- a/c/graphLib/io/g6-read-iterator.h
+++ b/c/graphLib/io/g6-read-iterator.h
@@ -17,27 +17,6 @@ extern "C"
 
 #include "../graph.h"
 
-    // Declaration of package private structure for I/O
-    // from/to a string or file.
-    typedef struct strOrFileStruct strOrFileStruct;
-    typedef strOrFileStruct *strOrFileP;
-
-    struct G6ReadIteratorStruct
-    {
-        strOrFileP inputContainer;
-        int numGraphsRead;
-
-        int order;
-        int numCharsForOrder;
-        size_t numCharsForGraphEncoding;
-        size_t currGraphBuffSize;
-        char *currGraphBuff;
-
-        graphP currGraph;
-
-        bool endReached;
-    };
-
     typedef struct G6ReadIteratorStruct G6ReadIteratorStruct;
     typedef G6ReadIteratorStruct *G6ReadIteratorP;
 

--- a/c/graphLib/io/g6-write-iterator.c
+++ b/c/graphLib/io/g6-write-iterator.c
@@ -33,6 +33,32 @@ int _g6_WriteEncodedGraph(G6WriteIteratorP theG6WriteIterator);
 int _g6_WriteGraphToFile(graphP theGraph, char *g6OutputFileName);
 int _g6_WriteGraphToString(graphP theGraph, char **pOutputStr);
 
+/********************************************************************
+ Package private structure declaration for write iterator
+ ********************************************************************/
+    typedef struct strOrFileStruct strOrFileStruct;
+    typedef strOrFileStruct *strOrFileP;
+
+    struct G6WriteIteratorStruct
+    {
+        strOrFileP outputContainer;
+        int numGraphsWritten;
+
+        int order;
+        int numCharsForOrder;
+        size_t numCharsForGraphEncoding;
+        size_t currGraphBuffSize;
+        char *currGraphBuff;
+
+        size_t *columnOffsets;
+
+        graphP currGraph;
+    };
+
+/********************************************************************
+ Public and package private method implementations for write iterator
+ ********************************************************************/
+
 int g6_NewWriter(G6WriteIteratorP *pG6WriteIterator, graphP theGraph)
 {
     if (pG6WriteIterator == NULL)

--- a/c/graphLib/io/g6-write-iterator.h
+++ b/c/graphLib/io/g6-write-iterator.h
@@ -17,25 +17,6 @@ extern "C"
 
 #include "../graph.h"
 
-    typedef struct strOrFileStruct strOrFileStruct;
-    typedef strOrFileStruct *strOrFileP;
-
-    struct G6WriteIteratorStruct
-    {
-        strOrFileP outputContainer;
-        int numGraphsWritten;
-
-        int order;
-        int numCharsForOrder;
-        size_t numCharsForGraphEncoding;
-        size_t currGraphBuffSize;
-        char *currGraphBuff;
-
-        size_t *columnOffsets;
-
-        graphP currGraph;
-    };
-
     typedef struct G6WriteIteratorStruct G6WriteIteratorStruct;
     typedef G6WriteIteratorStruct *G6WriteIteratorP;
 

--- a/c/planarityApp/planarityTestAllGraphs.c
+++ b/c/planarityApp/planarityTestAllGraphs.c
@@ -180,9 +180,11 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
     {
         if (g6_ReadGraph(theG6ReadIterator) != OK)
         {
+            int numGraphsRead = 0;
+            g6_GetNumGraphsRead(theG6ReadIterator, &numGraphsRead);
             gp_ErrorMessage("Unable to read graph on line %d from .g6 read "
                             "iterator.\n",
-                            theG6ReadIterator->numGraphsRead + 1);
+                            numGraphsRead + 1);
             Result = NOTOK;
             break;
         }
@@ -201,16 +203,20 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
         Result = gp_Embed(graphForEmbedding, embedFlags);
         if (Result != OK && Result != NONEMBEDDABLE)
         {
+            int numGraphsRead = 0;
+            g6_GetNumGraphsRead(theG6ReadIterator, &numGraphsRead);
             gp_ErrorMessage("Failed to embed graph on line %d for command '%c'.\n",
-                            theG6ReadIterator->numGraphsRead + 1, command);
+                            numGraphsRead + 1, command);
             Result = NOTOK;
         }
 
         if (gp_TestEmbedResultIntegrity(graphForEmbedding, origGraphRead, Result) != Result)
         {
+            int numGraphsRead = 0;
+            g6_GetNumGraphsRead(theG6ReadIterator, &numGraphsRead);
             gp_ErrorMessage("Embed integrity check failed for graph on line %d "
                             "for command '%c'.\n",
-                            theG6ReadIterator->numGraphsRead + 1, command);
+                            numGraphsRead + 1, command);
             Result = NOTOK;
         }
 
@@ -227,23 +233,28 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
         {
             if (modifier == '\0')
             {
+                int numGraphsRead = 0;
+                g6_GetNumGraphsRead(theG6ReadIterator, &numGraphsRead);
                 gp_ErrorMessage("Error applying algorithm '%c' to graph on line "
                                 "%d.\n",
-                                command, theG6ReadIterator->numGraphsRead + 1);
+                                command, numGraphsRead + 1);
             }
             else
             {
+                int numGraphsRead = 0;
+                g6_GetNumGraphsRead(theG6ReadIterator, &numGraphsRead);
                 gp_ErrorMessage("Error applying algorithm '%c' with modifier '%c' "
                                 "to graph on line %d.\n",
-                                command, modifier,
-                                theG6ReadIterator->numGraphsRead + 1);
+                                command, modifier, numGraphsRead + 1);
             }
             Result = NOTOK;
             break;
         }
     }
 
-    stats->numGraphsRead = theG6ReadIterator->numGraphsRead;
+    stats->numGraphsRead = 0;
+    if (g6_GetNumGraphsRead(theG6ReadIterator, &stats->numGraphsRead) != OK)
+        NOTOK;
     stats->numOK = numOK;
     stats->numNONEMBEDDABLE = numNONEMBEDDABLE;
     stats->errorFlag = (Result == OK) ? FALSE : TRUE;

--- a/c/planarityApp/planarityTestAllGraphs.c
+++ b/c/planarityApp/planarityTestAllGraphs.c
@@ -253,8 +253,7 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
     }
 
     stats->numGraphsRead = 0;
-    if (g6_GetNumGraphsRead(theG6ReadIterator, &stats->numGraphsRead) != OK)
-        NOTOK;
+    g6_GetNumGraphsRead(theG6ReadIterator, &stats->numGraphsRead);
     stats->numOK = numOK;
     stats->numNONEMBEDDABLE = numNONEMBEDDABLE;
     stats->errorFlag = (Result == OK) ? FALSE : TRUE;


### PR DESCRIPTION
Resolves #167 

## Changes

1. Hid internal data structures for G6 read/write iterators by moving the declarations from the public header files to the c source files.
2. Replaced read iterator data member accesses in test all graphs with calls to the getter method.
3. Removed assignment of NULL to `currGraph` when `endReached` during `g6_ReadGraph()` because assigning NULL causes the iterator to report it is not initialized, which prevents success on the last call of `g6_GetNumGraphsRead()` in test all graphs.

## Testing

Ran test all graphs with N5-all.g6 from samples directory.

(The last line of this PR template needs to have a details end tab, so please add a slash to it)
