### PR TITLE
Issue216 improve copy extensions and Issue218 spell checker fix

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -8,4 +8,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: codespell-project/actions-codespell@v2
         with:
-          skip: ../../c/samples/n8.mALL.g6
+          skip: ./c/samples

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -8,4 +8,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: codespell-project/actions-codespell@v2
         with:
-          skip: c/samples/n8.mALL.g6
+          skip: ../../c/samples/n8.mALL.g6

--- a/c/graphLib/extensionSystem/graphExtensions.c
+++ b/c/graphLib/extensionSystem/graphExtensions.c
@@ -53,19 +53,10 @@ static int moduleIDGenerator = 0;
      An instance of this context structure is passed to the "context"
      parameter of gp_AddExtension().
 
-  3) Define a function capable of duplicating your context data
-     structure.  It receives a void pointer indicating the context
-     to duplicate and a void pointer that can be cast to a graph
-     pointer indicating the graph for which the context is being
-     duplicated.  The void pointer returned indicates the newly
-     allocated context structure.  The pointer to this function is
-     passed to the "dupContext" parameter of gp_AddExtension()
-
-     Note: It is useful to store in your context structure a pointer
-     to the graph that the context is extending.  There are certain
-     function overloads you will perform that will only receive
-     the context, and you may need to know things about the graph,
-     such as the number of vertices or edges.
+  3) Define a function capable of copying your context data. It receives 
+     void pointers to destination and source contexts, and then copies the
+     extension-specific data from source to destination. This function's
+     pointer is passed to the "copyData" parameter of gp_AddExtension()
 
   4) Define a function that can free the memory used by your context
      data structure.  It will receive a void pointer indicating the
@@ -132,7 +123,8 @@ static int moduleIDGenerator = 0;
         of fpReadPostprocess() and fpWritePostprocess() are needed.
 
   7) Define internal functions for _Feature_ClearStructures(),
-     _Feature_CreateStructures() and _Feature_InitStructures();
+     _Feature_CreateStructures(), _Feature_InitStructures(), and
+     _Feature_CopyStructures();
 
      a) The _Feature_ClearStructures() should simply null out pointers
         to extra structures on its first invocation, but thereafter it
@@ -150,6 +142,13 @@ static int moduleIDGenerator = 0;
      c) The _Feature_InitStructures() should invoke just the functions
         needed to initialize the custom VertexRec, VertexInfo and
         EdgeRec data members, if any.
+
+     d) The _Feature_CopyStructures() should invoke just the functions
+        needed to copy the custom VertexRec, VertexInfo and EdgeRec data
+        members, if any, from a source extension context to a destination
+        extension context. For custom EdgeRec arrays, if the destination
+        has more capacitiy than the source, then the implementation should
+        also ensure the extra EdgeRecs are initialized in the destination.
 
   8) Define a function gp_Detach_Feature() that invokes gp_RemoveExtension()
      This should be done for consistency, so that users of a feature
@@ -170,7 +169,7 @@ static int moduleIDGenerator = 0;
                  value can be used to find and remove the extension from any graph
  @param context - the data storage for the extension being added
                The context is owned by the extension and freed with freeContext()
- @param dupContext - a function capable of duplicating the context data
+ @param copyData - a function capable of copying the context data
  @param freeContext - a function capable of freeing the context data
  @param functions - pointer to a table of functions stored in the data context.
                         The table of functions is an input and output parameter.
