### PR TITLE
Issue #224 - setup `dependabot` for updating GHA dependencies to pinned hash corresponding to latest release tag

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/compile-warnings.yml
+++ b/.github/workflows/compile-warnings.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         compiler: [clang-18, gcc-14]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Compiler information . . .
         run: $CC --version
       - name: Configure . . .

--- a/.github/workflows/compile-warnings.yml
+++ b/.github/workflows/compile-warnings.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         compiler: [clang-18, gcc-14]
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Compiler information . . .
         run: $CC --version
       - name: Configure . . .

--- a/.github/workflows/compiler-versions.yml
+++ b/.github/workflows/compiler-versions.yml
@@ -33,7 +33,7 @@ jobs:
           - { compiler: clang, version: 18 }
           - { compiler: clang, version: 19 }
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup compiler . . .
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa -y

--- a/.github/workflows/compiler-versions.yml
+++ b/.github/workflows/compiler-versions.yml
@@ -33,7 +33,7 @@ jobs:
           - { compiler: clang, version: 18 }
           - { compiler: clang, version: 19 }
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Setup compiler . . .
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa -y

--- a/.github/workflows/dev-platforms.yml
+++ b/.github/workflows/dev-platforms.yml
@@ -16,8 +16,8 @@ jobs:
     name: Ubuntu-aarch64
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: uraimo/run-on-arch-action@v3.1.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: uraimo/run-on-arch-action@f9b26e3a1a408d5fd530d20c17b9f3f4428ff8d9 # v3.1.0
         with:
           arch: aarch64
           distro: ubuntu22.04
@@ -35,8 +35,8 @@ jobs:
         shell: alpine.sh {0}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: jirutka/setup-alpine@v1.4.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: jirutka/setup-alpine@ae3b3ddba35054804fc4a3507b519fa7e8152050 # v1.4.1
         with:
           branch: v3.15
       - name: Alpine/musl versions . . .
@@ -57,7 +57,7 @@ jobs:
     name: Ubuntu-arm
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install autotools etc . . .
         run: sudo apt-get install autoconf automake libtool
       - name: Configure . . .
@@ -72,7 +72,7 @@ jobs:
     container:
       image: debian:latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install autotools etc . . .
         run: apt update && apt -y upgrade && apt install -y make autoconf automake libtool
       - name: Configure . . .
@@ -91,8 +91,8 @@ jobs:
     steps:
       - run: git config --global core.autocrlf input
         shell: pwsh -command ". '{0}'".
-      - uses: actions/checkout@v6.0.2
-      - uses: cygwin/cygwin-install-action@v6.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: cygwin/cygwin-install-action@f2009323764960f80959895c7bc3bb30210afe4d # v6.0
         with:
           packages: gcc-core,automake,libtool,autoconf
       - name: Configure . . .
@@ -108,7 +108,7 @@ jobs:
     env:
       CC: clang
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install dependencies . . .
         run: brew install autoconf automake libtool
       - name: Clang version . . .
@@ -131,9 +131,9 @@ jobs:
       matrix:
         arch: [x64, x86, x86_amd64, amd64_x86]
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup MSVC Developer Command Prompt
-        uses: TheMrMilchmann/setup-msvc-dev@v4.0.0
+        uses: TheMrMilchmann/setup-msvc-dev@79dac248aac9d0059f86eae9d8b5bfab4e95e97c # v4.0.0
         with:
           arch: ${{ matrix.arch }}
         # NOTE: Using defaults for sdk (use default Windows SDK), toolset (use
@@ -163,12 +163,12 @@ jobs:
       matrix:
         sys: [MINGW64, MINGW32, UCRT64, CLANG64]
     steps:
-      - uses: msys2/setup-msys2@v2.31.1
+      - uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2.31.1
         with:
           update: true
           msystem: ${{ matrix.sys }}
           pacboy: toolchain autotools
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Configure . . .
         run: autoreconf -if && ./configure
       - name: Build . . .
