### PR TITLE
Issue #222 - Refactor to remove accessors of private members of read and write iterators

### DIFF
--- a/c/graphLib/io/g6-read-iterator.c
+++ b/c/graphLib/io/g6-read-iterator.c
@@ -82,8 +82,8 @@ int g6_NewReader(G6ReadIteratorP *pG6ReadIterator, graphP theGraph)
         return NOTOK;
     }
 
-    // numGraphsRead, order, numCharsForOrder,
-    // numCharsForGraphEncoding, and currGraphBuffSize all set to 0
+    // numGraphsRead, order, numCharsForOrder, numCharsForGraphEncoding, and
+    // currGraphBuffSize all set to 0
     (*pG6ReadIterator) = (G6ReadIteratorP)calloc(1, sizeof(G6ReadIteratorStruct));
 
     if ((*pG6ReadIterator) == NULL)
@@ -150,100 +150,6 @@ int g6_EndReached(G6ReadIteratorP theG6ReadIterator)
         return TRUE;
 
     return theG6ReadIterator->endReached;
-}
-
-int g6_GetNumGraphsRead(G6ReadIteratorP theG6ReadIterator, int *pNumGraphsRead)
-{
-    if (theG6ReadIterator == NULL)
-    {
-        gp_ErrorMessage("Invalid parameter: theG6ReadIterator must be non-NULL.\n");
-        return NOTOK;
-    }
-
-    if (pNumGraphsRead == NULL)
-    {
-        gp_ErrorMessage(
-            "Unable to get numGraphsRead from G6ReadIterator, as output "
-            "parameter pNumGraphsRead is NULL.\n");
-        return NOTOK;
-    }
-
-    if (!_g6_IsReaderInitialized(theG6ReadIterator, TRUE))
-    {
-        gp_ErrorMessage("Unable to get numGraphsRead, as G6ReadIterator is not "
-                        "initialized.\n");
-
-        (*pNumGraphsRead) = 0;
-
-        return NOTOK;
-    }
-
-    (*pNumGraphsRead) = theG6ReadIterator->numGraphsRead;
-
-    return OK;
-}
-
-int g6_GetOrderFromReader(G6ReadIteratorP theG6ReadIterator, int *pOrder)
-{
-    if (theG6ReadIterator == NULL)
-    {
-        gp_ErrorMessage("Invalid parameter: theG6ReadIterator must be non-NULL.\n");
-        return NOTOK;
-    }
-
-    if (pOrder == NULL)
-    {
-        gp_ErrorMessage(
-            "Unable to get order from G6ReadIterator, as output parameter "
-            "pOrder is NULL.\n");
-        return NOTOK;
-    }
-
-    if (!_g6_IsReaderInitialized(theG6ReadIterator, TRUE))
-    {
-        gp_ErrorMessage("Unable to get order, as G6ReadIterator is not "
-                        "initialized.\n");
-
-        (*pOrder) = 0;
-
-        return NOTOK;
-    }
-
-    (*pOrder) = theG6ReadIterator->order;
-
-    return OK;
-}
-
-int g6_GetGraphFromReader(G6ReadIteratorP theG6ReadIterator, graphP *pGraph)
-{
-    if (theG6ReadIterator == NULL)
-    {
-        gp_ErrorMessage("Invalid parameter: theG6ReadIterator must be non-NULL.\n");
-        return NOTOK;
-    }
-
-    if (pGraph == NULL)
-    {
-        gp_ErrorMessage(
-            "Unable to get graph from G6ReadIterator, as output parameter "
-            "pGraph is NULL.\n");
-        return NOTOK;
-    }
-
-    if (!_g6_IsReaderInitialized(theG6ReadIterator, TRUE))
-    {
-        gp_ErrorMessage(
-            "Unable to get graph from reader, as G6ReadIterator is not "
-            "initialized.\n");
-
-        (*pGraph) = NULL;
-
-        return NOTOK;
-    }
-
-    (*pGraph) = theG6ReadIterator->currGraph;
-
-    return OK;
 }
 
 int g6_InitReaderWithString(G6ReadIteratorP theG6ReadIterator, char *inputString)
