### PR TITLE
Issue #226 - Removed dependency on `stdbool.h`

### DIFF
--- a/c/graphLib/io/g6-read-iterator.c
+++ b/c/graphLib/io/g6-read-iterator.c
@@ -27,7 +27,7 @@ int _g6_ReadGraphFromStrOrFile(graphP theGraph, strOrFileP *pInputContainer);
 /* Private functions */
 int _g6_InitReaderWithStrOrFile(G6ReadIteratorP theG6ReadIterator, strOrFileP *pInputContainer);
 int _g6_InitReader(G6ReadIteratorP theG6ReadIterator);
-bool _g6_IsReaderInitialized(G6ReadIteratorP theG6ReadIterator, bool reportUninitializedParts);
+int _g6_IsReaderInitialized(G6ReadIteratorP theG6ReadIterator, int reportUninitializedParts);
 int _g6_ValidateHeader(strOrFileP inputContainer);
 int _g6_ValidateFirstChar(char c, const int lineNum);
 int _g6_DetermineOrderFromInput(strOrFileP inputContainer, int *order);
@@ -56,7 +56,7 @@ struct G6ReadIteratorStruct
 
     graphP currGraph;
 
-    bool endReached;
+    int endReached;
 };
 
 /********************************************************************
@@ -108,15 +108,15 @@ int g6_NewReader(G6ReadIteratorP *pG6ReadIterator, graphP theGraph)
     return exitCode;
 }
 
-bool _g6_IsReaderInitialized(G6ReadIteratorP theG6ReadIterator, bool reportUninitializedParts)
+int _g6_IsReaderInitialized(G6ReadIteratorP theG6ReadIterator, int reportUninitializedParts)
 {
-    bool readerInitialized = true;
+    int readerInitialized = TRUE;
 
     if (theG6ReadIterator == NULL)
     {
         if (reportUninitializedParts)
             gp_ErrorMessage("G6ReadIterator is NULL.\n");
-        readerInitialized = false;
+        readerInitialized = FALSE;
     }
     else
     {
@@ -125,29 +125,29 @@ bool _g6_IsReaderInitialized(G6ReadIteratorP theG6ReadIterator, bool reportUnini
             if (reportUninitializedParts)
                 gp_ErrorMessage("G6ReadIterator's inputContainer string-or-file container "
                                 "is not valid.\n");
-            readerInitialized = false;
+            readerInitialized = FALSE;
         }
         if (theG6ReadIterator->currGraphBuff == NULL)
         {
             if (reportUninitializedParts)
                 gp_ErrorMessage("G6ReadIterator's currGraphBuff is NULL.\n");
-            readerInitialized = false;
+            readerInitialized = FALSE;
         }
         if (theG6ReadIterator->currGraph == NULL)
         {
             if (reportUninitializedParts)
                 gp_ErrorMessage("G6ReadIterator's currGraph is NULL.\n");
-            readerInitialized = false;
+            readerInitialized = FALSE;
         }
     }
 
     return readerInitialized;
 }
 
-bool g6_EndReached(G6ReadIteratorP theG6ReadIterator)
+int g6_EndReached(G6ReadIteratorP theG6ReadIterator)
 {
     if (theG6ReadIterator == NULL)
-        return true;
+        return TRUE;
 
     return theG6ReadIterator->endReached;
 }
@@ -168,7 +168,7 @@ int g6_GetNumGraphsRead(G6ReadIteratorP theG6ReadIterator, int *pNumGraphsRead)
         return NOTOK;
     }
 
-    if (!_g6_IsReaderInitialized(theG6ReadIterator, true))
+    if (!_g6_IsReaderInitialized(theG6ReadIterator, TRUE))
     {
         gp_ErrorMessage("Unable to get numGraphsRead, as G6ReadIterator is not "
                         "initialized.\n");
@@ -199,7 +199,7 @@ int g6_GetOrderFromReader(G6ReadIteratorP theG6ReadIterator, int *pOrder)
         return NOTOK;
     }
 
-    if (!_g6_IsReaderInitialized(theG6ReadIterator, true))
+    if (!_g6_IsReaderInitialized(theG6ReadIterator, TRUE))
     {
         gp_ErrorMessage("Unable to get order, as G6ReadIterator is not "
                         "initialized.\n");
@@ -230,7 +230,7 @@ int g6_GetGraphFromReader(G6ReadIteratorP theG6ReadIterator, graphP *pGraph)
         return NOTOK;
     }
 
-    if (!_g6_IsReaderInitialized(theG6ReadIterator, true))
+    if (!_g6_IsReaderInitialized(theG6ReadIterator, TRUE))
     {
         gp_ErrorMessage(
             "Unable to get graph from reader, as G6ReadIterator is not "
@@ -256,7 +256,7 @@ int g6_InitReaderWithString(G6ReadIteratorP theG6ReadIterator, char *inputString
         return NOTOK;
     }
 
-    if (_g6_IsReaderInitialized(theG6ReadIterator, false))
+    if (_g6_IsReaderInitialized(theG6ReadIterator, FALSE))
     {
         gp_ErrorMessage(
             "Unable to initialize reader, as it was already previously "
@@ -293,7 +293,7 @@ int g6_InitReaderWithFileName(G6ReadIteratorP theG6ReadIterator, char const *con
         return NOTOK;
     }
 
-    if (_g6_IsReaderInitialized(theG6ReadIterator, false))
+    if (_g6_IsReaderInitialized(theG6ReadIterator, FALSE))
     {
         gp_ErrorMessage(
             "Unable to initialize reader, as it was already previously "
@@ -566,7 +566,7 @@ int g6_ReadGraph(G6ReadIteratorP theG6ReadIterator)
     const int numCharsForGraphEncoding = theG6ReadIterator == NULL ? 0 : theG6ReadIterator->numCharsForGraphEncoding;
     const int currGraphBuffSize = theG6ReadIterator == NULL ? 0 : theG6ReadIterator->currGraphBuffSize;
 
-    if (!_g6_IsReaderInitialized(theG6ReadIterator, true))
+    if (!_g6_IsReaderInitialized(theG6ReadIterator, TRUE))
     {
         gp_ErrorMessage("G6ReadIterator is not initialized.\n");
         return NOTOK;
@@ -640,7 +640,7 @@ int g6_ReadGraph(G6ReadIteratorP theG6ReadIterator)
     }
     else
     {
-        theG6ReadIterator->endReached = true;
+        theG6ReadIterator->endReached = TRUE;
     }
 
     return OK;

--- a/c/graphLib/io/g6-read-iterator.h
+++ b/c/graphLib/io/g6-read-iterator.h
@@ -13,7 +13,6 @@ extern "C"
 #endif
 
 #include <stdio.h>
-#include <stdbool.h>
 
 #include "../graph.h"
 
@@ -21,7 +20,7 @@ extern "C"
     typedef G6ReadIteratorStruct *G6ReadIteratorP;
 
     int g6_NewReader(G6ReadIteratorP *pG6ReadIterator, graphP theGraph);
-    bool g6_EndReached(G6ReadIteratorP theG6ReadIterator);
+    int g6_EndReached(G6ReadIteratorP theG6ReadIterator);
 
     int g6_GetNumGraphsRead(G6ReadIteratorP theG6ReadIterator, int *pNumGraphsRead);
     int g6_GetOrderFromReader(G6ReadIteratorP theG6ReadIterator, int *pOrder);

--- a/c/graphLib/io/g6-write-iterator.c
+++ b/c/graphLib/io/g6-write-iterator.c
@@ -23,7 +23,7 @@ int _g6_WriteGraphToStrOrFile(graphP theGraph, strOrFileP *pOutputContainer);
 /* Private functions */
 int _g6_InitWriterWithStrOrFile(G6WriteIteratorP theG6WriteIterator, strOrFileP *pOutputContainer);
 int _g6_InitWriter(G6WriteIteratorP theG6WriteIterator);