@@ -182,12 +182,12 @@ jobs:
         shell: msys2 {0}
     runs-on: windows-11-arm
     steps:
-      - uses: msys2/setup-msys2@v2.31.1
+      - uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2.31.1
         with:
           update: true
           msystem: CLANGARM64
           pacboy: toolchain autotools
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Configure . . .
         run: autoreconf -if && ./configure
       - name: Build . . .

--- a/.github/workflows/dev-platforms.yml
+++ b/.github/workflows/dev-platforms.yml
@@ -16,8 +16,8 @@ jobs:
     name: Ubuntu-aarch64
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v6
-      - uses: uraimo/run-on-arch-action@v3
+      - uses: actions/checkout@v6.0.2
+      - uses: uraimo/run-on-arch-action@v3.1.0
         with:
           arch: aarch64
           distro: ubuntu22.04
@@ -35,8 +35,8 @@ jobs:
         shell: alpine.sh {0}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: jirutka/setup-alpine@v1
+      - uses: actions/checkout@v6.0.2
+      - uses: jirutka/setup-alpine@v1.4.1
         with:
           branch: v3.15
       - name: Alpine/musl versions . . .
@@ -57,7 +57,7 @@ jobs:
     name: Ubuntu-arm
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Install autotools etc . . .
         run: sudo apt-get install autoconf automake libtool
       - name: Configure . . .
@@ -72,7 +72,7 @@ jobs:
     container:
       image: debian:latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Install autotools etc . . .
         run: apt update && apt -y upgrade && apt install -y make autoconf automake libtool
       - name: Configure . . .
@@ -91,8 +91,8 @@ jobs:
     steps:
       - run: git config --global core.autocrlf input
         shell: pwsh -command ". '{0}'".
-      - uses: actions/checkout@v6
-      - uses: cygwin/cygwin-install-action@v6
+      - uses: actions/checkout@v6.0.2
+      - uses: cygwin/cygwin-install-action@v6.0
         with:
           packages: gcc-core,automake,libtool,autoconf
       - name: Configure . . .
@@ -108,7 +108,7 @@ jobs:
     env:
       CC: clang
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Install dependencies . . .
         run: brew install autoconf automake libtool
       - name: Clang version . . .
@@ -131,7 +131,7 @@ jobs:
       matrix:
         arch: [x64, x86, x86_amd64, amd64_x86]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Setup MSVC Developer Command Prompt
         uses: TheMrMilchmann/setup-msvc-dev@v4.0.0
         with:
@@ -163,12 +163,12 @@ jobs:
       matrix:
         sys: [MINGW64, MINGW32, UCRT64, CLANG64]
     steps:
-      - uses: msys2/setup-msys2@v2
+      - uses: msys2/setup-msys2@v2.31.1
         with:
           update: true
           msystem: ${{ matrix.sys }}
           pacboy: toolchain autotools
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Configure . . .
         run: autoreconf -if && ./configure
       - name: Build . . .
@@ -182,12 +182,12 @@ jobs:
         shell: msys2 {0}
     runs-on: windows-11-arm
     steps:
-      - uses: msys2/setup-msys2@v2
+      - uses: msys2/setup-msys2@v2.31.1
         with:
           update: true
           msystem: CLANGARM64
           pacboy: toolchain autotools
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Configure . . .
         run: autoreconf -if && ./configure
       - name: Build . . .

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         compiler: [clang, gcc]
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: test
         run: |
           echo ${{ github.event_name }}
@@ -43,7 +43,7 @@ jobs:
     env:
       CC: gcc
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Configure . . .
         run: |
           mkdir -p m4 

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         compiler: [clang, gcc]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: test
         run: |
           echo ${{ github.event_name }}
@@ -43,7 +43,7 @@ jobs:
     env:
       CC: gcc
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Configure . . .
         run: |
           mkdir -p m4 