@@ -556,7 +462,7 @@ int _g6_DetermineOrderFromInput(strOrFileP inputContainer, int *order)
 int g6_ReadGraph(G6ReadIteratorP theG6ReadIterator)
 {
     strOrFileP inputContainer = NULL;
-    int numGraphsRead = 0;
+    int lineNum = 0;
     char *currGraphBuff = NULL;
     char firstChar = '\0';
     char *graphEncodingChars = NULL;
@@ -573,16 +479,15 @@ int g6_ReadGraph(G6ReadIteratorP theG6ReadIterator)
     }
 
     inputContainer = theG6ReadIterator->inputContainer;
-    numGraphsRead = theG6ReadIterator->numGraphsRead;
+    lineNum = theG6ReadIterator->numGraphsRead + 1;
     currGraphBuff = theG6ReadIterator->currGraphBuff;
     currGraph = theG6ReadIterator->currGraph;
 
     if (sf_fgets(currGraphBuff, currGraphBuffSize, inputContainer) != NULL)
     {
-        numGraphsRead++;
         firstChar = currGraphBuff[0];
 
-        if (_g6_ValidateFirstChar(firstChar, numGraphsRead) != OK)
+        if (_g6_ValidateFirstChar(firstChar, lineNum) != OK)
             return NOTOK;
 
         // From https://stackoverflow.com/a/28462221, strcspn finds the index of the first
@@ -592,19 +497,19 @@ int g6_ReadGraph(G6ReadIteratorP theG6ReadIterator)
         // If the line was too long, then we would have placed the null terminator at the final
         // index (where it already was; see strcpn docs), and the length of the string will be
         // longer than the line should have been, i.e. orderOffset + numCharsForGraphRepr
-        if ((int)strlen(currGraphBuff) != (((numGraphsRead == 1) ? 0 : numCharsForOrder) + numCharsForGraphEncoding))
+        if ((int)strlen(currGraphBuff) != (((lineNum == 1) ? 0 : numCharsForOrder) + numCharsForGraphEncoding))
         {
             gp_ErrorMessage("Invalid line length read on line %d\n",
-                            numGraphsRead);
+                            lineNum);
             return NOTOK;
         }
 
-        if (numGraphsRead > 1)
+        if (lineNum > 1)
         {
             if (_g6_ValidateOrderOfEncodedGraph(currGraphBuff, order) != OK)
             {
                 gp_ErrorMessage("Order of graph on line %d is incorrect.\n",
-                                numGraphsRead);
+                                lineNum);
                 return NOTOK;
             }
         }
@@ -613,15 +518,15 @@ int g6_ReadGraph(G6ReadIteratorP theG6ReadIterator)
         // order, so there's no need to apply the offset. On subsequent lines, the orderOffset
         // must be applied so that we are only starting validation on the byte corresponding to
         // the encoding of the adjacency matrix.
-        graphEncodingChars = (numGraphsRead == 1) ? currGraphBuff : currGraphBuff + numCharsForOrder;
+        graphEncodingChars = (lineNum == 1) ? currGraphBuff : currGraphBuff + numCharsForOrder;
 
         if (_g6_ValidateGraphEncoding(graphEncodingChars, order, numCharsForGraphEncoding) != OK)
         {
-            gp_ErrorMessage("Graph on line %d is invalid.", numGraphsRead);
+            gp_ErrorMessage("Graph on line %d is invalid.", lineNum);
             return NOTOK;
         }
 
-        if (numGraphsRead > 1)
+        if (lineNum > 1)
         {
             gp_ResetGraphStorage(currGraph);
             // Ensures zero-based flag is set after reinitializing graph.
@@ -632,11 +537,11 @@ int g6_ReadGraph(G6ReadIteratorP theG6ReadIterator)
         {
             gp_ErrorMessage("Unable to interpret bits on line %d to populate "
                             "adjacency matrix.\n",
-                            numGraphsRead);
+                            lineNum);
             return NOTOK;
         }
 