@@ -190,14 +189,14 @@ static int moduleIDGenerator = 0;
 int gp_AddExtension(graphP theGraph,
                     int *pModuleID,
                     void *context,
-                    void *(*dupContext)(void *, void *),
+                    int  (*copyData)(void *, void *),
                     void (*freeContext)(void *),
                     graphFunctionTableP functions)
 {
     graphExtensionP newExtension = NULL;
 
     if (theGraph == NULL || pModuleID == NULL ||
-        context == NULL || dupContext == NULL || freeContext == NULL ||
+        context == NULL || copyData == NULL || freeContext == NULL ||
         functions == NULL)
     {
         return NOTOK;
@@ -224,7 +223,7 @@ int gp_AddExtension(graphP theGraph,
     // Assign the data payload of the extension
     newExtension->moduleID = *pModuleID;
     newExtension->context = context;
-    newExtension->dupContext = dupContext;
+    newExtension->copyData = copyData;
     newExtension->freeContext = freeContext;
     newExtension->functions = functions;
 
@@ -459,39 +458,51 @@ graphExtensionP _FindNearestOverload(graphP theGraph, graphExtensionP target, in
  gp_CopyExtensions()
  ********************************************************************/
 
+// This number can just be made bigger if ever needed
+#define MAXNUMSUPPORTEDEXTENSIONS 32
+
 int gp_CopyExtensions(graphP dstGraph, graphP srcGraph)
 {
-    graphExtensionP next = NULL, newNext = NULL, newLast = NULL;
+    graphExtensionP dstExtension = NULL, srcExtension = NULL;
+    graphExtensionP srcExtensionIDMap[MAXNUMSUPPORTEDEXTENSIONS+1];
 
     if (srcGraph == NULL || dstGraph == NULL)
         return NOTOK;
 
-    gp_FreeExtensions(dstGraph);
+    if (gp_GetN(dstGraph) != gp_GetN(srcGraph) || gp_GetN(dstGraph) == 0)
+        return NOTOK;
 
-    next = srcGraph->extensions;
+    // NULL out the pointers in the srcExtensionIDMap
+    memset(srcExtensionIDMap, 0, (MAXNUMSUPPORTEDEXTENSIONS+1)*sizeof(graphExtensionP));
 
-    while (next != NULL)
+    // Run through the srcGraph extensions linked list and put the pointer to 
+    // each extension in the srcExtensionIDMap at the index location indicated
+    // by the extension module ID. This mapping is needed because the srcGraph
+    // may have been extended with the extensions in a different order than the
+    // dstGraph, but the moduleID for each extension is the same across graphs. 
+    srcExtension = srcGraph->extensions;
+    while (srcExtension != NULL)
     {
-        if ((newNext = (graphExtensionP)malloc(sizeof(graphExtensionStruct))) == NULL)
-        {
-            gp_FreeExtensions(dstGraph);
+        if (srcExtension->moduleID < 0 || srcExtension->moduleID > MAXNUMSUPPORTEDEXTENSIONS)
             return NOTOK;
-        }
 
-        newNext->moduleID = next->moduleID;
-        newNext->context = next->dupContext(next->context, dstGraph);
-        newNext->dupContext = next->dupContext;
-        newNext->freeContext = next->freeContext;
-        newNext->functions = next->functions;
-        newNext->next = NULL;
+        srcExtensionIDMap[srcExtension->moduleID] = srcExtension;
+        srcExtension = (graphExtensionP)srcExtension->next;        
+    }
 
-        if (newLast != NULL)
-            newLast->next = (struct graphExtensionStruct *)newNext;
-        else
-            dstGraph->extensions = newNext;
+    // For each extension in the dstGraph, if the srcGraph has the same extension,
+    // then we invoke the extension's copyData to copy from srcGraph to dstGraph.
+    // If the dstGraph has an extension that the srcGraph does not have, then
+    // NULL is passed for the srcGraph extension, which is expected to cause
+    // the extension's copyData() to reset/reinitialize the dstGraph structures.
+    dstExtension = dstGraph->extensions;
+    while (dstExtension != NULL)
+    {
+        srcExtension = srcExtensionIDMap[dstExtension->moduleID];
+        if (dstExtension->copyData(dstExtension->context, srcExtension->context) != OK)
+            return NOTOK;
 
-        newLast = newNext;
-        next = (graphExtensionP)next->next;
+        dstExtension = (graphExtensionP)dstExtension->next;
     }
 
     return OK;

--- a/c/graphLib/extensionSystem/graphExtensions.c
+++ b/c/graphLib/extensionSystem/graphExtensions.c
@@ -499,7 +499,7 @@ int gp_CopyExtensions(graphP dstGraph, graphP srcGraph)
     while (dstExtension != NULL)
     {
         srcExtension = srcExtensionIDMap[dstExtension->moduleID];
-        if (dstExtension->copyData(dstExtension->context, srcExtension->context) != OK)
+        if (dstExtension->copyData(dstExtension->context, srcExtension ? srcExtension->context : NULL) != OK)
             return NOTOK;
 
         dstExtension = (graphExtensionP)dstExtension->next;

--- a/c/graphLib/extensionSystem/graphExtensions.h
+++ b/c/graphLib/extensionSystem/graphExtensions.h
@@ -17,7 +17,7 @@ extern "C"
     int gp_AddExtension(graphP theGraph,
                         int *pModuleID,
                         void *context,
-                        void *(*dupContext)(void *, void *),
+                        int  (*copyData)(void *, void *),
                         void (*freeContext)(void *),
                         graphFunctionTableP overloadTable);
 

--- a/c/graphLib/extensionSystem/graphExtensions.private.h
+++ b/c/graphLib/extensionSystem/graphExtensions.private.h
@@ -18,7 +18,7 @@ extern "C"
     {
         int moduleID;
         void *context;
-        void *(*dupContext)(void *, void *);
+        int  (*copyData)(void *, void *);
         void (*freeContext)(void *);
 
         graphFunctionTableP functions;

--- a/c/graphLib/graph.c
+++ b/c/graphLib/graph.c
@@ -1062,21 +1062,12 @@ int gp_CopyGraph(graphP dstGraph, graphP srcGraph)
     if (gp_CopyExtensions(dstGraph, srcGraph) != OK)
         return NOTOK;
 
-    // Copy the graph's function table, which has the pointers to
-    // the most recent extension overloads of each function (or
-    // the original function pointer if a particular function has
-    // not been overloaded).
-    //
-    // This must be done after copying the extension because the
-    // first step of copying the extensions is to free the extensions
-    // of the dstGraph, which performs _InitFunctionTable() on dstGraph.
-    // Therefore, assigning the srcGraph functions to dstGraph *before*
-    // copying the extensions doesn't work because the assignment would be
-    // wiped out. This, in turn, means that the DupContext function of an
-    // extension *cannot* depend on any extension function overloads;
-    // the extension must directly invoke extension functions only.
-    *(dstGraph->functions) = *(srcGraph->functions);
-
+    // We do not copy the function table of srcGraph to the dstGraph
+    // because copy extensions now copies all possible data from
+    // srcGraph to dstGraph, but it does not extend dstGraph with
+    // any extensions it doesn't already have, so the dstGraph
+    // function table is already correct for its type.
+    
     return OK;
 }
 

--- a/c/graphLib/graph.c
+++ b/c/graphLib/graph.c
@@ -1002,20 +1002,6 @@ int gp_CopyGraph(graphP dstGraph, graphP srcGraph)
         return NOTOK;
     }
 
-    // If the dstGraph has a larger edge capacity than the srcGraph
-    // then we report failure because the code below only gives valid
-    // values to edge records up to the edge capacity of the srcGraph
-    // It would be possible to invoke _InitEdgeRec() on the extra
-    // edge records in dstGraph, but we do not support this
-    // currently because we would need to have and currently do
-    // not have a way to reinitialize the edge record extensions
-    // (gp_CopyExtensions() only copies the content in extension
-    // content up to the size of data structures in srcGraph).
-    if (dstGraph->edgeCapacity > srcGraph->edgeCapacity)
-    {
-        return NOTOK;
-    }
-
     // Copy the vertices (non-virtual only).  Augmentations to vertices created
     // by extensions are copied below by gp_CopyExtensions()
     for (v = gp_LowerBoundVertices(srcGraph); v < gp_UpperBoundVertices(srcGraph); ++v)
@@ -1042,6 +1028,15 @@ int gp_CopyGraph(graphP dstGraph, graphP srcGraph)
     // created by extensions are copied below by gp_CopyExtensions()
     for (e = gp_LowerBoundEdgeStorage(srcGraph); e < gp_UpperBoundEdgeStorage(srcGraph); e++)
         _gp_CopyEdgeRec(dstGraph, e, srcGraph, e);
+
+    // If the dstGraph has more edge storage than the srcGraph, then we clear the extra 
+    // base edgeRec structures. In gp_CopyExtensions(), the various extensions' copyData()
+    // functions are expected to clear out any extension-specific extra edgeRec structures
+    if (gp_UpperBoundEdgeStorage(dstGraph) > gp_UpperBoundEdgeStorage(srcGraph))
+    {
+        for (e = gp_UpperBoundEdgeStorage(srcGraph); e < gp_UpperBoundEdgeStorage(dstGraph); e++)
+            _InitEdgeRec(dstGraph, e);
+    }
 
     // Give the dstGraph the same size and intrinsic properties
     dstGraph->N = gp_GetN(srcGraph);

--- a/c/graphLib/homeomorphSearch/graphK23Search_Extensions.c
+++ b/c/graphLib/homeomorphSearch/graphK23Search_Extensions.c
@@ -28,7 +28,7 @@ int _K23Search_CheckObstructionIntegrity(graphP theGraph, graphP origGraph);
 
 /* Forward declarations of functions used by the extension system */
 
-void *_K23Search_DupContext(void *pContext, void *theGraph);
+int  _K23Search_CopyData(void *, void *);
 void _K23Search_FreeContext(void *);
 
 /****************************************************************************
@@ -85,7 +85,7 @@ int gp_ExtendWith_K23Search(graphP theGraph)
     // Store the K23 search context, including the data structure and the
     // function pointers, as an extension of the graph
     if (gp_AddExtension(theGraph, &K23SEARCH_ID, (void *)context,
-                        _K23Search_DupContext, _K23Search_FreeContext,
+                        _K23Search_CopyData, _K23Search_FreeContext,
                         &context->functions) != OK)
     {
         _K23Search_FreeContext(context);
@@ -107,20 +107,11 @@ int gp_Detach_K23Search(graphP theGraph)
 }
 
 /********************************************************************
- _K23Search_DupContext()
+ _K23Search_CopyData()
  ********************************************************************/
-
-void *_K23Search_DupContext(void *pContext, void *theGraph)
+int _K23Search_CopyData(void *dstContext, void *srcContext)
 {
-    K23SearchContext *context = (K23SearchContext *)pContext;
-    K23SearchContext *newContext = (K23SearchContext *)malloc(sizeof(K23SearchContext));
-
-    if (newContext != NULL)
-    {
-        *newContext = *context;
-    }
-
-    return newContext;
+    return OK;
 }
 
 /********************************************************************

--- a/c/graphLib/homeomorphSearch/graphK33Search_Extensions.c
+++ b/c/graphLib/homeomorphSearch/graphK33Search_Extensions.c
@@ -49,7 +49,7 @@ int _K33Search_EnsureEdgeCapacity(graphP theGraph, int requiredEdgeCapacity);
 
 /* Forward declarations of functions used by the extension system */
 
-void *_K33Search_DupContext(void *pContext, void *theGraph);
+int _K33Search_CopyData(void *dstContext, void *srcContext);
 void _K33Search_FreeContext(void *);
 
 /****************************************************************************
@@ -122,7 +122,7 @@ int gp_ExtendWith_K33Search(graphP theGraph)
     // Store the K33 search context, including the data structure and the
     // function pointers, as an extension of the graph
     if (gp_AddExtension(theGraph, &K33SEARCH_ID, (void *)context,
-                        _K33Search_DupContext, _K33Search_FreeContext,
+                        _K33Search_CopyData, _K33Search_FreeContext,
                         &context->functions) != OK)
     {
         _K33Search_FreeContext(context);
@@ -240,6 +240,47 @@ int _K33Search_InitStructures(K33SearchContext *context)
 }
 
 /********************************************************************
+ _K33Search_CopyData()
+ ********************************************************************/
+int _K33Search_CopyData(void *dstContext, void *srcContext)
+{
+    K33SearchContext *dstK33Context = (K33SearchContext *)dstContext;
+    K33SearchContext *srcK33Context = (K33SearchContext *)srcContext;
+    int dstEdgeStorage, srcEdgeStorage;
+
+    if (dstContext == NULL)
+        return NOTOK;
+
+    // If the srcContext is NULL, then the caller wants the data
+    // structures in the dstContext to be reset/reinitialized
+
+    if (srcContext == NULL)
+        return _K33Search_InitStructures(dstK33Context);
+
+    // ELSE: If there is also a srcContext, then we copy data from it
+    dstEdgeStorage = gp_UpperBoundEdgeStorage(dstK33Context->theGraph);
+    srcEdgeStorage = gp_UpperBoundEdgeStorage(srcK33Context->theGraph);
+
+    // The caller (ultimately gp_CopyGraph()) is responsible for making sure that the
+    // destination graph has enough edge capacity to receive the source graph content
+    if (dstEdgeStorage < srcEdgeStorage)
+        return NOTOK;
+
+    // If the destination graph has more edge capacity, then we make sure that the
+    // extra edge capacity is reinitialized
+    if (dstEdgeStorage > srcEdgeStorage)
+    {
+        memset(dstK33Context->E, NIL_CHAR, gp_UpperBoundEdgeStorage(dstK33Context->theGraph) * sizeof(K33Search_EdgeRec));
+    }
+
+    memcpy(dstK33Context->E, srcK33Context->E, gp_UpperBoundEdgeStorage(dstK33Context->theGraph) * sizeof(K33Search_EdgeRec));
+
+    memcpy(dstK33Context->VI, srcK33Context->VI, gp_UpperBoundVertices(dstK33Context->theGraph) * sizeof(K33Search_VertexInfo));
+
+    return OK;
+}
+
+/********************************************************************
  ********************************************************************/
 
 int _K33Search_InitGraph(graphP theGraph, int N)
@@ -306,15 +347,15 @@ int _K33Search_EnsureEdgeCapacity(graphP theGraph, int requiredEdgeCapacity)
         return NOTOK;
 
     // Call the superclass function to make sure lower levels of parallel
-    // edge arrays can successfully meet the new capacity requirement 
+    // edge arrays can successfully meet the new capacity requirement
     if (context->functions.fpEnsureEdgeCapacity(theGraph, requiredEdgeCapacity) != OK)
         return NOTOK;
 
     // Save the current E so it can be freed once we replace it
     oldE = context->E;
 
-    // The superclass EnsureEdgeCapacity method succeeded, so the graph's 
-    // new edge capacity is already set, which means we the upper bound of 
+    // The superclass EnsureEdgeCapacity method succeeded, so the graph's
+    // new edge capacity is already set, which means we the upper bound of
     // the graph's edge storage gives the new parallel array size we need.
     newEsize = gp_UpperBoundEdgeStorage(theGraph);
 
@@ -334,45 +375,6 @@ int _K33Search_EnsureEdgeCapacity(graphP theGraph, int requiredEdgeCapacity)
     free(oldE);
 
     return OK;
-}
-
-/********************************************************************
- _K33Search_DupContext()
- ********************************************************************/
-
-void *_K33Search_DupContext(void *pContext, void *theGraph)
-{
-    K33SearchContext *context = (K33SearchContext *)pContext;
-    K33SearchContext *newContext = (K33SearchContext *)malloc(sizeof(K33SearchContext));
-
-    if (newContext != NULL)
-    {
-        int VIsize = gp_UpperBoundVertices((graphP)theGraph);
-        int Esize = gp_UpperBoundEdgeStorage((graphP)theGraph);
-
-        *newContext = *context;
-
-        newContext->theGraph = (graphP)theGraph;
-
-        newContext->initialized = 0;
-        _K33Search_ClearStructures(newContext);
-        if (((graphP)theGraph)->N > 0)
-        {
-            if (_K33Search_CreateStructures(newContext) != OK)
-            {
-                _K33Search_FreeContext(newContext);
-                newContext = NULL;
-
-                return NULL;
-            }
-
-            memcpy(newContext->E, context->E, Esize * sizeof(K33Search_EdgeRec));
-            memcpy(newContext->VI, context->VI, VIsize * sizeof(K33Search_VertexInfo));
-            LCCopy(newContext->separatedDFSChildLists, context->separatedDFSChildLists);
-        }
-    }
-
-    return newContext;
 }
 
 /********************************************************************

--- a/c/graphLib/homeomorphSearch/graphK4Search_Extensions.c
+++ b/c/graphLib/homeomorphSearch/graphK4Search_Extensions.c
@@ -42,7 +42,7 @@ int _K4Search_EnsureEdgeCapacity(graphP theGraph, int requiredEdgeCapacity);
 
 /* Forward declarations of functions used by the extension system */
 
-void *_K4Search_DupContext(void *pContext, void *theGraph);
+int _K4Search_CopyData(void *dstContext, void *srcContext);
 void _K4Search_FreeContext(void *);
 
 /****************************************************************************
@@ -110,7 +110,7 @@ int gp_ExtendWith_K4Search(graphP theGraph)
     // Store the K4 search context, including the data structure and the
     // function pointers, as an extension of the graph
     if (gp_AddExtension(theGraph, &K4SEARCH_ID, (void *)context,
-                        _K4Search_DupContext, _K4Search_FreeContext,
+                        _K4Search_CopyData, _K4Search_FreeContext,
                         &context->functions) != OK)
     {
         _K4Search_FreeContext(context);
@@ -206,6 +206,44 @@ int _K4Search_InitStructures(K4SearchContext *context)
 }
 
 /********************************************************************
+ _K4Search_CopyData()
+ ********************************************************************/
+int _K4Search_CopyData(void *dstContext, void *srcContext)
+{
+    K4SearchContext *dstK4Context = (K4SearchContext *) dstContext;
+    K4SearchContext *srcK4Context = (K4SearchContext *) srcContext;
+    int dstEdgeStorage, srcEdgeStorage;
+
+    if (dstContext == NULL)
+        return NOTOK;
+
+    // If the srcContext is NULL, then the caller wants the data
+    // structures in the dstContext to be reset/reinitialized
+
+    if (srcContext == NULL)
+        return _K4Search_InitStructures(dstK4Context);
+
+    // ELSE: If there is also a srcContext, then we copy data from it
+    dstEdgeStorage = gp_UpperBoundEdgeStorage(dstK4Context->theGraph);
+    srcEdgeStorage = gp_UpperBoundEdgeStorage(srcK4Context->theGraph);
+
+    // The caller (ultimately gp_CopyGraph()) is responsible for making sure that the
+    // destination graph has enough edge capacity to receive the source graph content
+    if (dstEdgeStorage < srcEdgeStorage)
+        return NOTOK;
+
+    // If the destination graph has more edge capacity, then we make sure that the
+    // extra edge capacity is reinitialized
+    if (dstEdgeStorage > srcEdgeStorage)
+    {
+        memset(dstK4Context->E, NIL_CHAR, gp_UpperBoundEdgeStorage(dstK4Context->theGraph) * sizeof(K4Search_EdgeRec));
+    }
+
+    memcpy(dstK4Context->E, srcK4Context->E, gp_UpperBoundEdgeStorage(dstK4Context->theGraph) * sizeof(K4Search_EdgeRec));
+    return OK;
+}
+
+/********************************************************************
  ********************************************************************/
 
 int _K4Search_InitGraph(graphP theGraph, int N)
@@ -296,42 +334,6 @@ int _K4Search_EnsureEdgeCapacity(graphP theGraph, int requiredEdgeCapacity)
     free(oldE);
 
     return OK;
-}
-
-/********************************************************************
- _K4Search_DupContext()
- ********************************************************************/
-
-void *_K4Search_DupContext(void *pContext, void *theGraph)
-{
-    K4SearchContext *context = (K4SearchContext *)pContext;
-    K4SearchContext *newContext = (K4SearchContext *)malloc(sizeof(K4SearchContext));
-
-    if (newContext != NULL)
-    {
-        int Esize = gp_UpperBoundEdgeStorage((graphP)theGraph);
-
-        *newContext = *context;
-
-        newContext->theGraph = (graphP)theGraph;
-
-        newContext->initialized = 0;
-        _K4Search_ClearStructures(newContext);
-        if (((graphP)theGraph)->N > 0)
-        {
-            if (_K4Search_CreateStructures(newContext) != OK)
-            {
-                _K4Search_FreeContext(newContext);
-                newContext = NULL;
-
-                return NULL;
-            }
-
-            memcpy(newContext->E, context->E, Esize * sizeof(K4Search_EdgeRec));
-        }
-    }
-
-    return newContext;
 }
 
 /********************************************************************

--- a/c/graphLib/planarityRelated/graphDrawPlanar_Extensions.c
+++ b/c/graphLib/planarityRelated/graphDrawPlanar_Extensions.c
@@ -300,43 +300,6 @@ int _DrawPlanar_CopyData(void *dstContext, void *srcContext)
 }
 
 /********************************************************************
- _DrawPlanar_DupContext()
-// Keeping this around as a comment for now
-void *_DrawPlanar_DupContext(void *pContext, void *theGraph)
-{
-    DrawPlanarContext *context = (DrawPlanarContext *)pContext;
-    DrawPlanarContext *newContext = (DrawPlanarContext *)malloc(sizeof(DrawPlanarContext));
-
-    if (newContext != NULL)
-    {
-        int VIsize = gp_UpperBoundVertices((graphP)theGraph);
-        int Esize = gp_UpperBoundEdgeStorage((graphP)theGraph);
-
-        *newContext = *context;
-
-        newContext->theGraph = (graphP)theGraph;
-
-        newContext->initialized = 0;
-        _DrawPlanar_ClearStructures(newContext);
-        if (((graphP)theGraph)->N > 0)
-        {
-            if (_DrawPlanar_CreateStructures(newContext) != OK)
-            {
-                _DrawPlanar_FreeContext(newContext);
-                return NULL;
-            }
-
-            // Initialize custom data structures by copying
-            memcpy(newContext->E, context->E, Esize * sizeof(DrawPlanar_EdgeRec));
-            memcpy(newContext->VI, context->VI, VIsize * sizeof(DrawPlanar_VertexInfo));
-        }
-    }
-
-    return newContext;
-}
- ********************************************************************/
-
-/********************************************************************
  _DrawPlanar_FreeContext()
  ********************************************************************/
 

--- a/c/graphLib/planarityRelated/graphDrawPlanar_Extensions.c
+++ b/c/graphLib/planarityRelated/graphDrawPlanar_Extensions.c
@@ -47,7 +47,7 @@ int _DrawPlanar_WritePostprocess(graphP theGraph, char **pExtraData);
 
 /* Forward declarations of functions used by the extension system */
 
-void *_DrawPlanar_DupContext(void *pContext, void *theGraph);
+int _DrawPlanar_CopyData(void *dstContext, void *srcContext);
 void _DrawPlanar_FreeContext(void *);
 
 /****************************************************************************
@@ -133,7 +133,7 @@ int gp_ExtendWith_DrawPlanar(graphP theGraph)
     // Store the Draw context, including the data structure and the
     // function pointers, as an extension of the graph
     if (gp_AddExtension(theGraph, &DRAWPLANAR_ID, (void *)context,
-                        _DrawPlanar_DupContext, _DrawPlanar_FreeContext,
+                        _DrawPlanar_CopyData, _DrawPlanar_FreeContext,
                         &context->functions) != OK)
     {
         _DrawPlanar_FreeContext(context);
@@ -259,9 +259,49 @@ int _DrawPlanar_InitStructures(DrawPlanarContext *context)
 }
 
 /********************************************************************
- _DrawPlanar_DupContext()
+ _DrawPlanar_CopyData()
  ********************************************************************/
+int _DrawPlanar_CopyData(void *dstContext, void *srcContext)
+{
+    DrawPlanarContext *dstDrawPlanarContext = (DrawPlanarContext *)dstContext;
+    DrawPlanarContext *srcDrawPlanarContext = (DrawPlanarContext *)srcContext;
+    int dstEdgeStorage, srcEdgeStorage;
 
+    if (dstContext == NULL)
+        return NOTOK;
+
+    // If the srcContext is NULL, then the caller wants the data
+    // structures in the dstContext to be reset/reinitialized
+
+    if (srcContext == NULL)
+        return _DrawPlanar_InitStructures(dstDrawPlanarContext);
+
+    // ELSE: If there is also a srcContext, then we copy data from it
+    dstEdgeStorage = gp_UpperBoundEdgeStorage(dstDrawPlanarContext->theGraph);
+    srcEdgeStorage = gp_UpperBoundEdgeStorage(srcDrawPlanarContext->theGraph);
+
+    // The caller (ultimately gp_CopyGraph()) is responsible for making sure that the
+    // destination graph has enough edge capacity to receive the source graph content
+    if (dstEdgeStorage < srcEdgeStorage)
+        return NOTOK;
+
+    // If the destination graph has more edge capacity, then we make sure that the
+    // extra edge capacity is reinitialized
+    if (dstEdgeStorage > srcEdgeStorage)
+    {
+        memset(dstDrawPlanarContext->E, NIL_CHAR, gp_UpperBoundEdgeStorage(dstDrawPlanarContext->theGraph) * sizeof(DrawPlanar_EdgeRec));
+    }
+
+    memcpy(dstDrawPlanarContext->E, srcDrawPlanarContext->E, gp_UpperBoundEdgeStorage(dstDrawPlanarContext->theGraph) * sizeof(DrawPlanar_EdgeRec));
+
+    memcpy(dstDrawPlanarContext->VI, srcDrawPlanarContext->VI, gp_UpperBoundVertices(dstDrawPlanarContext->theGraph) * sizeof(DrawPlanar_VertexInfo));
+
+    return OK;
+}
+
+/********************************************************************
+ _DrawPlanar_DupContext()
+// Keeping this around as a comment for now
 void *_DrawPlanar_DupContext(void *pContext, void *theGraph)
 {
     DrawPlanarContext *context = (DrawPlanarContext *)pContext;
@@ -294,6 +334,7 @@ void *_DrawPlanar_DupContext(void *pContext, void *theGraph)
 
     return newContext;
 }
+ ********************************************************************/
 
 /********************************************************************
  _DrawPlanar_FreeContext()

--- a/c/planarityApp/planarityRandomGraphs.c
+++ b/c/planarityApp/planarityRandomGraphs.c
@@ -78,7 +78,8 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
     }
 
     theGraph = MakeGraph(SizeOfGraphs, command);
-    origGraph = MakeGraph(SizeOfGraphs, command);
+    // The origGraph no longer needs extensions, so we just use a null terminator for the command
+    origGraph = MakeGraph(SizeOfGraphs, '\0');
     if (theGraph == NULL || origGraph == NULL)
     {
         gp_ErrorMessage("Unable to allocate and initialize graph datastructures "
@@ -446,10 +447,13 @@ graphP MakeGraph(int Size, char command)
         return NULL;
     }
 
-    if (ExtendGraph(theGraph, command) != OK)
+    if (command != '\0')
     {
-        gp_ErrorMessage("Unable to extend graph based on command '%c'\n", command);
-        gp_Free(&theGraph);
+        if (ExtendGraph(theGraph, command) != OK)
+        {
+            gp_ErrorMessage("Unable to extend graph based on command '%c'\n", command);
+            gp_Free(&theGraph);
+        }
     }
 
     return theGraph;

--- a/c/planarityApp/planarityTestAllGraphs.c
+++ b/c/planarityApp/planarityTestAllGraphs.c
@@ -141,8 +141,7 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
         return NOTOK;
     }
 
-    if (ExtendGraph(origGraphRead, command) != OK ||
-        ExtendGraph(graphForEmbedding, command) != OK)
+    if (ExtendGraph(graphForEmbedding, command) != OK)
     {
         gp_ErrorMessage("Unable to extend graph for embedding operation.\n");
         g6_FreeReader(&theG6ReadIterator);


### PR DESCRIPTION
Resolves #216 (and #218)

## Type of change

Please check only relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes

### Updated

* Updated the `gp_CopyExtensions()` method and dependent code to copy extension data rather than freeing destination extensions and then duplicating the source extensions.
* Fixed the spell-checker to ignore the data files in the samples directory

## Testing

Release and Debug, gcc and cl on windows, test all graphs and random graphs for all extensions