-bool _g6_IsWriterInitialized(G6WriteIteratorP theG6WriteIterator, bool reportUninitializedParts);
+int _g6_IsWriterInitialized(G6WriteIteratorP theG6WriteIterator, int reportUninitializedParts);
 void _g6_PrecomputeColumnOffsets(size_t *columnOffsets, int order);
 void _g6_EncodeAdjMatAsG6(G6WriteIteratorP theG6WriteIterator);
 void _g6_GetFirstEdgeInUse(graphP theGraph, int *e, int *u, int *v);
@@ -36,24 +36,24 @@ int _g6_WriteGraphToString(graphP theGraph, char **pOutputStr);
 /********************************************************************
  Package private structure declaration for write iterator
  ********************************************************************/
-    typedef struct strOrFileStruct strOrFileStruct;
-    typedef strOrFileStruct *strOrFileP;
+typedef struct strOrFileStruct strOrFileStruct;
+typedef strOrFileStruct *strOrFileP;
 
-    struct G6WriteIteratorStruct
-    {
-        strOrFileP outputContainer;
-        int numGraphsWritten;
+struct G6WriteIteratorStruct
+{
+    strOrFileP outputContainer;
+    int numGraphsWritten;
 
-        int order;
-        int numCharsForOrder;
-        size_t numCharsForGraphEncoding;
-        size_t currGraphBuffSize;
-        char *currGraphBuff;
+    int order;
+    int numCharsForOrder;
+    size_t numCharsForGraphEncoding;
+    size_t currGraphBuffSize;
+    char *currGraphBuff;
 
-        size_t *columnOffsets;
+    size_t *columnOffsets;
 
-        graphP currGraph;
-    };
+    graphP currGraph;
+};
 
 /********************************************************************
  Public and package private method implementations for write iterator
@@ -101,15 +101,15 @@ int g6_NewWriter(G6WriteIteratorP *pG6WriteIterator, graphP theGraph)
     return OK;
 }
 
-bool _g6_IsWriterInitialized(G6WriteIteratorP theG6WriteIterator, bool reportUninitializedParts)
+int _g6_IsWriterInitialized(G6WriteIteratorP theG6WriteIterator, int reportUninitializedParts)
 {
-    bool writerIsInitialized = true;
+    int writerIsInitialized = TRUE;
 
     if (theG6WriteIterator == NULL)
     {
         if (reportUninitializedParts)
             gp_ErrorMessage("G6WriteIterator is NULL.\n");
-        writerIsInitialized = false;
+        writerIsInitialized = FALSE;
     }
     else
     {
@@ -117,25 +117,25 @@ bool _g6_IsWriterInitialized(G6WriteIteratorP theG6WriteIterator, bool reportUni
         {
             if (reportUninitializedParts)
                 gp_ErrorMessage("G6WriteIterator's outputContainer is not valid.\n");
-            writerIsInitialized = false;
+            writerIsInitialized = FALSE;
         }
         if (theG6WriteIterator->currGraphBuff == NULL)
         {
             if (reportUninitializedParts)
                 gp_ErrorMessage("G6WriteIterator's currGraphBuff is NULL.\n");
-            writerIsInitialized = false;
+            writerIsInitialized = FALSE;
         }
         if (theG6WriteIterator->columnOffsets == NULL)
         {
             if (reportUninitializedParts)
                 gp_ErrorMessage("G6WriteIterator's columnOffsets is NULL.\n");
-            writerIsInitialized = false;
+            writerIsInitialized = FALSE;
         }
         if (theG6WriteIterator->currGraph == NULL)
         {
             if (reportUninitializedParts)
                 gp_ErrorMessage("G6WriteIterator's currGraph is NULL.\n");
-            writerIsInitialized = false;
+            writerIsInitialized = FALSE;
         }
         else
         {
@@ -145,7 +145,7 @@ bool _g6_IsWriterInitialized(G6WriteIteratorP theG6WriteIterator, bool reportUni
                     gp_ErrorMessage(
                         "G6WriteIterator's currGraph does not contain a valid "
                         "graph.\n");
-                writerIsInitialized = false;
+                writerIsInitialized = FALSE;
             }
         }
     }
@@ -169,7 +169,7 @@ int g6_GetNumGraphsWritten(G6WriteIteratorP theG6WriteIterator, int *pNumGraphsW
         return NOTOK;
     }
 
-    if (!_g6_IsWriterInitialized(theG6WriteIterator, true))
+    if (!_g6_IsWriterInitialized(theG6WriteIterator, TRUE))
     {
         gp_ErrorMessage("Unable to get numGraphsWritten, as G6WriteIterator is "
                         "not initialized.\n");
@@ -200,7 +200,7 @@ int g6_GetOrderFromWriter(G6WriteIteratorP theG6WriteIterator, int *pOrder)
         return NOTOK;
     }
 
-    if (!_g6_IsWriterInitialized(theG6WriteIterator, true))
+    if (!_g6_IsWriterInitialized(theG6WriteIterator, TRUE))
     {
         gp_ErrorMessage("Unable to get order, as G6WriteIterator is not "
                         "initialized.\n");
@@ -231,7 +231,7 @@ int g6_GetGraphFromWriter(G6WriteIteratorP theG6WriteIterator, graphP *pGraph)
         return NOTOK;
     }
 
-    if (!_g6_IsWriterInitialized(theG6WriteIterator, true))
+    if (!_g6_IsWriterInitialized(theG6WriteIterator, TRUE))
     {
         gp_ErrorMessage("Unable to get numGraphsWritten, as G6WriteIterator is "
                         "not initialized.\n");
@@ -256,7 +256,7 @@ int g6_InitWriterWithString(G6WriteIteratorP theG6WriteIterator, char **pOutputS
         return NOTOK;
     }
 
-    if (_g6_IsWriterInitialized(theG6WriteIterator, false))
+    if (_g6_IsWriterInitialized(theG6WriteIterator, FALSE))
     {
         gp_ErrorMessage(
             "Unable to initialize writer, as it was already previously "
@@ -303,7 +303,7 @@ int g6_InitWriterWithFileName(G6WriteIteratorP theG6WriteIterator, char *outputF
         return NOTOK;
     }
 
-    if (_g6_IsWriterInitialized(theG6WriteIterator, false))
+    if (_g6_IsWriterInitialized(theG6WriteIterator, FALSE))
     {
         gp_ErrorMessage(
             "Unable to initialize writer, as it was already previously "
@@ -340,7 +340,7 @@ int _g6_InitWriterWithStrOrFile(G6WriteIteratorP theG6WriteIterator, strOrFileP 
         return NOTOK;
     }
 
-    if (_g6_IsWriterInitialized(theG6WriteIterator, false))
+    if (_g6_IsWriterInitialized(theG6WriteIterator, FALSE))
     {
         gp_ErrorMessage(
             "Unable to initialize writer, as it was already previously "
@@ -435,7 +435,7 @@ void _g6_PrecomputeColumnOffsets(size_t *columnOffsets, int order)
 int g6_WriteGraph(G6WriteIteratorP theG6WriteIterator)
 {
     char *graphEncodingChars = NULL;
-    if (!_g6_IsWriterInitialized(theG6WriteIterator, true))
+    if (!_g6_IsWriterInitialized(theG6WriteIterator, TRUE))
     {
         gp_ErrorMessage("Unable to write graph because G6WriteIterator is not initialized.\n");
         return NOTOK;

--- a/c/graphLib/io/g6-write-iterator.h
+++ b/c/graphLib/io/g6-write-iterator.h
@@ -13,7 +13,6 @@ extern "C"
 #endif
 
 #include <stdio.h>
-#include <stdbool.h>
 
 #include "../graph.h"
 

--- a/c/graphLib/io/graphIO.c
+++ b/c/graphLib/io/graphIO.c
@@ -496,7 +496,7 @@ int _ReadGraph(graphP theGraph, strOrFileP *pInputContainer)
 {
     int RetVal = OK;
 
-    bool extraDataAllowed = false;
+    int extraDataAllowed = FALSE;
     char lineBuff[MAXLINE + 1];
 
     memset(lineBuff, '\0', (MAXLINE + 1));
@@ -524,13 +524,13 @@ int _ReadGraph(graphP theGraph, strOrFileP *pInputContainer)
     {
         RetVal = _ReadAdjList(theGraph, (*pInputContainer));
         if (RetVal == OK)
-            extraDataAllowed = true;
+            extraDataAllowed = TRUE;
     }
     else if (isdigit(lineBuff[0]))
     {
         RetVal = _ReadAdjMatrix(theGraph, (*pInputContainer));
         if (RetVal == OK)
-            extraDataAllowed = true;
+            extraDataAllowed = TRUE;
     }
     else
     {

--- a/c/graphLib/io/strOrFile.c
+++ b/c/graphLib/io/strOrFile.c
@@ -182,17 +182,17 @@ strOrFileP sf_NewOutputContainer(char **pOutputStr, char const *const fileName)
     should only contain one source).
  5. containerType is either set to INPUT_CONTAINER or OUTPUT_CONTAINER
 
- Returns false if any of these conditions are not met, otherwise true.
+ Returns FALSE if any of these conditions are not met, otherwise TRUE.
  ********************************************************************/
 