-        theG6ReadIterator->numGraphsRead = numGraphsRead;
+        theG6ReadIterator->numGraphsRead = lineNum;
     }
     else
     {

--- a/c/graphLib/io/g6-read-iterator.h
+++ b/c/graphLib/io/g6-read-iterator.h
@@ -20,17 +20,13 @@ extern "C"
     typedef G6ReadIteratorStruct *G6ReadIteratorP;
 
     int g6_NewReader(G6ReadIteratorP *pG6ReadIterator, graphP theGraph);
-    int g6_EndReached(G6ReadIteratorP theG6ReadIterator);
-
-    int g6_GetNumGraphsRead(G6ReadIteratorP theG6ReadIterator, int *pNumGraphsRead);
-    int g6_GetOrderFromReader(G6ReadIteratorP theG6ReadIterator, int *pOrder);
-    int g6_GetGraphFromReader(G6ReadIteratorP theG6ReadIterator, graphP *pGraph);
 
     int g6_InitReaderWithString(G6ReadIteratorP theG6ReadIterator, char *inputString);
     int g6_InitReaderWithFileName(G6ReadIteratorP theG6ReadIterator, char const *const infileName);
 
     int g6_ReadGraph(G6ReadIteratorP theG6ReadIterator);
 
+    int g6_EndReached(G6ReadIteratorP theG6ReadIterator);
     void g6_FreeReader(G6ReadIteratorP *pG6ReadIterator);
 
 #ifdef __cplusplus

--- a/c/graphLib/io/g6-write-iterator.c
+++ b/c/graphLib/io/g6-write-iterator.c
@@ -42,7 +42,6 @@ typedef strOrFileStruct *strOrFileP;
 struct G6WriteIteratorStruct
 {
     strOrFileP outputContainer;
-    int numGraphsWritten;
 
     int order;
     int numCharsForOrder;
@@ -83,8 +82,8 @@ int g6_NewWriter(G6WriteIteratorP *pG6WriteIterator, graphP theGraph)
         return NOTOK;
     }
 
-    // numGraphsWritten, order, numCharsForOrder,
-    // numCharsForGraphEncoding, and currGraphBuffSize all set to 0
+    // order, numCharsForOrder, numCharsForGraphEncoding, and currGraphBuffSize
+    // all set to 0
     (*pG6WriteIterator) = (G6WriteIteratorP)calloc(1, sizeof(G6WriteIteratorStruct));
 
     if ((*pG6WriteIterator) == NULL)
@@ -151,99 +150,6 @@ int _g6_IsWriterInitialized(G6WriteIteratorP theG6WriteIterator, int reportUnini
     }
 
     return writerIsInitialized;
-}
-
-int g6_GetNumGraphsWritten(G6WriteIteratorP theG6WriteIterator, int *pNumGraphsWritten)
-{
-    if (theG6WriteIterator == NULL)
-    {
-        gp_ErrorMessage("Invalid parameter: theG6WriteIterator must be non-NULL.\n");
-        return NOTOK;
-    }
-
-    if (pNumGraphsWritten == NULL)
-    {
-        gp_ErrorMessage(
-            "Unable to get numGraphsWritten from G6WriteIterator, as output "
-            "parameter pNumGraphsWritten is NULL.\n");
-        return NOTOK;
-    }
-
-    if (!_g6_IsWriterInitialized(theG6WriteIterator, TRUE))
-    {
-        gp_ErrorMessage("Unable to get numGraphsWritten, as G6WriteIterator is "
-                        "not initialized.\n");
-
-        (*pNumGraphsWritten) = 0;
-
-        return NOTOK;
-    }
-
-    (*pNumGraphsWritten) = theG6WriteIterator->numGraphsWritten;
-
-    return OK;
-}
-
-int g6_GetOrderFromWriter(G6WriteIteratorP theG6WriteIterator, int *pOrder)
-{
-    if (theG6WriteIterator == NULL)
-    {
-        gp_ErrorMessage("Invalid parameter: theG6WriteIterator must be non-NULL.\n");
-        return NOTOK;
-    }
-
-    if (pOrder == NULL)
-    {
-        gp_ErrorMessage(
-            "Unable to get order from G6WriteIterator, as output parameter "
-            "pOrder is NULL.\n");
-        return NOTOK;
-    }
-
-    if (!_g6_IsWriterInitialized(theG6WriteIterator, TRUE))
-    {
-        gp_ErrorMessage("Unable to get order, as G6WriteIterator is not "
-                        "initialized.\n");
-
-        (*pOrder) = 0;
-
-        return NOTOK;
-    }
-
-    (*pOrder) = theG6WriteIterator->order;
-
-    return OK;
-}
-
-int g6_GetGraphFromWriter(G6WriteIteratorP theG6WriteIterator, graphP *pGraph)
-{
-    if (theG6WriteIterator == NULL)
-    {
-        gp_ErrorMessage("Invalid parameter: theG6WriteIterator must be non-NULL.\n");
-        return NOTOK;
-    }
-
-    if (pGraph == NULL)
-    {
-        gp_ErrorMessage(
-            "Unable to get graph from G6WriteIterator, as output parameter "
-            "pGraph is NULL.\n");
-        return NOTOK;
-    }
-
-    if (!_g6_IsWriterInitialized(theG6WriteIterator, TRUE))
-    {
-        gp_ErrorMessage("Unable to get numGraphsWritten, as G6WriteIterator is "
-                        "not initialized.\n");
-
-        (*pGraph) = NULL;
-
-        return NOTOK;
-    }
-
-    (*pGraph) = theG6WriteIterator->currGraph;
-
-    return OK;
 }
 
 int g6_InitWriterWithString(G6WriteIteratorP theG6WriteIterator, char **pOutputString)