--- a/.github/workflows/sanitisers.yml
+++ b/.github/workflows/sanitisers.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
     name: ${{ matrix.type }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Configure with -fsanitize=${{ matrix.type }} . . .
         run: |
           mkdir -p m4 && autoreconf -if
@@ -48,7 +48,7 @@ jobs:
       CC: gcc
       CFLAGS: -g -O0
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Install dependencies . . .
         run: |
           sudo apt-get --yes update

--- a/.github/workflows/sanitisers.yml
+++ b/.github/workflows/sanitisers.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
     name: ${{ matrix.type }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Configure with -fsanitize=${{ matrix.type }} . . .
         run: |
           mkdir -p m4 && autoreconf -if
@@ -48,7 +48,7 @@ jobs:
       CC: gcc
       CFLAGS: -g -O0
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install dependencies . . .
         run: |
           sudo apt-get --yes update

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -5,7 +5,7 @@ jobs:
   codespell:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: codespell-project/actions-codespell@v2
+      - uses: actions/checkout@v6.0.2
+      - uses: codespell-project/actions-codespell@v2.2
         with:
           skip: ./c/samples

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -5,7 +5,7 @@ jobs:
   codespell:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: codespell-project/actions-codespell@v2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579 # v2.2
         with:
           skip: ./c/samples

--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@ AC_CONFIG_SRCDIR([c/])
 # The version number in the following line must be synchronized with 
 # the LibPlanarity version numbers in graphLib.h 
 #
-# The meanings of the three vesrion number components are
+# The meanings of the three version number components are
 #    current : Most recent interface number that the library implements
 #    revision: The implementation number of the current interface
 #    age     : The number of previous interfaces that this version


### PR DESCRIPTION
Resolves #224

## Type of change

Please check only relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
    * __**N.B.**__ Using pinned hashes might break security/vulnerabulity alerts; see [this](https://www.reddit.com/r/devops/s/XHmOH6CRIr) Reddit Post, referring to [About dependabot alerts - Limitations](https://docs.github.com/en/code-security/concepts/supply-chain-security/about-dependabot-alerts#limitations) 
- [ ] This change requires a documentation update

## Changes

### Added

* `.github/dependabot.yml` - basic configuration added to check weekly for a new tag for all GHA workflow dependencies, with a 7-day [`cooldown`](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown) (i.e. I'm reading "If a dependency’s new release falls within its cooldown period, Dependabot skips updating the version for that dependency." as "don't make a new PR if an update is released within 7 days of having already updated the dependency"). We'll still manually have to approve these PRs to update, but the workflow files *should* update with the pinned hash of the latest release for the actions.

### Updated

* `.github/workflows/` - updated the versions of GHA dependencies to the latest `vX.X.X` releases:
    * `actions/checkout`: `de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`
    * `uraimo/run-on-arch-action` - `f9b26e3a1a408d5fd530d20c17b9f3f4428ff8d9 # v3.1.0`
    * `jirutka/setup-alpine` - `ae3b3ddba35054804fc4a3507b519fa7e8152050 # v1.4.1`
    * `cygwin/cygwin-install-action` - `f2009323764960f80959895c7bc3bb30210afe4d # v6.0`
    * `TheMrMilchmann/setup-msvc-dev` - `79dac248aac9d0059f86eae9d8b5bfab4e95e97c # v4.0.0`
    * `msys2/setup-msys2` - `e9898307ac31d1a803454791be09ab9973336e1c # v2.31.1`
    * `codespell-project/actions-codespell` - `8f01853be192eb0f849a5c7d721450e7a467c579 # v2.2`
* `configure.ac` - fixed spelling error that caused `spelling.yml` to fail

### Removed

* N.A.

## Testing

Not sure how to test this, other than waiting for a new release of a GHA dependency to come out and seeing that the hash is updated to the expected value corresponding to the latest release.