-bool sf_IsValidStrOrFile(strOrFileP theStrOrFile)
+int sf_IsValidStrOrFile(strOrFileP theStrOrFile)
 {
     if (theStrOrFile == NULL ||
         (theStrOrFile->pFile == NULL && theStrOrFile->theStrBuf == NULL) ||
         (theStrOrFile->pFile != NULL && theStrOrFile->theStrBuf != NULL) ||
         (theStrOrFile->containerType != INPUT_CONTAINER &&
          theStrOrFile->containerType != OUTPUT_CONTAINER))
-        return false;
+        return FALSE;
 
     if (theStrOrFile->containerType == INPUT_CONTAINER)
     {
@@ -201,18 +201,18 @@ bool sf_IsValidStrOrFile(strOrFileP theStrOrFile)
             (theStrOrFile->theStrBuf != NULL && sb_GetSize(theStrOrFile->theStrBuf) == 0))
 
         {
-            return false;
+            return FALSE;
         }
     }
     else // Otherwise, due to the above validation, can only be an output container
     {
         if (theStrOrFile->ungetBuf != NULL)
         {
-            return false;
+            return FALSE;
         }
     }
 
-    return true;
+    return TRUE;
 }
 
 /********************************************************************
@@ -349,7 +349,7 @@ int sf_ReadInteger(int *intToRead, strOrFileP theStrOrFile)
 
     int intCandidate = 0, intCandidateIndex = 0;
     char currChar = '\0', nextChar = '\0';
-    bool startedReadingInt = FALSE, isNegative = FALSE;
+    int startedReadingInt = FALSE, isNegative = FALSE;
     char intCandidateStr[MAXCHARSFOR32BITINT + 1];
     memset(intCandidateStr, '\0', (MAXCHARSFOR32BITINT + 1) * sizeof(char));
 
@@ -574,7 +574,7 @@ char *sf_fgets(char *str, int count, strOrFileP theStrOrFile)
         if (numCharsInUngetBuf > 0)
         {
             char currChar = '\0';
-            bool encounteredNewline = FALSE;
+            int encounteredNewline = FALSE;
 
             charsToReadFromUngetBuf = (count > numCharsInUngetBuf) ? numCharsInUngetBuf : count;
             for (int i = 0; i < charsToReadFromUngetBuf; i++)

--- a/c/graphLib/io/strOrFile.h
+++ b/c/graphLib/io/strOrFile.h
@@ -12,7 +12,6 @@ extern "C"
 {
 #endif
 
-#include <stdbool.h>
 #include <stdio.h>
 
 #include "../lowLevelUtils/stack.h"
@@ -35,7 +34,7 @@ extern "C"
     strOrFileP sf_NewInputContainer(char const *const inputStr, char const *const fileName);
     strOrFileP sf_NewOutputContainer(char **pOutputStr, char const *const fileName);
 
-    bool sf_IsValidStrOrFile(strOrFileP theStrOrFile);
+    int sf_IsValidStrOrFile(strOrFileP theStrOrFile);
 
     char sf_getc(strOrFileP theStrOrFile);
     int sf_ReadSkipChar(strOrFileP theStrOrFile);

--- a/c/planarityApp/planarityTestAllGraphs.c
+++ b/c/planarityApp/planarityTestAllGraphs.c
@@ -149,7 +149,7 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
         return NOTOK;
     }
 
-    while (true)
+    while (TRUE)
     {
         if (g6_ReadGraph(theG6ReadIterator) != OK)
         {


### PR DESCRIPTION
Resolves #226

## Type of change

Please check only relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
    * changed `graphLib` API function signatures to accept as a parameter or to return `int` (i.e. `TRUE`/`FALSE`) rather than `bool`
- [ ] This change requires a documentation update

## Changes

### Added

* N/A

### Updated

* `c/graphLib/io/g6-read-iterator.h`/`.c` - updated `endReached` member of `G6ReadIteratorStruct` so that it is an `int` rather than `bool`, and updated `g6_EndReached()` return type. Also assign `int` to `endReached` in `g6_ReadGraph()` when there's no more contents to read from the input container. Also updated `_g6_IsReaderInitialized()` return type to `int` as well as type of parameter `reportUninitializedParts`, in addition to updating all places where this function is called.
* `c/graphLib/io/g6-read-iterator.h`/`.c` - Updated `_g6_IsWriterInitialized()` return type to `int` as well as type of parameter `reportUninitializedParts`, in addition to updating all places where this function is called.
* `c/graphLib/io/graphIO.c` - changed type of `extraDataAllowed`,  
* `c/graphLib/io/strOrFile.h`/`.c` - changed return type of `sf_IsValidStrOrFile()` from `bool` to `int`. Also, there were a few places where we were already using `TRUE`/`FALSE`, but assigning to `bool`-type variables, so I changed the types to `int`.
* `c/planarityApp/planarityTestAllGraphs.c` - changed loop condition    


### Removed

* N/A

## Testing

1. Ran `planarity_testAllGraphs_orchestrator.py` for N=8 and regenerated test tables for all graph algorithm extensions (same `OK`/`NONEMBEDDABLE`),
2. Ran `RandomGraphs()` for planarity and generated 10000 graphs with N=100, verified successful write to .g6
3. Ran `-test` on `c/samples` successfully
4. Ran `TestAllGraphs()` via the menu-driven experience for planarity on `c/samples/n8.mALL.g6`
5. Ran `SpecificGraph()` for DrawPlanar on `c/samples/maxPlanar5.0-based.txt` to verify `extraData` being written5.