@@ -622,7 +528,6 @@ void g6_FreeWriter(G6WriteIteratorP *pG6WriteIterator)
         if ((*pG6WriteIterator)->outputContainer != NULL)
             sf_Free((&((*pG6WriteIterator)->outputContainer)));
 
-        (*pG6WriteIterator)->numGraphsWritten = 0;
         (*pG6WriteIterator)->order = 0;
 
         if ((*pG6WriteIterator)->currGraphBuff != NULL)

--- a/c/graphLib/io/g6-write-iterator.h
+++ b/c/graphLib/io/g6-write-iterator.h
@@ -21,10 +21,6 @@ extern "C"
 
     int g6_NewWriter(G6WriteIteratorP *pG6WriteIterator, graphP theGraph);
 
-    int g6_GetNumGraphsWritten(G6WriteIteratorP theG6WriteIterator, int *pNumGraphsWritten);
-    int g6_GetOrderFromWriter(G6WriteIteratorP theG6WriteIterator, int *pOrder);
-    int g6_GetGraphFromWriter(G6WriteIteratorP theG6WriteIterator, graphP *pGraph);
-
     int g6_InitWriterWithString(G6WriteIteratorP theG6WriteIterator, char **pOutputString);
     int g6_InitWriterWithFileName(G6WriteIteratorP theG6WriteIterator, char *outputFileName);
 

--- a/c/planarityApp/planarityTestAllGraphs.c
+++ b/c/planarityApp/planarityTestAllGraphs.c
@@ -9,7 +9,7 @@ See the LICENSE.TXT file for licensing information.
 typedef struct
 {
     double duration;
-    int numGraphsRead;
+    int numGraphsTested;
     int numOK;
     int numNONEMBEDDABLE;
     int errorFlag;
@@ -213,7 +213,11 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
         }
     }
 
-    stats->numGraphsRead = lineNum;
+    // Since we increment lineNum at the beginning of the loop, if an error
+    // occurs during processing a graph on the current lineNum, or if we reach
+    // the end of the input, then the number of graphs successfully tested is
+    // lineNum - 1.
+    stats->numGraphsTested = lineNum - 1;
     stats->numOK = numOK;
     stats->numNONEMBEDDABLE = numNONEMBEDDABLE;
     stats->errorFlag = (Result == OK) ? FALSE : TRUE;
