### PR TITLE
Issue #213 - Update `actions/checkout` to `v6` through all GHA workflow files

### DIFF
--- a/.github/workflows/compile-warnings.yml
+++ b/.github/workflows/compile-warnings.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         compiler: [clang-18, gcc-14]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Compiler information . . .
         run: $CC --version
       - name: Configure . . .

--- a/.github/workflows/compiler-versions.yml
+++ b/.github/workflows/compiler-versions.yml
@@ -33,7 +33,7 @@ jobs:
           - { compiler: clang, version: 18 }
           - { compiler: clang, version: 19 }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup compiler . . .
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa -y

--- a/.github/workflows/dev-platforms.yml
+++ b/.github/workflows/dev-platforms.yml
@@ -16,7 +16,7 @@ jobs:
     name: Ubuntu-aarch64
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: uraimo/run-on-arch-action@v3
         with:
           arch: aarch64
@@ -35,7 +35,7 @@ jobs:
         shell: alpine.sh {0}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: jirutka/setup-alpine@v1
         with:
           branch: v3.15
@@ -57,7 +57,7 @@ jobs:
     name: Ubuntu-arm
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install autotools etc . . .
         run: sudo apt-get install autoconf automake libtool
       - name: Configure . . .
@@ -72,7 +72,7 @@ jobs:
     container:
       image: debian:latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install autotools etc . . .
         run: apt update && apt -y upgrade && apt install -y make autoconf automake libtool
       - name: Configure . . .
@@ -91,7 +91,7 @@ jobs:
     steps:
       - run: git config --global core.autocrlf input
         shell: pwsh -command ". '{0}'".
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: cygwin/cygwin-install-action@v6
         with:
           packages: gcc-core,automake,libtool,autoconf
@@ -108,7 +108,7 @@ jobs:
     env:
       CC: clang
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install dependencies . . .
         run: brew install autoconf automake libtool
       - name: Clang version . . .
@@ -131,7 +131,7 @@ jobs:
       matrix:
         arch: [x64, x86, x86_amd64, amd64_x86]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup MSVC Developer Command Prompt
         uses: TheMrMilchmann/setup-msvc-dev@v4.0.0
         with:
@@ -168,7 +168,7 @@ jobs:
           update: true
           msystem: ${{ matrix.sys }}
           pacboy: toolchain autotools
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Configure . . .
         run: autoreconf -if && ./configure
       - name: Build . . .
@@ -187,7 +187,7 @@ jobs:
           update: true
           msystem: CLANGARM64
           pacboy: toolchain autotools
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Configure . . .
         run: autoreconf -if && ./configure
       - name: Build . . .

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         compiler: [clang, gcc]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: test
         run: |
           echo ${{ github.event_name }}
@@ -43,7 +43,7 @@ jobs:
     env:
       CC: gcc
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Configure . . .
         run: |
           mkdir -p m4 

--- a/.github/workflows/sanitisers.yml
+++ b/.github/workflows/sanitisers.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
     name: ${{ matrix.type }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Configure with -fsanitize=${{ matrix.type }} . . .
         run: |
           mkdir -p m4 && autoreconf -if
@@ -48,7 +48,7 @@ jobs:
       CC: gcc
       CFLAGS: -g -O0
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install dependencies . . .
         run: |
           sudo apt-get --yes update

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -5,7 +5,7 @@ jobs:
   codespell:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: codespell-project/actions-codespell@v2
         with:
           skip: ./c/samples


### PR DESCRIPTION
Resolves #213 

## Type of change

Please check only relevant options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes

Updated all GHA workflow files so that they use [`actions/checkout`](https://github.com/actions/checkout) v6 (__**N.B.**__ latest release is [6.0.2](https://github.com/actions/checkout/releases/tag/v6.0.2))

## Testing

The proof is in the PR (or, at the very least, in the GHA runs associated with this PR)