@@ -233,7 +237,7 @@ int outputTestAllGraphsResults(char command, char modifier, testAllStatsP stats,
     char const *infileBasename = finalSlash ? (finalSlash + 1) : infileName;
 
     char const *headerFormat = "FILENAME=\"%s\" DURATION=\"%.3lf\"\n";
-    int numCharsToReprNumGraphsRead = 0, numCharsToReprNumOK = 0, numCharsToReprNumNONEMBEDDABLE = 0;
+    int numCharsToReprNumGraphsTested = 0, numCharsToReprNumOK = 0, numCharsToReprNumNONEMBEDDABLE = 0;
 
     char *theOutputStr = NULL;
     int headerStrLen = 0, resultStrLen = 0;
@@ -251,7 +255,7 @@ int outputTestAllGraphsResults(char command, char modifier, testAllStatsP stats,
         strlen("-1.7976931348623158e+308") + // -DBL_MAX from float.h
         3;
 
-    if (GetNumCharsToReprInt(stats->numGraphsRead, &numCharsToReprNumGraphsRead) != OK ||
+    if (GetNumCharsToReprInt(stats->numGraphsTested, &numCharsToReprNumGraphsTested) != OK ||
         GetNumCharsToReprInt(stats->numOK, &numCharsToReprNumOK) != OK ||
         GetNumCharsToReprInt(stats->numNONEMBEDDABLE, &numCharsToReprNumNONEMBEDDABLE) != OK)
     {
@@ -265,7 +269,7 @@ int outputTestAllGraphsResults(char command, char modifier, testAllStatsP stats,
         1 + // command char
         1 + // optional modifier char
         1 + // space char
-        numCharsToReprNumGraphsRead +
+        numCharsToReprNumGraphsTested +
         1 + // space char
         numCharsToReprNumOK +
         1 + // space char
@@ -291,10 +295,10 @@ int outputTestAllGraphsResults(char command, char modifier, testAllStatsP stats,
 
     if (modifier == '\0')
         sprintf(resultsStr, "-%c %d %d %d %s\n",
-                command, stats->numGraphsRead, stats->numOK, stats->numNONEMBEDDABLE, stats->errorFlag ? "ERROR" : "SUCCESS");
+                command, stats->numGraphsTested, stats->numOK, stats->numNONEMBEDDABLE, stats->errorFlag ? "ERROR" : "SUCCESS");
     else
         sprintf(resultsStr, "-%c%c %d %d %d %s\n",
-                command, modifier, stats->numGraphsRead, stats->numOK, stats->numNONEMBEDDABLE, stats->errorFlag ? "ERROR" : "SUCCESS");
+                command, modifier, stats->numGraphsTested, stats->numOK, stats->numNONEMBEDDABLE, stats->errorFlag ? "ERROR" : "SUCCESS");
 
     if (outfileName != NULL)
     {

--- a/c/planarityApp/planarityTestAllGraphs.c
+++ b/c/planarityApp/planarityTestAllGraphs.c
@@ -96,6 +96,7 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
     graphP graphForEmbedding = NULL;
     int embedFlags = 0, numOK = 0, numNONEMBEDDABLE = 0;
     int order = 0;
+    int lineNum = 0;
 
     G6ReadIteratorP theG6ReadIterator = NULL;
 
@@ -151,12 +152,11 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
 
     while (TRUE)
     {
+        lineNum++;
         if (g6_ReadGraph(theG6ReadIterator) != OK)
         {
-            int numGraphsRead = 0;
-            g6_GetNumGraphsRead(theG6ReadIterator, &numGraphsRead);
             gp_ErrorMessage("Unable to read graph on line %d.\n",
-                            numGraphsRead + 1);
+                            lineNum);
             Result = NOTOK;
             break;
         }
@@ -174,20 +174,16 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
         Result = gp_Embed(graphForEmbedding, embedFlags);
         if (Result != OK && Result != NONEMBEDDABLE)
         {
-            int numGraphsRead = 0;
-            g6_GetNumGraphsRead(theG6ReadIterator, &numGraphsRead);
             gp_ErrorMessage("Failed to embed graph on line %d for command '%c'.\n",
-                            numGraphsRead + 1, command);
+                            lineNum, command);
             Result = NOTOK;
         }
 
         if (gp_TestEmbedResultIntegrity(graphForEmbedding, origGraphRead, Result) != Result)
         {
-            int numGraphsRead = 0;
-            g6_GetNumGraphsRead(theG6ReadIterator, &numGraphsRead);
             gp_ErrorMessage("Embed integrity check failed for graph on line %d "
                             "for command '%c'.\n",
-                            numGraphsRead + 1, command);
+                            lineNum, command);
             Result = NOTOK;
         }
 
@@ -204,25 +200,20 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
         {
             if (modifier == '\0')
             {
-                int numGraphsRead = 0;
-                g6_GetNumGraphsRead(theG6ReadIterator, &numGraphsRead);
                 gp_ErrorMessage("Command '%c' error on graph on line %d.\n",
-                                command, numGraphsRead + 1);
+                                command, lineNum);
             }
             else
             {
-                int numGraphsRead = 0;
-                g6_GetNumGraphsRead(theG6ReadIterator, &numGraphsRead);
                 gp_ErrorMessage("Command '%c%c' error on graph on line %d.\n",
-                                command, modifier, numGraphsRead + 1);
+                                command, modifier, lineNum);
             }
             Result = NOTOK;
             break;
         }
     }
 
-    stats->numGraphsRead = 0;
-    g6_GetNumGraphsRead(theG6ReadIterator, &stats->numGraphsRead);
+    stats->numGraphsRead = lineNum;
     stats->numOK = numOK;
     stats->numNONEMBEDDABLE = numNONEMBEDDABLE;
     stats->errorFlag = (Result == OK) ? FALSE : TRUE;

--- a/c/planarityApp/planarityUtils.c
+++ b/c/planarityApp/planarityUtils.c
@@ -831,17 +831,13 @@ char *ConstructInputFileName(char const *infileName)
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
             if (strlen(lineBuff) == 0 || strlen(lineBuff) > FILENAMEMAXLENGTH ||
                 sscanf(lineBuff, fileNameFormat, theFileName) != 1)
-                gp_ErrorMessage("Invalid input file name.\n");
+                gp_Message("Invalid input file name; retry.\n");
             else
             {
                 if (strncmp(theFileName, "stdin", strlen("stdin")) != 0 && !strchr(theFileName, '.'))
                 {
                     gp_Message("Graph file name does not have extension; automatically appending \".txt\".\n");
-                    if (strcat(theFileName, ".txt") == NULL)
-                    {
-                        gp_ErrorMessage("Appending \".txt\" extension to theFileName using strcat() failed.\n");
-                        Result = NOTOK;
-                    }
+                    strcat(theFileName, ".txt");
                 }
                 break;
             }
@@ -906,7 +902,7 @@ char *ConstructPrimaryOutputFileName(char const *infileName, char const *outfile
             strcat(theFileName, algorithmName);
         }
         else
-            gp_ErrorMessage("Algorithm Name is too long, so it will not be used in output file name.\n");
+            gp_Message("Algorithm Name is too long, so it will not be used in output file name.\n");
 
         strcat(theFileName, ".out.txt");
     }
@@ -925,7 +921,7 @@ char *ConstructPrimaryOutputFileName(char const *infileName, char const *outfile
             }
             strcat(theFileName, ".out.txt");
 
-            gp_ErrorMessage("Outfile file name is too long. Result placed in \"%.*s\"", FILENAME_MAX, theFileName);
+            gp_Message("Outfile file name is too long. Result placed in \"%.*s\"", FILENAME_MAX, theFileName);
         }
         else
         {


### PR DESCRIPTION
Resolves #222

## Type of change

Please check only relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes

### Added

* N/A

### Updated

* `g6-(read|write)-iterator.h`/`.c` - Removed unnecessary accessors. Removed `numGraphsWritten` member from `G6WriteIteratorStruct`. `g6_ReadGraph()` now uses a local variable, `lineNum`, for error messaging (since `G6ReadIterator`'s `numGraphsRead` keeps track of how many graphs have successfully been read)
* `c/planarityApp/planarityTestAllGraphs.c` - `testAllGraphs()` independently keeps track of the `lineNum` on which the test is being performed with a local variable (no longer accesses the `numGraphsRead` from the `G6ReadIteratorStruct`). Changed name of `testAllStats` member from `numGraphsRead` to `numGraphsTested`, since this better represents having read and tested the graphs of the input file, and is assigned the value of one less than the `lineNum` in `testAllGraphs()`: in an error state for the current loop iteration, we only successfully tested `lineNum - 1` graphs in the input file; if g6_EndReached(), then we only actually processed `lineNum - 1` graphs.

"While I'm in the neighbourhood(ish)":
* `c/planarityApp/planarityUtils.c` - some `gp_ErrorMessage()` changed to `gp_Message()` in `ConstructInputFileName()` and `ConstructPrimaryOutputFileName()`, since these messages are informational and don't result in returning `NOTOK`.

### Removed

* N/A

## Testing

Locally ran `-test` on `c/samples` with `Debug` build produced by VSCode on MacOS using `clang` 22.1.4 installed via `homebrew`

<details>

```
% ./Debug/planarity -test c/samples

	Starting 1-based Array Index Tests

The graph "maxPlanar5.txt" is planar.
Algorithm 'Planarity' executed in 0.000 seconds.
Test succeeded (result equal to exemplar).

The graph "maxPlanar5.txt" is planar.
Algorithm 'DrawPlanar' executed in 0.000 seconds.
Test succeeded (result equal to exemplar).
Test succeeded (secondary result equal to exemplar).

The graph "drawExample.txt" is planar.
Algorithm 'DrawPlanar' executed in 0.000 seconds.
Test succeeded (result equal to exemplar).
Test succeeded (secondary result equal to exemplar).

The graph "Petersen.txt" is not planar.
Algorithm 'Planarity' executed in 0.000 seconds.
Test succeeded (result equal to exemplar).

The graph "Petersen.txt" is not outerplanar.
Algorithm 'Outerplanarity' executed in 0.000 seconds.
Test succeeded (result equal to exemplar).

The graph "Petersen.txt" has a subgraph homeomorphic to K_{2,3}.
Algorithm 'K23Search' executed in 0.000 seconds.
Test succeeded (result equal to exemplar).

The graph "Petersen.txt" has a subgraph homeomorphic to K_{3,3}.
Algorithm 'K33Search' executed in 0.000 seconds.
Test succeeded (result equal to exemplar).

The graph "Petersen.txt" has a subgraph homeomorphic to K_4.
Algorithm 'K4Search' executed in 0.000 seconds.
Test succeeded (result equal to exemplar).

	Finished 1-based Array Index Tests.

The graph "maxPlanar5.0-based.txt" is planar.
Algorithm 'Planarity' executed in 0.000 seconds.
Test succeeded (result equal to exemplar).

The graph "maxPlanar5.0-based.txt" is planar.
Algorithm 'DrawPlanar' executed in 0.000 seconds.
Test succeeded (result equal to exemplar).
Test succeeded (secondary result equal to exemplar).

The graph "drawExample.0-based.txt" is planar.
Algorithm 'DrawPlanar' executed in 0.000 seconds.
Test succeeded (result equal to exemplar).
Test succeeded (secondary result equal to exemplar).

The graph "Petersen.0-based.txt" is not planar.
Algorithm 'Planarity' executed in 0.000 seconds.
Test succeeded (result equal to exemplar).

The graph "Petersen.0-based.txt" is not outerplanar.
Algorithm 'Outerplanarity' executed in 0.000 seconds.
Test succeeded (result equal to exemplar).

The graph "Petersen.0-based.txt" has a subgraph homeomorphic to K_{2,3}.
Algorithm 'K23Search' executed in 0.000 seconds.
Test succeeded (result equal to exemplar).

The graph "Petersen.0-based.txt" has a subgraph homeomorphic to K_{3,3}.
Algorithm 'K33Search' executed in 0.000 seconds.
Test succeeded (result equal to exemplar).

The graph "Petersen.0-based.txt" has a subgraph homeomorphic to K_4.
Algorithm 'K4Search' executed in 0.000 seconds.
Test succeeded (result equal to exemplar).

For the transformation -a on file "nauty_example.g6", actual output matched expected output file.

For the transformation -a on file "nauty_example.g6", actual output matched expected output file.

For the transformation -a on file "N5-all.g6", actual output matched expected output file.

For the transformation -a on file "N5-all.g6", actual output matched expected output file.

For the transformation -a on file "K10.g6", actual output matched expected output file.

For the transformation -a on file "K10.g6", actual output matched expected output file.

For the transformation -m on file "nauty_example.g6", actual output matched expected output file.

For the transformation -m on file "nauty_example.g6", actual output matched expected output file.

For the transformation -m on file "N5-all.g6", actual output matched expected output file.

For the transformation -m on file "N5-all.g6", actual output matched expected output file.

For the transformation -m on file "K10.g6", actual output matched expected output file.

For the transformation -m on file "K10.g6", actual output matched expected output file.

For the transformation -g on file "nauty_example.g6.0-based.AdjList.out.txt", actual output matched expected output file.

For the transformation -g on file "K10.g6.0-based.AdjList.out.txt", actual output matched expected output file.

Start testing all graphs in "n8.mALL.g6".

Done testing all graphs (0.193 seconds).
Start testing all graphs in "n8.mALL.g6".

Done testing all graphs (0.227 seconds).
Start testing all graphs in "n8.mALL.g6".

Done testing all graphs (0.181 seconds).
Start testing all graphs in "n8.mALL.g6".

Done testing all graphs (0.149 seconds).
Start testing all graphs in "n8.mALL.g6".

Done testing all graphs (0.187 seconds).
Start testing all graphs in "n8.mALL.g6".

Done testing all graphs (0.167 seconds).
============
All tests have succeeded.

	Press return key to exit...

```

</details>
