### PR TITLE
Issue #225 - refactor variadic message functions

### DIFF
--- a/c/graphLib/graph.c
+++ b/c/graphLib/graph.c
@@ -1076,20 +1076,21 @@ graphP gp_DupGraph(graphP theGraph)
 
     if ((result = gp_New()) == NULL)
     {
-        gp_ErrorMessage("Failed to create a new graph.\n");
+        gp_ErrorMessage("Failed to create a new graph.");
         return NULL;
     }
 
     if (gp_EnsureVertexCapacity(result, gp_GetN(theGraph)) != OK)
     {
-        gp_ErrorMessage("Failed to increase the vertex capacity of the new graph.\n");
+        gp_ErrorMessage("Failed to increase the vertex capacity of the new "
+                        "graph.");
         gp_Free(&result);
         return NULL;
     }
 
     if (gp_CopyGraph(result, theGraph) != OK)
     {
-        gp_ErrorMessage("Failed to copy the source graph to the new graph.\n");
+        gp_ErrorMessage("Failed to copy the source graph to the new graph.");
         gp_Free(&result);
         return NULL;
     }

--- a/c/graphLib/io/g6-api-utilities.c
+++ b/c/graphLib/io/g6-api-utilities.c
@@ -70,12 +70,12 @@ int _g6_ValidateOrderOfEncodedGraph(char *graphBuff, int order)
     {
         if (graphBuff[1] == 126)
         {
-            gp_ErrorMessage("Can only handle graphs of order <= 100,000.\n");
+            gp_ErrorMessage("Can only handle graphs of order <= 100,000.");
             return NOTOK;
         }
         else if (graphBuff[1] > 126)
         {
-            gp_ErrorMessage("Invalid graph order signifier.\n");
+            gp_ErrorMessage("Invalid graph order signifier.");
             return NOTOK;
         }
         else
@@ -90,7 +90,7 @@ int _g6_ValidateOrderOfEncodedGraph(char *graphBuff, int order)
     else
     {
         gp_ErrorMessage("Character doesn't correspond to a printable ASCII "
-                        "character.\n");
+                        "character.");
         return NOTOK;
     }
 
@@ -114,7 +114,7 @@ int _g6_ValidateGraphEncoding(char *graphBuff, const int order, const size_t num
 
     if (graphBuff == NULL || strlen(graphBuff) == 0)
     {
-        gp_ErrorMessage("Invalid encoding: graphBuff is NULL or empty.\n");
+        gp_ErrorMessage("Invalid encoding: graphBuff is NULL or empty.");
         return NOTOK;
     }
 
@@ -130,8 +130,10 @@ int _g6_ValidateGraphEncoding(char *graphBuff, const int order, const size_t num
     if (expectedNumChars != numCharsForGraphEncoding)
     {
         gp_ErrorMessage("Invalid number of bytes for graph of order %d; got %d "
-                        "but expected %d\n",
-                        order, (int)numCharsForGraphEncoding, (int)expectedNumChars);
+                        "but expected %d",
+                        order,
+                        (int)numCharsForGraphEncoding,
+                        (int)expectedNumChars);
         return NOTOK;
     }
 
@@ -140,7 +142,7 @@ int _g6_ValidateGraphEncoding(char *graphBuff, const int order, const size_t num
     {
         if (graphBuff[i] < 63 || graphBuff[i] > 126)
         {
-            gp_ErrorMessage("Invalid character at index %d: \"%c\"\n",
+            gp_ErrorMessage("Invalid character at index %d: '%c'",
                             (int)i, graphBuff[i]);
             return NOTOK;
         }
@@ -158,7 +160,7 @@ int _g6_ValidateGraphEncoding(char *graphBuff, const int order, const size_t num
 
     if (numPaddingZeroes != expectedNumPaddingZeroes)
     {
-        gp_ErrorMessage("Expected %d padding zeroes, but got %d.\n",
+        gp_ErrorMessage("Expected %d padding zeroes, but got %d.",
                         (int)expectedNumPaddingZeroes, (int)numPaddingZeroes);
         exitCode = NOTOK;
     }

--- a/c/graphLib/io/g6-read-iterator.c
+++ b/c/graphLib/io/g6-read-iterator.c
@@ -69,16 +69,16 @@ int g6_NewReader(G6ReadIteratorP *pG6ReadIterator, graphP theGraph)
 
     if (pG6ReadIterator == NULL)
     {
-        gp_ErrorMessage(
-            "Unable to allocate G6ReadIterator, as pointer to which to assign "
-            "address of memory allocated for G6ReadIterator is NULL.\n");
+        gp_ErrorMessage("Unable to allocate G6ReadIterator, as pointer to "
+                        "which to assign address of memory allocated for "
+                        "G6ReadIterator is NULL.");
         return NOTOK;
     }
 
     if (pG6ReadIterator != NULL && (*pG6ReadIterator) != NULL)
     {
-        gp_ErrorMessage(
-            "G6ReadIterator is not NULL and therefore can't be allocated.\n");
+        gp_ErrorMessage("G6ReadIterator is not NULL and therefore can't be "
+                        "allocated.");
         return NOTOK;
     }
 
@@ -88,7 +88,7 @@ int g6_NewReader(G6ReadIteratorP *pG6ReadIterator, graphP theGraph)
 
     if ((*pG6ReadIterator) == NULL)
     {
-        gp_ErrorMessage("Unable to allocate memory for G6ReadIterator.\n");
+        gp_ErrorMessage("Unable to allocate memory for G6ReadIterator.");
         return NOTOK;
     }
 
@@ -96,7 +96,7 @@ int g6_NewReader(G6ReadIteratorP *pG6ReadIterator, graphP theGraph)
 
     if (theGraph == NULL)
     {
-        gp_ErrorMessage("Must allocate graph to be used by G6ReadIterator.\n");
+        gp_ErrorMessage("Must allocate graph to be used by G6ReadIterator.");
 
         g6_FreeReader(pG6ReadIterator);
     }
@@ -115,7 +115,7 @@ int _g6_IsReaderInitialized(G6ReadIteratorP theG6ReadIterator, int reportUniniti
     if (theG6ReadIterator == NULL)
     {
         if (reportUninitializedParts)
-            gp_ErrorMessage("G6ReadIterator is NULL.\n");
+            gp_ErrorMessage("G6ReadIterator is NULL.");
         readerInitialized = FALSE;
     }
     else
@@ -123,20 +123,20 @@ int _g6_IsReaderInitialized(G6ReadIteratorP theG6ReadIterator, int reportUniniti
         if (!sf_IsValidStrOrFile(theG6ReadIterator->inputContainer))
         {
             if (reportUninitializedParts)
-                gp_ErrorMessage("G6ReadIterator's inputContainer string-or-file container "
-                                "is not valid.\n");
+                gp_ErrorMessage("G6ReadIterator's inputContainer string-or-file "
+                                "container is not valid.");
             readerInitialized = FALSE;
         }
         if (theG6ReadIterator->currGraphBuff == NULL)
         {
             if (reportUninitializedParts)
-                gp_ErrorMessage("G6ReadIterator's currGraphBuff is NULL.\n");
+                gp_ErrorMessage("G6ReadIterator's currGraphBuff is NULL.");
             readerInitialized = FALSE;
         }
         if (theG6ReadIterator->currGraph == NULL)
         {
             if (reportUninitializedParts)
-                gp_ErrorMessage("G6ReadIterator's currGraph is NULL.\n");
+                gp_ErrorMessage("G6ReadIterator's currGraph is NULL.");
             readerInitialized = FALSE;
         }
     }
@@ -158,29 +158,27 @@ int g6_InitReaderWithString(G6ReadIteratorP theG6ReadIterator, char *inputString
 
     if (theG6ReadIterator == NULL)
     {
-        gp_ErrorMessage("Invalid parameter: theG6ReadIterator must be non-NULL.\n");
+        gp_ErrorMessage("Invalid parameter: theG6ReadIterator must be non-NULL.");
         return NOTOK;
     }
 
     if (_g6_IsReaderInitialized(theG6ReadIterator, FALSE))
     {
-        gp_ErrorMessage(
-            "Unable to initialize reader, as it was already previously "
-            "initialized.\n");
+        gp_ErrorMessage("Unable to initialize reader, as it was already "
+                        "previously initialized.");
         return NOTOK;
     }
 
     if (inputString == NULL || strlen(inputString) == 0)
     {
-        gp_ErrorMessage("Unable to initialize reader with empty input string.\n");
+        gp_ErrorMessage("Unable to initialize reader with empty input string.");
         return NOTOK;
     }
 
     if ((inputContainer = sf_NewInputContainer(inputString, NULL)) == NULL)
     {
-        gp_ErrorMessage(
-            "Unable to initialize reader with string, as we failed to allocate "
-            "the inputContainer.\n");
+        gp_ErrorMessage("Unable to initialize reader with string, as we failed "
+                        "to allocate the inputContainer.");
         return NOTOK;
     }
 
@@ -195,7 +193,7 @@ int g6_InitReaderWithFileName(G6ReadIteratorP theG6ReadIterator, char const *con
 
     if (theG6ReadIterator == NULL)
     {
-        gp_ErrorMessage("Invalid parameter: theG6ReadIterator must be non-NULL.\n");
+        gp_ErrorMessage("Invalid parameter: theG6ReadIterator must be non-NULL.");
         return NOTOK;
     }
 
@@ -209,15 +207,14 @@ int g6_InitReaderWithFileName(G6ReadIteratorP theG6ReadIterator, char const *con
 
     if (infileName == NULL || strlen(infileName) == 0)
     {
-        gp_ErrorMessage("Unable to initialize reader with empty infile name.\n");
+        gp_ErrorMessage("Unable to initialize reader with empty infile name.");
         return NOTOK;
     }
 
     if ((inputContainer = sf_NewInputContainer(NULL, infileName)) == NULL)
     {
-        gp_ErrorMessage(
-            "Unable to initialize reader with file name, as we failed to "
-            "allocate the inputContainer.\n");
+        gp_ErrorMessage("Unable to initialize reader with file name, as we "
+                        "failed to allocate the inputContainer.");
         return NOTOK;
     }
 
@@ -230,14 +227,14 @@ int _g6_InitReaderWithStrOrFile(G6ReadIteratorP theG6ReadIterator, strOrFileP *p
 {
     if (theG6ReadIterator == NULL)
     {
-        gp_ErrorMessage("Invalid parameter: theG6ReadIterator must be non-NULL.\n");
+        gp_ErrorMessage("Invalid parameter: theG6ReadIterator must be non-NULL.");
         return NOTOK;
     }
 
     if (pInputContainer == NULL || !sf_IsValidStrOrFile((*pInputContainer)))
     {
         gp_ErrorMessage("Unable to initialize reader with invalid strOrFile "
-                        "input container.\n");
+                        "input container.");
         return NOTOK;
     }
 
@@ -260,7 +257,7 @@ int _g6_InitReader(G6ReadIteratorP theG6ReadIterator)
 
     if ((firstChar = sf_getc(inputContainer)) == EOF)
     {
-        gp_ErrorMessage("Unable to initialize reader: .g6 infile is empty.\n");
+        gp_ErrorMessage("Unable to initialize reader: .g6 infile is empty.");
         return NOTOK;
     }
     else
@@ -269,8 +266,8 @@ int _g6_InitReader(G6ReadIteratorP theG6ReadIterator)
 
         if (charConfirmation != firstChar)
         {
-            gp_ErrorMessage("Unable to initialize reader due to failure to ungetc "
-                            "first character.\n");
+            gp_ErrorMessage("Unable to initialize reader due to failure to "
+                            "ungetc first character.");
             return NOTOK;
         }
 
@@ -278,8 +275,8 @@ int _g6_InitReader(G6ReadIteratorP theG6ReadIterator)
         {
             if (_g6_ValidateHeader(inputContainer) != OK)
             {
-                gp_ErrorMessage("Unable to initialize reader due to inability to "
-                                "process and check .g6 infile header.\n");
+                gp_ErrorMessage("Unable to initialize reader due to inability "
+                                "to process and check .g6 infile header.");
                 return NOTOK;
             }
         }
@@ -291,7 +288,7 @@ int _g6_InitReader(G6ReadIteratorP theG6ReadIterator)
     if (charConfirmation != firstChar)
     {
         gp_ErrorMessage("Unable to initialize reader due to failure to ungetc "
-                        "first character.\n");
+                        "first character.");
         return NOTOK;
     }
 
@@ -302,8 +299,8 @@ int _g6_InitReader(G6ReadIteratorP theG6ReadIterator)
     // in practice n will be limited such that an integer will suffice in storing it.
     if (_g6_DetermineOrderFromInput(inputContainer, &order) != OK)
     {
-        gp_ErrorMessage("Unable to initialize reader due to invalid graph order "
-                        "on line %d of .g6 file.\n",
+        gp_ErrorMessage("Unable to initialize reader due to invalid graph "
+                        "order on line %d of .g6 file.",
                         lineNum);
         return NOTOK;
     }
@@ -313,8 +310,8 @@ int _g6_InitReader(G6ReadIteratorP theG6ReadIterator)
         if (gp_EnsureVertexCapacity(theG6ReadIterator->currGraph, order) != OK)
         {
             gp_ErrorMessage("Unable to initialize reader due to failure "
-                            "initializing graph datastructure with order %d for "
-                            "graph on line %d of the .g6 file.\n",
+                            "initializing graph datastructure with order %d "
+                            "for graph on line %d of the .g6 file.",
                             order, lineNum);
             return NOTOK;
         }
@@ -325,10 +322,10 @@ int _g6_InitReader(G6ReadIteratorP theG6ReadIterator)
     {
         if (gp_GetN(theG6ReadIterator->currGraph) != order)
         {
-            gp_ErrorMessage("Unable to initialize reader, as graph datastructure "
-                            "passed in was already initialized with graph order "
-                            "%d,\n\twhich doesn't match the graph order %d "
-                            "specified in the file.\n",
+            gp_ErrorMessage("Unable to initialize reader, as graph structure "
+                            "passed in was already initialized with order "
+                            "%d, which doesn't match the graph order %d "
+                            "specified in the file.",
                             gp_GetN(theG6ReadIterator->currGraph), order);
             return NOTOK;
         }
@@ -350,7 +347,7 @@ int _g6_InitReader(G6ReadIteratorP theG6ReadIterator)
 
     if (theG6ReadIterator->currGraphBuff == NULL)
     {
-        gp_ErrorMessage("Unable to allocate memory for currGraphBuff.\n");
+        gp_ErrorMessage("Unable to allocate memory for currGraphBuff.");
         return NOTOK;
     }
 
@@ -368,7 +365,7 @@ int _g6_ValidateHeader(strOrFileP inputContainer)
 
     if (inputContainer == NULL)
     {
-        gp_ErrorMessage("Invalid .g6 string-or-file container.\n");
+        gp_ErrorMessage("Invalid .g6 string-or-file container.");
         return NOTOK;
     }
 
@@ -382,11 +379,13 @@ int _g6_ValidateHeader(strOrFileP inputContainer)
     if (strcmp(g6Header, headerCandidateChars) != 0)
     {
         if (strcmp(sparse6Header, headerCandidateChars) == 0)
-            gp_ErrorMessage("Graph file is sparse6 format, which is not supported.\n");
+            gp_ErrorMessage("Graph file is sparse6 format, which is not "
+                            "supported.");
         else if (strcmp(digraph6Header, headerCandidateChars) == 0)
-            gp_ErrorMessage("Graph file is digraph6 format, which is not supported.\n");
+            gp_ErrorMessage("Graph file is digraph6 format, which is not "
+                            "supported.");
         else
-            gp_ErrorMessage("Invalid header for .g6 file.\n");
+            gp_ErrorMessage("Invalid header for .g6 file.");
 
         return NOTOK;
     }
@@ -399,7 +398,7 @@ int _g6_ValidateFirstChar(char c, const int lineNum)
     if (strchr(":;&", c) != NULL)
     {
         gp_ErrorMessage("Invalid first character on line %d, i.e. one of ':', "
-                        "';', or '&'; aborting.\n",
+                        "';', or '&'.",
                         lineNum);
 
         return NOTOK;
@@ -415,7 +414,7 @@ int _g6_DetermineOrderFromInput(strOrFileP inputContainer, int *order)
 
     if (inputContainer == NULL)
     {
-        gp_ErrorMessage("Invalid string-or-file container for .g6 input.\n");
+        gp_ErrorMessage("Invalid string-or-file container for .g6 input.");
         return NOTOK;
     }
 
@@ -426,8 +425,8 @@ int _g6_DetermineOrderFromInput(strOrFileP inputContainer, int *order)
     {
         if ((graphChar = sf_getc(inputContainer)) == 126)
         {
-            gp_ErrorMessage("Graphs of order n > 100000 are not supported at this "
-                            "time.\n");
+            gp_ErrorMessage("Graphs of order n > 100000 are not supported at "
+                            "this time.");
             return NOTOK;
         }
 
@@ -441,7 +440,7 @@ int _g6_DetermineOrderFromInput(strOrFileP inputContainer, int *order)
 
         if (n > 100000)
         {
-            gp_ErrorMessage("Graph order greater than 100000 not supported.\n");
+            gp_ErrorMessage("Graph order greater than 100000 not supported.");
             return NOTOK;
         }
     }
@@ -449,8 +448,8 @@ int _g6_DetermineOrderFromInput(strOrFileP inputContainer, int *order)
         n = graphChar - 63;
     else
     {
-        gp_ErrorMessage("Graph order is too small; character doesn't correspond "
-                        "to a printable ASCII character.\n");
+        gp_ErrorMessage("Graph order is too small; character doesn't "
+                        "correspond to a printable ASCII character.");
         return NOTOK;
     }
 
@@ -474,7 +473,7 @@ int g6_ReadGraph(G6ReadIteratorP theG6ReadIterator)
 
     if (!_g6_IsReaderInitialized(theG6ReadIterator, TRUE))
     {
-        gp_ErrorMessage("G6ReadIterator is not initialized.\n");
+        gp_ErrorMessage("G6ReadIterator is not initialized.");
         return NOTOK;
     }
 
@@ -499,7 +498,7 @@ int g6_ReadGraph(G6ReadIteratorP theG6ReadIterator)
         // longer than the line should have been, i.e. orderOffset + numCharsForGraphRepr
         if ((int)strlen(currGraphBuff) != (((lineNum == 1) ? 0 : numCharsForOrder) + numCharsForGraphEncoding))
         {
-            gp_ErrorMessage("Invalid line length read on line %d\n",
+            gp_ErrorMessage("Invalid line length read on line %d",
                             lineNum);
             return NOTOK;
         }
@@ -508,7 +507,7 @@ int g6_ReadGraph(G6ReadIteratorP theG6ReadIterator)
         {
             if (_g6_ValidateOrderOfEncodedGraph(currGraphBuff, order) != OK)
             {
-                gp_ErrorMessage("Order of graph on line %d is incorrect.\n",
+                gp_ErrorMessage("Order of graph on line %d is incorrect.",
                                 lineNum);
                 return NOTOK;
             }
@@ -536,7 +535,7 @@ int g6_ReadGraph(G6ReadIteratorP theG6ReadIterator)
         if (_g6_DecodeGraph(graphEncodingChars, order, numCharsForGraphEncoding, currGraph) != OK)
         {
             gp_ErrorMessage("Unable to interpret bits on line %d to populate "
-                            "adjacency matrix.\n",
+                            "adjacency matrix.",
                             lineNum);
             return NOTOK;
         }
@@ -569,8 +568,8 @@ int _g6_DecodeGraph(char *graphBuff, const int order, const int numChars, graphP
 
     if (theGraph == NULL)
     {
-        gp_ErrorMessage("Must initialize graph datastructure before decoding the "
-                        "graph representation.\n");
+        gp_ErrorMessage("Must initialize graph datastructure before decoding "
+                        "the graph representation.");
         return NOTOK;
     }
 
@@ -639,18 +638,16 @@ int _g6_ReadGraphFromFile(graphP theGraph, char *pathToG6File)
 
     if (pathToG6File == NULL || strlen(pathToG6File) == 0)
     {
-        gp_ErrorMessage(
-            "Unable to read graph from file, as pathToG6File is NULL "
-            "or empty string.\n");
+        gp_ErrorMessage("Unable to read graph from file, as pathToG6File is "
+                        "NULL or empty string.");
         return NOTOK;
     }
 
     if ((inputContainer = sf_NewInputContainer(NULL, pathToG6File)) == NULL)
     {
         gp_ErrorMessage("Unable to allocate strOrFile container for infile "
-                        "\"%.*s\".\n",
+                        "\"%.*s\".",
                         FILENAME_MAX, pathToG6File);
-
         return NOTOK;
     }
 
@@ -663,14 +660,14 @@ int _g6_ReadGraphFromString(graphP theGraph, char *g6EncodedString)
 
     if (g6EncodedString == NULL || strlen(g6EncodedString) == 0)
     {
-        gp_ErrorMessage("Unable to proceed with empty .g6 input string.\n");
+        gp_ErrorMessage("Unable to proceed with empty .g6 input string.");
         return NOTOK;
     }
 
     if ((inputContainer = sf_NewInputContainer(g6EncodedString, NULL)) == NULL)
     {
-        gp_ErrorMessage(
-            "Unable to allocate strOrFile container for .g6 input string.\n");
+        gp_ErrorMessage("Unable to allocate strOrFile container for .g6 input "
+                        "string.");
         return NOTOK;
     }
 
@@ -683,13 +680,13 @@ int _g6_ReadGraphFromStrOrFile(graphP theGraph, strOrFileP *pInputContainer)
 
     if (!sf_IsValidStrOrFile((*pInputContainer)))
     {
-        gp_ErrorMessage("Invalid G6 output container.\n");
+        gp_ErrorMessage("Invalid G6 output container.");
         return NOTOK;
     }
 
     if (g6_NewReader((&theG6ReadIterator), theGraph) != OK)
     {
-        gp_ErrorMessage("Unable to allocate G6ReadIterator.\n");
+        gp_ErrorMessage("Unable to allocate G6ReadIterator.");
         return NOTOK;
     }
 
@@ -697,15 +694,13 @@ int _g6_ReadGraphFromStrOrFile(graphP theGraph, strOrFileP *pInputContainer)
     // since the read iterator will take ownership of the input container.
     if (_g6_InitReaderWithStrOrFile(theG6ReadIterator, pInputContainer) != OK)
     {
-        gp_ErrorMessage("Unable to initialize G6ReadIterator.\n");
-
+        gp_ErrorMessage("Unable to initialize G6ReadIterator.");
         g6_FreeReader((&theG6ReadIterator));
-
         return NOTOK;
     }
 
     if (g6_ReadGraph(theG6ReadIterator) != OK)
-        gp_ErrorMessage("Unable to read graph from .g6 read iterator.\n");
+        gp_ErrorMessage("Unable to read graph from .g6 read iterator.");
 
     g6_FreeReader((&theG6ReadIterator));
 

--- a/c/graphLib/io/g6-write-iterator.c
+++ b/c/graphLib/io/g6-write-iterator.c
@@ -70,14 +70,15 @@ int g6_NewWriter(G6WriteIteratorP *pG6WriteIterator, graphP theGraph)
 
     if (pG6WriteIterator != NULL && (*pG6WriteIterator) != NULL)
     {
-        gp_ErrorMessage("G6WriteIterator is not NULL and therefore can't be allocated.\n");
+        gp_ErrorMessage("G6WriteIterator is not NULL and therefore can't be "
+                        "allocated.");
         return NOTOK;
     }
 
     if (theGraph == NULL || gp_GetN(theGraph) <= 0)
     {
-        gp_ErrorMessage("Must allocate and initialize graph with an order greater "
-                        "than 0 to use the G6WriteIterator.\n");
+        gp_ErrorMessage("Must allocate and initialize graph with an order "
+                        "greater than 0 to use the G6WriteIterator.");
 
         return NOTOK;
     }
@@ -88,7 +89,7 @@ int g6_NewWriter(G6WriteIteratorP *pG6WriteIterator, graphP theGraph)
 
     if ((*pG6WriteIterator) == NULL)
     {
-        gp_ErrorMessage("Unable to allocate memory for G6WriteIterator.\n");
+        gp_ErrorMessage("Unable to allocate memory for G6WriteIterator.");
         return NOTOK;
     }
 
@@ -107,7 +108,7 @@ int _g6_IsWriterInitialized(G6WriteIteratorP theG6WriteIterator, int reportUnini
     if (theG6WriteIterator == NULL)
     {
         if (reportUninitializedParts)
-            gp_ErrorMessage("G6WriteIterator is NULL.\n");
+            gp_ErrorMessage("G6WriteIterator is NULL.");
         writerIsInitialized = FALSE;
     }
     else
@@ -115,25 +116,26 @@ int _g6_IsWriterInitialized(G6WriteIteratorP theG6WriteIterator, int reportUnini
         if (!sf_IsValidStrOrFile(theG6WriteIterator->outputContainer))
         {
             if (reportUninitializedParts)
-                gp_ErrorMessage("G6WriteIterator's outputContainer is not valid.\n");
+                gp_ErrorMessage("G6WriteIterator's outputContainer is not "
+                                "valid.");
             writerIsInitialized = FALSE;
         }
         if (theG6WriteIterator->currGraphBuff == NULL)
         {
             if (reportUninitializedParts)
-                gp_ErrorMessage("G6WriteIterator's currGraphBuff is NULL.\n");
+                gp_ErrorMessage("G6WriteIterator's currGraphBuff is NULL.");
             writerIsInitialized = FALSE;
         }
         if (theG6WriteIterator->columnOffsets == NULL)
         {
             if (reportUninitializedParts)
-                gp_ErrorMessage("G6WriteIterator's columnOffsets is NULL.\n");
+                gp_ErrorMessage("G6WriteIterator's columnOffsets is NULL.");
             writerIsInitialized = FALSE;
         }
         if (theG6WriteIterator->currGraph == NULL)
         {
             if (reportUninitializedParts)
-                gp_ErrorMessage("G6WriteIterator's currGraph is NULL.\n");
+                gp_ErrorMessage("G6WriteIterator's currGraph is NULL.");
             writerIsInitialized = FALSE;
         }
         else
@@ -141,9 +143,8 @@ int _g6_IsWriterInitialized(G6WriteIteratorP theG6WriteIterator, int reportUnini
             if (gp_GetN(theG6WriteIterator->currGraph) == 0)
             {
                 if (reportUninitializedParts)
-                    gp_ErrorMessage(
-                        "G6WriteIterator's currGraph does not contain a valid "
-                        "graph.\n");
+                    gp_ErrorMessage("G6WriteIterator's currGraph does not "
+                                    "contain a valid graph.");
                 writerIsInitialized = FALSE;
             }
         }
@@ -158,7 +159,8 @@ int g6_InitWriterWithString(G6WriteIteratorP theG6WriteIterator, char **pOutputS
 
     if (theG6WriteIterator == NULL)
     {
-        gp_ErrorMessage("Invalid parameter: theG6WriteIterator must be non-NULL.\n");
+        gp_ErrorMessage("Invalid parameter: theG6WriteIterator must be "
+                        "non-NULL.");
         return NOTOK;
     }
 
@@ -166,31 +168,29 @@ int g6_InitWriterWithString(G6WriteIteratorP theG6WriteIterator, char **pOutputS
     {
         gp_ErrorMessage(
             "Unable to initialize writer, as it was already previously "
-            "initialized.\n");
+            "initialized.");
         return NOTOK;
     }
 
     if (pOutputString == NULL)
     {
-        gp_ErrorMessage(
-            "Unable to initialize writer with string, as pointer to which to "
-            "assign address of output string is NULL.\n");
+        gp_ErrorMessage("Unable to initialize writer with string, as pointer "
+                        "to which to assign address of output string is NULL.");
         return NOTOK;
     }
 
     if ((*pOutputString) != NULL)
     {
-        gp_ErrorMessage(
-            "Unable to initialize writer with string, as pointer to which to "
-            "assign address of output string points to allocated memory.\n");
+        gp_ErrorMessage("Unable to initialize writer with string, as pointer "
+                        "to which to assign address of output string points to "
+                        "allocated memory.");
         return NOTOK;
     }
 
     if ((outputContainer = sf_NewOutputContainer(pOutputString, NULL)) == NULL)
     {
-        gp_ErrorMessage(
-            "Unable to initialize writer with string, as we failed to allocate "
-            "the outputContainer.\n");
+        gp_ErrorMessage("Unable to initialize writer with string, as we failed "
+                        "to allocate the outputContainer.");
         return NOTOK;
     }
 
@@ -205,31 +205,29 @@ int g6_InitWriterWithFileName(G6WriteIteratorP theG6WriteIterator, char *outputF
 
     if (theG6WriteIterator == NULL)
     {
-        gp_ErrorMessage("Invalid parameter: theG6WriteIterator must be non-NULL.\n");
+        gp_ErrorMessage("Invalid parameter: theG6WriteIterator must be "
+                        "non-NULL.");
         return NOTOK;
     }
 
     if (_g6_IsWriterInitialized(theG6WriteIterator, FALSE))
     {
-        gp_ErrorMessage(
-            "Unable to initialize writer, as it was already previously "
-            "initialized.\n");
+        gp_ErrorMessage("Unable to initialize writer, as it was already "
+                        "previously initialized.");
         return NOTOK;
     }
 
     if (outputFileName == NULL || strlen(outputFileName) == 0)
     {
-        gp_ErrorMessage(
-            "Unable to initialize writer with NULL or empty output file "
-            "name.\n");
+        gp_ErrorMessage("Unable to initialize writer with NULL or empty output "
+                        "file name.");
         return NOTOK;
     }
 
     if ((outputContainer = sf_NewOutputContainer(NULL, outputFileName)) == NULL)
     {
-        gp_ErrorMessage(
-            "Unable to initialize writer with file name, as we failed to "
-            "allocate the outputContainer.\n");
+        gp_ErrorMessage("Unable to initialize writer with file name, as we "
+                        "failed to allocate the outputContainer.");
         return NOTOK;
     }
 
@@ -242,22 +240,22 @@ int _g6_InitWriterWithStrOrFile(G6WriteIteratorP theG6WriteIterator, strOrFileP 
 {
     if (theG6WriteIterator == NULL)
     {
-        gp_ErrorMessage("Invalid parameter: theG6WriteIterator must be non-NULL.\n");
+        gp_ErrorMessage("Invalid parameter: theG6WriteIterator must be "
+                        "non-NULL.");
         return NOTOK;
     }
 
     if (_g6_IsWriterInitialized(theG6WriteIterator, FALSE))
     {
-        gp_ErrorMessage(
-            "Unable to initialize writer, as it was already previously "
-            "initialized.\n");
+        gp_ErrorMessage("Unable to initialize writer, as it was already "
+                        "previously initialized.");
         return NOTOK;
     }
 
     if (!sf_IsValidStrOrFile((*pOutputContainer)))
     {
         gp_ErrorMessage("Unable to initialize writer with invalid strOrFile "
-                        "output container.\n");
+                        "output container.");
         return NOTOK;
     }
 
@@ -279,15 +277,14 @@ int _g6_InitWriter(G6WriteIteratorP theG6WriteIterator)
     if (theG6WriteIterator->order > 100000)
     {
         gp_ErrorMessage("Graphs of order n > 100000 are not supported at this "
-                        "time.\n");
+                        "time.");
         return NOTOK;
     }
 
     if (sf_fputs(g6Header, theG6WriteIterator->outputContainer) < 0)
     {
-        gp_ErrorMessage(
-            "Unable to initialize writer due to failure to fputs header to "
-            "outputContainer.\n");
+        gp_ErrorMessage("Unable to initialize writer due to failure to fputs "
+                        "header to outputContainer.");
         return NOTOK;
     }
 
@@ -295,8 +292,8 @@ int _g6_InitWriter(G6WriteIteratorP theG6WriteIterator)
 
     if (theG6WriteIterator->columnOffsets == NULL)
     {
-        gp_ErrorMessage("Unable to initialize writer due to failure to allocate "
-                        "memory for column offsets.\n");
+        gp_ErrorMessage("Unable to initialize writer due to failure to "
+                        "allocate memory for column offsets.");
         return NOTOK;
     }
 
@@ -311,8 +308,8 @@ int _g6_InitWriter(G6WriteIteratorP theG6WriteIterator)
 
     if (theG6WriteIterator->currGraphBuff == NULL)
     {
-        gp_ErrorMessage("Unable to initialize writer due to failure to allocate "
-                        "memory for currGraphBuff.\n");
+        gp_ErrorMessage("Unable to initialize writer due to failure to "
+                        "allocate memory for currGraphBuff.");
         return NOTOK;
     }
 
@@ -328,7 +325,8 @@ void _g6_PrecomputeColumnOffsets(size_t *columnOffsets, int order)
 {
     if (columnOffsets == NULL)
     {
-        gp_ErrorMessage("Must allocate columnOffsets memory before precomputation.\n");
+        gp_ErrorMessage("Must allocate columnOffsets memory before "
+                        "precomputation.");
         return;
     }
 
@@ -343,7 +341,8 @@ int g6_WriteGraph(G6WriteIteratorP theG6WriteIterator)
     char *graphEncodingChars = NULL;
     if (!_g6_IsWriterInitialized(theG6WriteIterator, TRUE))
     {
-        gp_ErrorMessage("Unable to write graph because G6WriteIterator is not initialized.\n");
+        gp_ErrorMessage("Unable to write graph because G6WriteIterator is not "
+                        "initialized.");
         return NOTOK;
     }
 
@@ -351,20 +350,23 @@ int g6_WriteGraph(G6WriteIteratorP theG6WriteIterator)
 
     if (_g6_ValidateOrderOfEncodedGraph(theG6WriteIterator->currGraphBuff, theG6WriteIterator->order) != OK)
     {
-        gp_ErrorMessage("Unable to write graph, as constructed encoding has incorrect order.\n");
+        gp_ErrorMessage("Unable to write graph, as constructed encoding has "
+                        "incorrect order.");
         return NOTOK;
     }
 
     graphEncodingChars = theG6WriteIterator->currGraphBuff + theG6WriteIterator->numCharsForOrder;
     if (_g6_ValidateGraphEncoding(graphEncodingChars, theG6WriteIterator->order, theG6WriteIterator->numCharsForGraphEncoding) != OK)
     {
-        gp_ErrorMessage("Unable to write graph, as constructed encoding is invalid.\n");
+        gp_ErrorMessage("Unable to write graph, as constructed encoding is "
+                        "invalid.");
         return NOTOK;
     }
 
     if (_g6_WriteEncodedGraph(theG6WriteIterator) != OK)
     {
-        gp_ErrorMessage("Unable to write g6 encoded graph to output container.\n");
+        gp_ErrorMessage("Unable to write g6 encoded graph to output "
+                        "container.");
         return NOTOK;
     }
 
@@ -503,13 +505,13 @@ int _g6_WriteEncodedGraph(G6WriteIteratorP theG6WriteIterator)
 {
     if (sf_fputs(theG6WriteIterator->currGraphBuff, theG6WriteIterator->outputContainer) < 0)
     {
-        gp_ErrorMessage("Failed to output all characters of g6 encoding.\n");
+        gp_ErrorMessage("Failed to output all characters of g6 encoding.");
         return NOTOK;
     }
 
     if (sf_fputs("\n", theG6WriteIterator->outputContainer) < 0)
     {
-        gp_ErrorMessage("Failed to put line terminator after g6 encoding.\n");
+        gp_ErrorMessage("Failed to put line terminator after g6 encoding.");
         return NOTOK;
     }
 
@@ -556,14 +558,14 @@ int _g6_WriteGraphToFile(graphP theGraph, char *g6OutputFileName)
 
     if (g6OutputFileName == NULL || strlen(g6OutputFileName) == 0)
     {
-        gp_ErrorMessage(
-            "Unable to write graph to file, as output file name supplied is "
-            "NULL or empty.\n");
+        gp_ErrorMessage("Unable to write graph to file, as output file name "
+                        "supplied is NULL or empty.");
         return NOTOK;
     }
     if ((outputContainer = sf_NewOutputContainer(NULL, g6OutputFileName)) == NULL)
     {
-        gp_ErrorMessage("Unable to allocate outputContainer to which to write.\n");
+        gp_ErrorMessage("Unable to allocate outputContainer to which to "
+                        "write.");
         return NOTOK;
     }
 
@@ -578,7 +580,7 @@ int _g6_WriteGraphToString(graphP theGraph, char **pOutputStr)
     {
         gp_ErrorMessage("If writing G6 to string, must provide pointer-pointer "
                         "to allow _g6_WriteGraphToString() to assign the "
-                        "address of the output string.\n");
+                        "address of the output string.");
         return NOTOK;
     }
 
@@ -590,7 +592,8 @@ int _g6_WriteGraphToString(graphP theGraph, char **pOutputStr)
 
     if ((outputContainer = sf_NewOutputContainer(pOutputStr, NULL)) == NULL)
     {
-        gp_ErrorMessage("Unable to allocate outputContainer to which to write.\n");
+        gp_ErrorMessage("Unable to allocate outputContainer to which to "
+                        "write.");
         return NOTOK;
     }
 
@@ -606,13 +609,13 @@ int _g6_WriteGraphToStrOrFile(graphP theGraph, strOrFileP *pOutputContainer)
 
     if (!sf_IsValidStrOrFile((*pOutputContainer)))
     {
-        gp_ErrorMessage("Invalid G6 output container.\n");
+        gp_ErrorMessage("Invalid G6 output container.");
         return NOTOK;
     }
 
     if (g6_NewWriter((&theG6WriteIterator), theGraph) != OK)
     {
-        gp_ErrorMessage("Unable to allocate G6WriteIterator.\n");
+        gp_ErrorMessage("Unable to allocate G6WriteIterator.");
         g6_FreeWriter((&theG6WriteIterator));
         return NOTOK;
     }
@@ -621,14 +624,14 @@ int _g6_WriteGraphToStrOrFile(graphP theGraph, strOrFileP *pOutputContainer)
     // since the write iterator will take ownership of the output container.
     if (_g6_InitWriterWithStrOrFile(theG6WriteIterator, pOutputContainer) != OK)
     {
-        gp_ErrorMessage("Unable to initialize G6WriteIterator.\n");
+        gp_ErrorMessage("Unable to initialize G6WriteIterator.");
         g6_FreeWriter((&theG6WriteIterator));
         return NOTOK;
     }
 
     if (g6_WriteGraph(theG6WriteIterator) != OK)
     {
-        gp_ErrorMessage("Unable to write graph using G6WriteIterator.\n");
+        gp_ErrorMessage("Unable to write graph using G6WriteIterator.");
         g6_FreeWriter((&theG6WriteIterator));
         return NOTOK;
     }

--- a/c/graphLib/lowLevelUtils/apiutils.c
+++ b/c/graphLib/lowLevelUtils/apiutils.c
@@ -27,26 +27,33 @@ void gp_SetQuietMode(unsigned newQuietMode)
     quietMode = newQuietMode;
 }
 
-void gp_Message(char const *message, ...)
+void gp_Message(const char *message, ...)
 {
-    va_list args;
     if (!(gp_GetQuietMode() & QUIETMODE_MESSAGES))
     {
+        va_list args;
+
         va_start(args, message);
         vfprintf(stdout, message, args);
         va_end(args);
+
         fflush(stdout);
     }
 }
 
-void gp_ErrorMessage(char const *message, ...)
+void gp_LogErrorMessage(int line, const char *sourceFileName, const char *message, ...)
 {
-    va_list args;
     if (!(gp_GetQuietMode() & QUIETMODE_ERRORS))
     {
+        va_list args;
+
+        fprintf(stderr, "[ERROR] ");
+
         va_start(args, message);
         vfprintf(stderr, message, args);
         va_end(args);
+
+        fprintf(stderr, "\n\ton line %d of '%s'\n", line, sourceFileName);
         fflush(stderr);
     }
 }

--- a/c/graphLib/lowLevelUtils/apiutils.c
+++ b/c/graphLib/lowLevelUtils/apiutils.c
@@ -43,6 +43,22 @@ void gp_Message(const char *message, ...)
     }
 }
 
+void gp_MessagePrompt(const char *message, ...)
+{
+    if (!(gp_GetQuietMode() & QUIETMODE_MESSAGES))
+    {
+        va_list args;
+
+        va_start(args, message);
+        vfprintf(stdout, message, args);
+        va_end(args);
+
+        fprintf(stdout, " ");
+
+        fflush(stdout);
+    }
+}
+
 void gp_LogErrorMessage(int lineNum, const char *srcFileName, const char *message, ...)
 {
     if (!(gp_GetQuietMode() & QUIETMODE_ERRORS))

--- a/c/graphLib/lowLevelUtils/apiutils.c
+++ b/c/graphLib/lowLevelUtils/apiutils.c
@@ -37,11 +37,13 @@ void gp_Message(const char *message, ...)
         vfprintf(stdout, message, args);
         va_end(args);
 
+        fprintf(stdout, "\n");
+
         fflush(stdout);
     }
 }
 
-void gp_LogErrorMessage(int line, const char *sourceFileName, const char *message, ...)
+void gp_LogErrorMessage(int lineNum, const char *srcFileName, const char *message, ...)
 {
     if (!(gp_GetQuietMode() & QUIETMODE_ERRORS))
     {
@@ -53,7 +55,11 @@ void gp_LogErrorMessage(int line, const char *sourceFileName, const char *messag
         vfprintf(stderr, message, args);
         va_end(args);
 
-        fprintf(stderr, "\n\ton line %d of '%s'\n", line, sourceFileName);
+        if (lineNum > 0 && srcFileName != NULL)
+            fprintf(stderr, "\n\ton line %d of '%s'", lineNum, srcFileName);
+
+        fprintf(stderr, "\n");
+
         fflush(stderr);
     }
 }

--- a/c/graphLib/lowLevelUtils/apiutils.h
+++ b/c/graphLib/lowLevelUtils/apiutils.h
@@ -49,8 +49,10 @@ extern "C"
 #define QUIETMODE_MESSAGES 2
 #define QUIETMODE_ALL 0XFFFFFFFF
 
-    void gp_Message(char const *message, ...) FORMAT_PRINTF(1, 2);
-    void gp_ErrorMessage(char const *message, ...) FORMAT_PRINTF(1, 2);
+    void gp_Message(const char *message, ...) FORMAT_PRINTF(1, 2);
+
+#define gp_ErrorMessage(...) (gp_LogErrorMessage(__LINE__, __FILE__, __VA_ARGS__))
+    void gp_LogErrorMessage(int line, const char *sourceFileName, const char *message, ...) FORMAT_PRINTF(3, 4);
 
 #ifdef __cplusplus
 }

--- a/c/graphLib/lowLevelUtils/apiutils.h
+++ b/c/graphLib/lowLevelUtils/apiutils.h
@@ -50,6 +50,7 @@ extern "C"
 #define QUIETMODE_ALL 0XFFFFFFFF
 
     void gp_Message(const char *message, ...) FORMAT_PRINTF(1, 2);
+    void gp_MessagePrompt(const char *message, ...) FORMAT_PRINTF(1, 2);
 
 #define gp_ErrorMessage(...) (gp_LogErrorMessage(__LINE__, __FILE__, __VA_ARGS__))
     void gp_LogErrorMessage(int lineNum, const char *srcFileName, const char *message, ...) FORMAT_PRINTF(3, 4);

--- a/c/graphLib/lowLevelUtils/apiutils.h
+++ b/c/graphLib/lowLevelUtils/apiutils.h
@@ -52,7 +52,7 @@ extern "C"
     void gp_Message(const char *message, ...) FORMAT_PRINTF(1, 2);
 
 #define gp_ErrorMessage(...) (gp_LogErrorMessage(__LINE__, __FILE__, __VA_ARGS__))
-    void gp_LogErrorMessage(int line, const char *sourceFileName, const char *message, ...) FORMAT_PRINTF(3, 4);
+    void gp_LogErrorMessage(int lineNum, const char *srcFileName, const char *message, ...) FORMAT_PRINTF(3, 4);
 
 #ifdef __cplusplus
 }

--- a/c/planarityApp/planarityCommandLine.c
+++ b/c/planarityApp/planarityCommandLine.c
@@ -227,9 +227,9 @@ int runQuickRegressionTests(int argc, char *argv[])
 
     // All done.
     if (retVal == OK)
-        gp_Message("============\nAll tests have succeeded.");
+        gp_Message("============\n\nAll tests have succeeded.");
     else
-        gp_Message("============\nOne or more tests FAILED.");
+        gp_Message("============\n\nOne or more tests FAILED.");
 
     chdir(origDir);
     FlushConsole(stdout);
@@ -242,7 +242,7 @@ int runSpecificGraphTests(void)
     int retVal = OK;
 
 #ifdef USE_1BASEDARRAYS
-    gp_Message("\n\tStarting 1-based Array Index Tests");
+    gp_Message("\n\tStarting 1-based Array Index Tests\n");
 
     if (runSpecificGraphTest("-p", "maxPlanar5.txt", TRUE) != OK)
     {
@@ -292,7 +292,7 @@ int runSpecificGraphTests(void)
         retVal = NOTOK;
     }
 
-    gp_Message("\tFinished 1-based Array Index Tests.");
+    gp_Message("\tFinished 1-based Array Index Tests.\n");
 #endif
 
     if (runSpecificGraphTest("-p", "maxPlanar5.0-based.txt", FALSE) != OK)
@@ -568,6 +568,8 @@ int runTestAllGraphsTest(char const *commandString, char const *infileName)
             Result = strstr(outputStr, theValidationStr) ? OK : NOTOK;
     }
 
+    gp_Message(" ");
+
     if (outputStr != NULL)
     {
         free(outputStr);
@@ -668,7 +670,7 @@ int runSpecificGraphTest(char const *commandString, char const *infileName, int 
         }
     }
 
-    gp_Message("");
+    gp_Message(" ");
 
     if (inputString != NULL)
     {
@@ -785,7 +787,7 @@ int runGraphTransformationTest(char const *command, char const *infileName, int 
         }
     }
 
-    gp_Message("");
+    gp_Message(" ");
 
     if (inputString != NULL)
     {

--- a/c/planarityApp/planarityCommandLine.c
+++ b/c/planarityApp/planarityCommandLine.c
@@ -78,7 +78,8 @@ int commandLine(int argc, char *argv[])
 
     else
     {
-        gp_ErrorMessage("Unsupported command line.  Here is the help for this program.\n");
+        gp_ErrorMessage("Unsupported command line.  Here is the help for this "
+                        "program.");
         helpMessage(NULL);
         Result = NOTOK;
     }
@@ -95,7 +96,7 @@ int commandLine(int argc, char *argv[])
     fflush(stdout);
     if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
     {
-        gp_ErrorMessage("Unable to fetch from stdin; exiting.\n");
+        gp_ErrorMessage("Unable to fetch from stdin; exiting.");
         Result = NOTOK;
     }
 #endif
@@ -116,7 +117,7 @@ int legacyCommandLine(int argc, char *argv[])
 
     if (theGraph == NULL)
     {
-        gp_ErrorMessage("Unable to allocate memory for theGraph.\n");
+        gp_ErrorMessage("Unable to allocate memory for theGraph.");
         Result = NOTOK;
     }
 
@@ -137,10 +138,10 @@ int legacyCommandLine(int argc, char *argv[])
         if (Result == OK)
         {
             if ((Result = gp_SortVertices(theGraph)) != OK)
-                gp_ErrorMessage("Failed to restore original vertex labelling.\n");
+                gp_ErrorMessage("Failed to restore original vertex labelling.");
 
             if (Result == OK && (Result = gp_Write(theGraph, argv[2], WRITE_ADJLIST)) != OK)
-                gp_ErrorMessage("Failed to write embedding.\n");
+                gp_ErrorMessage("Failed to write embedding.");
         }
 
         else if (Result == NONEMBEDDABLE)
@@ -148,10 +149,11 @@ int legacyCommandLine(int argc, char *argv[])
             if (argc >= 5 && strcmp(argv[3], "-n") == 0)
             {
                 if ((Result = gp_SortVertices(theGraph)) != OK)
-                    gp_ErrorMessage("Failed to restore original vertex labelling.\n");
+                    gp_ErrorMessage("Failed to restore original vertex "
+                                    "labelling.");
 
                 if (Result == OK && (Result = gp_Write(theGraph, argv[4], WRITE_ADJLIST)) != OK)
-                    gp_ErrorMessage("Failed to write obstruction.\n");
+                    gp_ErrorMessage("Failed to write obstruction.");
             }
         }
         else
@@ -196,7 +198,8 @@ int runQuickRegressionTests(int argc, char *argv[])
             if (chdir("..") != 0 || chdir(samplesDir) != 0)
             {
                 // Give success result, but Warn if no samples (except no warning if in quiet mode)
-                gp_Message("WARNING: Unable to change to samples directory to run tests on samples.\n");
+                gp_Message("WARNING: Unable to change to samples directory to "
+                           "run tests on samples.");
                 chdir(origDir);
 
                 return OK;
@@ -208,7 +211,8 @@ int runQuickRegressionTests(int argc, char *argv[])
         // New behavior if samplesDir command-line parameter was specified
         if (chdir(samplesDir) != 0)
         {
-            gp_Message("WARNING: Unable to change to samples directory to run tests on samples.\n");
+            gp_Message("WARNING: Unable to change to samples directory to run "
+                       "tests on samples.");
 
             return OK;
         }
@@ -223,9 +227,9 @@ int runQuickRegressionTests(int argc, char *argv[])
 
     // All done.
     if (retVal == OK)
-        gp_Message("============\nAll tests have succeeded.\n");
+        gp_Message("============\nAll tests have succeeded.");
     else
-        gp_Message("============\nOne or more tests FAILED.\n");
+        gp_Message("============\nOne or more tests FAILED.");
 
     chdir(origDir);
     FlushConsole(stdout);
@@ -238,104 +242,104 @@ int runSpecificGraphTests(void)
     int retVal = OK;
 
 #ifdef USE_1BASEDARRAYS
-    gp_Message("\n\tStarting 1-based Array Index Tests\n\n");
+    gp_Message("\n\tStarting 1-based Array Index Tests");
 
     if (runSpecificGraphTest("-p", "maxPlanar5.txt", TRUE) != OK)
     {
-        gp_ErrorMessage("Planarity test on maxPlanar5.txt failed.\n");
+        gp_ErrorMessage("Planarity test on maxPlanar5.txt failed.");
         retVal = NOTOK;
     }
 
     if (runSpecificGraphTest("-d", "maxPlanar5.txt", FALSE) != OK)
     {
-        gp_ErrorMessage("Graph drawing test maxPlanar5.txt failed.\n");
+        gp_ErrorMessage("Graph drawing test maxPlanar5.txt failed.");
         retVal = NOTOK;
     }
 
     if (runSpecificGraphTest("-d", "drawExample.txt", TRUE) != OK)
     {
-        gp_ErrorMessage("Graph drawing on drawExample.txt failed.\n");
+        gp_ErrorMessage("Graph drawing on drawExample.txt failed.");
         retVal = NOTOK;
     }
 
     if (runSpecificGraphTest("-p", "Petersen.txt", FALSE) != OK)
     {
-        gp_ErrorMessage("Planarity test on Petersen.txt failed.\n");
+        gp_ErrorMessage("Planarity test on Petersen.txt failed.");
         retVal = NOTOK;
     }
 
     if (runSpecificGraphTest("-o", "Petersen.txt", TRUE) != OK)
     {
-        gp_ErrorMessage("Outerplanarity test on Petersen.txt failed.\n");
+        gp_ErrorMessage("Outerplanarity test on Petersen.txt failed.");
         retVal = NOTOK;
     }
 
     if (runSpecificGraphTest("-2", "Petersen.txt", FALSE) != OK)
     {
-        gp_ErrorMessage("K_{2,3} search on Petersen.txt failed.\n");
+        gp_ErrorMessage("K_{2,3} search on Petersen.txt failed.");
         retVal = NOTOK;
     }
 
     if (runSpecificGraphTest("-3", "Petersen.txt", TRUE) != OK)
     {
-        gp_ErrorMessage("K_{3,3} search on Petersen.txt failed.\n");
+        gp_ErrorMessage("K_{3,3} search on Petersen.txt failed.");
         retVal = NOTOK;
     }
 
     if (runSpecificGraphTest("-4", "Petersen.txt", FALSE) != OK)
     {
-        gp_ErrorMessage("K_4 search on Petersen.txt failed.\n");
+        gp_ErrorMessage("K_4 search on Petersen.txt failed.");
         retVal = NOTOK;
     }
 
-    gp_Message("\tFinished 1-based Array Index Tests.\n\n");
+    gp_Message("\tFinished 1-based Array Index Tests.");
 #endif
 
     if (runSpecificGraphTest("-p", "maxPlanar5.0-based.txt", FALSE) != OK)
     {
-        gp_ErrorMessage("Planarity test on maxPlanar5.0-based.txt failed.\n");
+        gp_ErrorMessage("Planarity test on maxPlanar5.0-based.txt failed.");
         retVal = NOTOK;
     }
 
     if (runSpecificGraphTest("-d", "maxPlanar5.0-based.txt", TRUE) != OK)
     {
-        gp_ErrorMessage("Graph drawing test maxPlanar5.0-based.txt failed.\n");
+        gp_ErrorMessage("Graph drawing test maxPlanar5.0-based.txt failed.");
         retVal = NOTOK;
     }
 
     if (runSpecificGraphTest("-d", "drawExample.0-based.txt", FALSE) != OK)
     {
-        gp_ErrorMessage("Graph drawing on drawExample.0-based.txt failed.\n");
+        gp_ErrorMessage("Graph drawing on drawExample.0-based.txt failed.");
         retVal = NOTOK;
     }
 
     if (runSpecificGraphTest("-p", "Petersen.0-based.txt", TRUE) != OK)
     {
-        gp_ErrorMessage("Planarity test on Petersen.0-based.txt failed.\n");
+        gp_ErrorMessage("Planarity test on Petersen.0-based.txt failed.");
         retVal = NOTOK;
     }
 
     if (runSpecificGraphTest("-o", "Petersen.0-based.txt", FALSE) != OK)
     {
-        gp_ErrorMessage("Outerplanarity test on Petersen.0-based.txt failed.\n");
+        gp_ErrorMessage("Outerplanarity test on Petersen.0-based.txt failed.");
         retVal = NOTOK;
     }
 
     if (runSpecificGraphTest("-2", "Petersen.0-based.txt", TRUE) != OK)
     {
-        gp_ErrorMessage("K_{2,3} search on Petersen.0-based.txt failed.\n");
+        gp_ErrorMessage("K_{2,3} search on Petersen.0-based.txt failed.");
         retVal = NOTOK;
     }
 
     if (runSpecificGraphTest("-3", "Petersen.0-based.txt", FALSE) != OK)
     {
-        gp_ErrorMessage("K_{3,3} search on Petersen.0-based.txt failed.\n");
+        gp_ErrorMessage("K_{3,3} search on Petersen.0-based.txt failed.");
         retVal = NOTOK;
     }
 
     if (runSpecificGraphTest("-4", "Petersen.0-based.txt", TRUE) != OK)
     {
-        gp_ErrorMessage("K_4 search on Petersen.0-based.txt failed.\n");
+        gp_ErrorMessage("K_4 search on Petersen.0-based.txt failed.");
         retVal = NOTOK;
     }
 
@@ -354,42 +358,48 @@ int runGraphTransformationTests(void)
     // runGraphTransformationTest by reading file contents into string
     if (runGraphTransformationTest("-a", "nauty_example.g6", TRUE) != OK)
     {
-        gp_ErrorMessage("Transforming nauty_example.g6 file contents as string to adjacency list failed.\n");
+        gp_ErrorMessage("Transforming nauty_example.g6 file contents as string "
+                        "to adjacency list failed.");
         retVal = NOTOK;
     }
 
     // runGraphTransformationTest by reading from file
     if (runGraphTransformationTest("-a", "nauty_example.g6", FALSE) != OK)
     {
-        gp_ErrorMessage("Transforming nauty_example.g6 using file pointer to adjacency list failed.\n");
+        gp_ErrorMessage("Transforming nauty_example.g6 using file pointer to "
+                        "adjacency list failed.");
         retVal = NOTOK;
     }
 
     // runGraphTransformationTest by reading first graph from file into string
     if (runGraphTransformationTest("-a", "N5-all.g6", TRUE) != OK)
     {
-        gp_ErrorMessage("Transforming first graph in N5-all.g6 (read as string) to adjacency list failed.\n");
+        gp_ErrorMessage("Transforming first graph in N5-all.g6 (read as "
+                        "string) to adjacency list failed.");
         retVal = NOTOK;
     }
 
     // runGraphTransformationTest by reading first graph from file pointer
     if (runGraphTransformationTest("-a", "N5-all.g6", FALSE) != OK)
     {
-        gp_ErrorMessage("Transforming first graph in N5-all.g6 (read from file pointer) to adjacency list failed.\n");
+        gp_ErrorMessage("Transforming first graph in N5-all.g6 (read from file "
+                        "pointer) to adjacency list failed.");
         retVal = NOTOK;
     }
 
     // runGraphTransformationTest by reading file contents corresponding to dense graph into string
     if (runGraphTransformationTest("-a", "K10.g6", TRUE) != OK)
     {
-        gp_ErrorMessage("Transforming K10.g6 file contents as string to adjacency list failed.\n");
+        gp_ErrorMessage("Transforming K10.g6 file contents as string to "
+                        "adjacency list failed.");
         retVal = NOTOK;
     }
 
     // runGraphTransformationTest by reading dense graph from file
     if (runGraphTransformationTest("-a", "K10.g6", FALSE) != OK)
     {
-        gp_ErrorMessage("Transforming K10.g6 using file pointer to adjacency list failed.\n");
+        gp_ErrorMessage("Transforming K10.g6 using file pointer to adjacency "
+                        "list failed.");
         retVal = NOTOK;
     }
 
@@ -398,28 +408,32 @@ int runGraphTransformationTests(void)
     // runGraphTransformationTest by reading file contents into string
     if (runGraphTransformationTest("-m", "nauty_example.g6", TRUE) != OK)
     {
-        gp_ErrorMessage("Transforming nauty_example.g6 file contents as string to adjacency matrix failed.\n");
+        gp_ErrorMessage("Transforming nauty_example.g6 file contents as string "
+                        "to adjacency matrix failed.");
         retVal = NOTOK;
     }
 
     // runGraphTransformationTest by reading from file
     if (runGraphTransformationTest("-m", "nauty_example.g6", FALSE) != OK)
     {
-        gp_ErrorMessage("Transforming nauty_example.g6 using file pointer to adjacency matrix failed.\n");
+        gp_ErrorMessage("Transforming nauty_example.g6 using file pointer to "
+                        "adjacency matrix failed.");
         retVal = NOTOK;
     }
 
     // runGraphTransformationTest by reading first graph from file into string
     if (runGraphTransformationTest("-m", "N5-all.g6", TRUE) != OK)
     {
-        gp_ErrorMessage("Transforming first graph in N5-all.g6 (read as string) to adjacency matrix failed.\n");
+        gp_ErrorMessage("Transforming first graph in N5-all.g6 (read as "
+                        "string) to adjacency matrix failed.");
         retVal = NOTOK;
     }
 
     // runGraphTransformationTest by reading first graph from file pointer
     if (runGraphTransformationTest("-m", "N5-all.g6", FALSE) != OK)
     {
-        gp_ErrorMessage("Transforming first graph in N5-all.g6 (read from file pointer) to adjacency matrix failed.\n");
+        gp_ErrorMessage("Transforming first graph in N5-all.g6 (read from file "
+                        "pointer) to adjacency matrix failed.");
 
         retVal = NOTOK;
     }
@@ -427,14 +441,16 @@ int runGraphTransformationTests(void)
     // runGraphTransformationTest by reading file contents corresponding to dense graph into string
     if (runGraphTransformationTest("-m", "K10.g6", TRUE) != OK)
     {
-        gp_ErrorMessage("Transforming K10.g6 file contents as string to adjacency matrix failed.\n");
+        gp_ErrorMessage("Transforming K10.g6 file contents as string to "
+                        "adjacency matrix failed.");
         retVal = NOTOK;
     }
 
     // runGraphTransformationTest by reading dense graph from file
     if (runGraphTransformationTest("-m", "K10.g6", FALSE) != OK)
     {
-        gp_ErrorMessage("Transforming K10.g6 using file pointer to adjacency matrix failed.\n");
+        gp_ErrorMessage("Transforming K10.g6 using file pointer to adjacency "
+                        "matrix failed.");
         retVal = NOTOK;
     }
 
@@ -443,14 +459,16 @@ int runGraphTransformationTests(void)
     // runGraphTransformationTest by reading from file
     if (runGraphTransformationTest("-g", "nauty_example.g6.0-based.AdjList.out.txt", TRUE) != OK)
     {
-        gp_ErrorMessage("Transforming nauty_example.g6.0-based.AdjList.out.txt using file pointer to .g6 failed.\n");
+        gp_ErrorMessage("Transforming nauty_example.g6.0-based.AdjList.out.txt "
+                        "using file pointer to .g6 failed.");
         retVal = NOTOK;
     }
 
     // runGraphTransformationTest by reading from file
     if (runGraphTransformationTest("-g", "K10.g6.0-based.AdjList.out.txt", TRUE) != OK)
     {
-        gp_ErrorMessage("Transforming K10.g6.0-based.AdjList.out.txt using file pointer to .g6 failed.\n");
+        gp_ErrorMessage("Transforming K10.g6.0-based.AdjList.out.txt using "
+                        "file pointer to .g6 failed.");
         retVal = NOTOK;
     }
 
@@ -464,32 +482,32 @@ int runTestAllGraphsTests(void)
     // Run TestAllGraphs Tests
     if (runTestAllGraphsTest("-p", "n8.mALL.g6") != OK)
     {
-        gp_ErrorMessage("Planarity test on all graphs failed.\n");
+        gp_ErrorMessage("Planarity test on all graphs failed.");
         retVal = NOTOK;
     }
     if (runTestAllGraphsTest("-d", "n8.mALL.g6") != OK)
     {
-        gp_ErrorMessage("Planar graph drawing test on all graphs failed.\n");
+        gp_ErrorMessage("Planar graph drawing test on all graphs failed.");
         retVal = NOTOK;
     }
     if (runTestAllGraphsTest("-o", "n8.mALL.g6") != OK)
     {
-        gp_ErrorMessage("Outerplanarity test on all graphs failed.\n");
+        gp_ErrorMessage("Outerplanarity test on all graphs failed.");
         retVal = NOTOK;
     }
     if (runTestAllGraphsTest("-2", "n8.mALL.g6") != OK)
     {
-        gp_ErrorMessage("K2,3 homeomorph search test on all graphs failed.\n");
+        gp_ErrorMessage("K2,3 homeomorph search test on all graphs failed.");
         retVal = NOTOK;
     }
     if (runTestAllGraphsTest("-3", "n8.mALL.g6") != OK)
     {
-        gp_ErrorMessage("K3,3 homeomorph search test on all graphs failed.\n");
+        gp_ErrorMessage("K3,3 homeomorph search test on all graphs failed.");
         retVal = NOTOK;
     }
     if (runTestAllGraphsTest("-4", "n8.mALL.g6") != OK)
     {
-        gp_ErrorMessage("K4 homeomorph search test on all graphs failed.\n");
+        gp_ErrorMessage("K4 homeomorph search test on all graphs failed.");
         retVal = NOTOK;
     }
 
@@ -504,7 +522,8 @@ int runTestAllGraphsTest(char const *commandString, char const *infileName)
 
     if (GetCommandAndOptionalModifier(commandString, &command, &modifier) != OK)
     {
-        gp_ErrorMessage("Unable to extract command (or optional modifier) from command string.\n");
+        gp_ErrorMessage("Unable to extract command (or optional modifier) from "
+                        "command string.");
         return NOTOK;
     }
 
@@ -569,7 +588,8 @@ int runSpecificGraphTest(char const *commandString, char const *infileName, int 
 
     if (GetCommandAndOptionalModifier(commandString, &command, &modifier) != OK)
     {
-        gp_ErrorMessage("Unable to extract command (or optional modifier) from command string.\n");
+        gp_ErrorMessage("Unable to extract command (or optional modifier) from "
+                        "command string.");
         return NOTOK;
     }
 
@@ -584,7 +604,7 @@ int runSpecificGraphTest(char const *commandString, char const *infileName, int 
         inputString = ReadTextFileIntoString(infileName);
         if (inputString == NULL)
         {
-            gp_ErrorMessage("Failed to read input file into string.\n");
+            gp_ErrorMessage("Failed to read input file into string.");
             Result = NOTOK;
         }
     }
@@ -599,17 +619,18 @@ int runSpecificGraphTest(char const *commandString, char const *infileName, int 
 
     if (Result != OK && Result != NONEMBEDDABLE)
     {
-        gp_ErrorMessage("Test failed (graph processor returned failure result).\n");
+        gp_ErrorMessage("Test failed (graph processor returned failure "
+                        "result).");
         Result = NOTOK;
     }
     else
     {
         // Test that the primary actual output matches the primary expected output
         if (TextFileMatchesString(expectedPrimaryResultFileName, actualOutput) == TRUE)
-            gp_Message("Test succeeded (result equal to exemplar).\n");
+            gp_Message("Test succeeded (result equal to exemplar).");
         else
         {
-            gp_ErrorMessage("Test failed (result not equal to exemplar).\n");
+            gp_ErrorMessage("Test failed (result not equal to exemplar).");
             Result = NOTOK;
         }
     }
@@ -621,7 +642,8 @@ int runSpecificGraphTest(char const *commandString, char const *infileName, int 
 
         if (expectedSecondaryResultFileName == NULL)
         {
-            gp_ErrorMessage("Unable to allocate memory for expected secondary output file name.\n");
+            gp_ErrorMessage("Unable to allocate memory for expected secondary "
+                            "output file name.");
             Result = NOTOK;
         }
         else
@@ -629,10 +651,12 @@ int runSpecificGraphTest(char const *commandString, char const *infileName, int 
             sprintf(expectedSecondaryResultFileName, "%s%s", expectedPrimaryResultFileName, ".render.txt");
 
             if (TextFileMatchesString(expectedSecondaryResultFileName, actualOutput2) == TRUE)
-                gp_Message("Test succeeded (secondary result equal to exemplar).\n");
+                gp_Message("Test succeeded (secondary result equal to "
+                           "exemplar).");
             else
             {
-                gp_ErrorMessage("Test failed (secondary result not equal to exemplar).\n");
+                gp_ErrorMessage("Test failed (secondary result not equal to "
+                                "exemplar).");
                 Result = NOTOK;
             }
 
@@ -644,7 +668,7 @@ int runSpecificGraphTest(char const *commandString, char const *infileName, int 
         }
     }
 
-    gp_Message("\n");
+    gp_Message("");
 
     if (inputString != NULL)
     {
@@ -681,7 +705,7 @@ int runGraphTransformationTest(char const *command, char const *infileName, int 
     // input graph; it will only support "-(gam)"
     if (command == NULL || strlen(command) < 2)
     {
-        gp_ErrorMessage("runGraphTransformationTest only supports -(gam).\n");
+        gp_ErrorMessage("runGraphTransformationTest only supports -(gam).");
         return NOTOK;
     }
     else if (strlen(command) == 2)
@@ -694,7 +718,7 @@ int runGraphTransformationTest(char const *command, char const *infileName, int 
         inputString = ReadTextFileIntoString(infileName);
         if (inputString == NULL)
         {
-            gp_ErrorMessage("Failed to read input file into string.\n");
+            gp_ErrorMessage("Failed to read input file into string.");
             Result = NOTOK;
         }
     }
@@ -711,7 +735,7 @@ int runGraphTransformationTest(char const *command, char const *infileName, int 
 
         if (Result != OK || actualOutput == NULL)
         {
-            gp_ErrorMessage("Failed to perform transformation.\n");
+            gp_ErrorMessage("Failed to perform transformation.");
             Result = NOTOK;
         }
         else
@@ -722,7 +746,8 @@ int runGraphTransformationTest(char const *command, char const *infileName, int 
 
             if (Result != OK || expectedOutfileName == NULL)
             {
-                gp_ErrorMessage("Unable to construct output file name for expected transformation output.\n");
+                gp_ErrorMessage("Unable to construct output file name for "
+                                "expected transformation output.");
                 Result = NOTOK;
             }
             else
@@ -732,15 +757,15 @@ int runGraphTransformationTest(char const *command, char const *infileName, int 
                 if (Result == TRUE)
                 {
                     gp_Message("For the transformation %s on file \"%.*s\", "
-                               "actual output matched expected output file.\n",
+                               "actual output matched expected output file.",
                                command, FILENAME_MAX, infileName);
                     Result = OK;
                 }
                 else
                 {
                     gp_ErrorMessage("For the transformation %s on file \"%.*s\", "
-                                    "actual output did not match expected output "
-                                    "file.\n",
+                                    "actual output did not match expected "
+                                    "output file.",
                                     command, FILENAME_MAX, infileName);
                     Result = NOTOK;
                 }
@@ -760,7 +785,7 @@ int runGraphTransformationTest(char const *command, char const *infileName, int 
         }
     }
 
-    gp_Message("\n");
+    gp_Message("");
 
     if (inputString != NULL)
     {

--- a/c/planarityApp/planarityHelp.c
+++ b/c/planarityApp/planarityHelp.c
@@ -90,7 +90,7 @@ int helpMessage(char *param)
             "'planarity -x [-q] -(gam) I O': Transform graph to .g6 (g), Adjacency List (a), or Adjacency Matrix (m)\n"
             "'planarity I O [-n O2]': Legacy command-line (default -s -p)\n");
 
-        gp_Message("-q is for quiet mode (no messages to stdout and stderr)");
+        gp_Message("-q is for quiet mode (no messages to stdout and stderr)\n");
 
         gp_Message("%s", GetAlgorithmFlags());
 

--- a/c/planarityApp/planarityHelp.c
+++ b/c/planarityApp/planarityHelp.c
@@ -39,8 +39,7 @@ int helpMessage(char *param)
             "'planarity (-h|-help)': this message\n"
             "'planarity (-h|-help) -menu': more help with menu-based command line\n"
             "'planarity (-i|-info): copyright and license information\n"
-            "'planarity -test [-q] [samples dir]': runs tests (optional quiet mode)\n"
-            "\n");
+            "'planarity -test [-q] [samples dir]': runs tests (optional quiet mode)\n");
 
         gp_Message(
             "Common usages\n"
@@ -53,7 +52,7 @@ int helpMessage(char *param)
             "planarity -s -q -d infile.txt embedding.out [drawing.out]\n"
             "If graph in infile.txt is planar, then put embedding in embedding.out \n"
             "and (optionally) an ASCII art drawing in drawing.out\n"
-            "Process returns 0=planar, 1=nonplanar, -1=error\n");
+            "Process returns 0=planar, 1=nonplanar, -1=error");
     }
 
     else if (strcmp(param, "-i") == 0 || strcmp(param, "-info") == 0)
@@ -77,8 +76,7 @@ int helpMessage(char *param)
             "\n"
             "* John M. Boyer. \"Simplified O(n) Algorithms for Planar Graph Embedding,\n"
             "  Kuratowski Subgraph Isolation, and Related Problems\". Ph.D. Dissertation,\n"
-            "  University of Victoria, 2001. https://dspace.library.uvic.ca/handle/1828/9918\n"
-            "\n");
+            "  University of Victoria, 2001. https://dspace.library.uvic.ca/handle/1828/9918\n");
     }
 
     else if (strcmp(param, "-menu") == 0)
@@ -90,10 +88,9 @@ int helpMessage(char *param)
             "'planarity -rn [-q] N O [O2]': Random nonplanar graph (maximal planar + edge)\n"
             "'planarity -t [-q] C I O': Test algorithm on graph(s) in .g6 file\n"
             "'planarity -x [-q] -(gam) I O': Transform graph to .g6 (g), Adjacency List (a), or Adjacency Matrix (m)\n"
-            "'planarity I O [-n O2]': Legacy command-line (default -s -p)\n"
-            "\n");
+            "'planarity I O [-n O2]': Legacy command-line (default -s -p)");
 
-        gp_Message("-q is for quiet mode (no messages to stdout and stderr)\n\n");
+        gp_Message("-q is for quiet mode (no messages to stdout and stderr)");
 
         gp_Message("%s", GetAlgorithmFlags());
 
@@ -107,15 +104,14 @@ int helpMessage(char *param)
             "O2= Secondary output file\n"
             "    For -s, if C=-p or -o, then O2 receives the embedding obstruction\n"
             "    For -s, if C=-d, then O2 receives a drawing of the planar graph\n"
-            "    For -rm and -rn, O2 contains the original randomly generated graph\n"
-            "\n");
+            "    For -rm and -rn, O2 contains the original randomly generated graph");
 
         gp_Message(
             "planarity process results: 0=OK, -1=NOTOK, 1=NONEMBEDDABLE\n"
             "    1 result only produced by specific graph mode (-s)\n"
             "      with command -2,-3,-4: found K_{2,3}, K_{3,3} or K_4\n"
             "      with command -p,-d: found planarity obstruction\n"
-            "      with command -o: found outerplanarity obstruction\n");
+            "      with command -o: found outerplanarity obstruction");
     }
 
     FlushConsole(stdout);

--- a/c/planarityApp/planarityHelp.c
+++ b/c/planarityApp/planarityHelp.c
@@ -88,7 +88,7 @@ int helpMessage(char *param)
             "'planarity -rn [-q] N O [O2]': Random nonplanar graph (maximal planar + edge)\n"
             "'planarity -t [-q] C I O': Test algorithm on graph(s) in .g6 file\n"
             "'planarity -x [-q] -(gam) I O': Transform graph to .g6 (g), Adjacency List (a), or Adjacency Matrix (m)\n"
-            "'planarity I O [-n O2]': Legacy command-line (default -s -p)");
+            "'planarity I O [-n O2]': Legacy command-line (default -s -p)\n");
 
         gp_Message("-q is for quiet mode (no messages to stdout and stderr)");
 

--- a/c/planarityApp/planarityMenu.c
+++ b/c/planarityApp/planarityMenu.c
@@ -32,8 +32,8 @@ int menu(void)
 
     if (GetNumCharsToReprInt(COMMANDSTRINGMAXLENGTH, &numCharsToReprCOMMANDSTRINGMAXLENGTH) != OK)
     {
-        gp_ErrorMessage("Unable to determine number of characters required to represent COMMANDSTRINGMAXLENGTH.\n");
-
+        gp_ErrorMessage("Unable to determine number of characters required to "
+                        "represent COMMANDSTRINGMAXLENGTH.");
         Result = NOTOK;
     }
     else
@@ -41,8 +41,8 @@ int menu(void)
         choiceStringFormat = (char *)malloc((strlen(choiceStringFormatFormat) + numCharsToReprCOMMANDSTRINGMAXLENGTH + 1) * sizeof(char));
         if (choiceStringFormat == NULL)
         {
-            gp_ErrorMessage("Unable to allocate memory for choice string format string.\n");
-
+            gp_ErrorMessage("Unable to allocate memory for choice string "
+                            "format string.");
             Result = NOTOK;
         }
     }
@@ -65,17 +65,14 @@ int menu(void)
                 "T. Perform an algorithm test on all graphs in .g6 input file\n"
                 "H. Help message for command line version\n"
                 "R. Reconfigure options\n"
-                "Q. Quit\n"
-                "\n");
+                "Q. Quit");
 
             gp_Message("Enter Choice: ");
 
             if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
             {
-                gp_ErrorMessage("Unable to fetch menu choice from stdin; exiting.\n");
-
+                gp_ErrorMessage("Unable to fetch menu choice from stdin.");
                 Result = NOTOK;
-
                 break;
             }
 
@@ -84,8 +81,7 @@ int menu(void)
             if (strlen(lineBuff) == 0 || strlen(lineBuff) > 2 ||
                 sscanf(lineBuff, choiceStringFormat, choiceString) != 1)
             {
-                gp_ErrorMessage("Invalid input; please retry.\n");
-
+                gp_Message("Invalid input; please retry.");
                 continue;
             }
 #pragma GCC diagnostic pop
@@ -100,10 +96,9 @@ int menu(void)
             {
                 if (Reconfigure() != OK)
                 {
-                    gp_ErrorMessage("Encountered unrecoverable error when reconfiguring; exiting.\n");
-
+                    gp_ErrorMessage("Encountered unrecoverable error when "
+                                    "reconfiguring; exiting.");
                     Result = NOTOK;
-
                     break;
                 }
 
@@ -113,12 +108,12 @@ int menu(void)
             else if (strcmp(choiceString, "x") == 0)
             {
                 if ((Result = TransformGraphMenu()) != OK)
-                    gp_ErrorMessage("Transform Graph Menu emitted an error.\n");
+                    gp_ErrorMessage("Transform Graph Menu emitted an error.");
             }
             else if (strcmp(choiceString, "t") == 0)
             {
                 if ((Result = TestAllGraphsMenu()) != OK)
-                    gp_ErrorMessage("Test All Graphs Menu emitted an error.\n");
+                    gp_ErrorMessage("Test All Graphs Menu emitted an error.");
             }
             else if (strcmp(choiceString, "q") == 0)
                 break;
@@ -127,10 +122,9 @@ int menu(void)
                 char *commandString = choiceString;
                 if (GetCommandAndOptionalModifier(commandString, &command, NULL) != OK)
                 {
-                    gp_ErrorMessage("Unable to extract command from choice, please retry.\n");
-
+                    gp_Message("Unable to extract command from choice; "
+                               "please retry.");
                     commandString = NULL;
-
                     continue;
                 }
 
@@ -138,7 +132,8 @@ int menu(void)
                     secondOutfile = (char *)"";
 
                 if (!strchr(GetAlgorithmChoices(), command))
-                    gp_ErrorMessage("Invalid algorithm command choice, please retry.\n");
+                    gp_Message("Invalid algorithm command choice; please "
+                               "retry.");
 
                 else
                 {
@@ -165,14 +160,12 @@ int menu(void)
             gp_Message("\nPress return key to continue...");
             if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
             {
-                gp_ErrorMessage("Unable to fetch from stdin; exiting.\n");
-
+                gp_ErrorMessage("Unable to fetch from stdin; exiting.");
                 Result = NOTOK;
-
                 break;
             }
 
-            gp_Message("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
+            gp_Message("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
             FlushConsole(stdout);
         }
     }
@@ -211,16 +204,16 @@ int TransformGraphMenu(void)
 
     if (GetNumCharsToReprInt(FILENAMEMAXLENGTH, &numCharsToReprFILENAMEMAXLENGTH) != OK)
     {
-        gp_ErrorMessage("Unable to determine number of characters required to represent FILENAMEMAXLENGTH.\n");
-
+        gp_ErrorMessage("Unable to determine number of characters required to "
+                        "represent FILENAMEMAXLENGTH.");
         return NOTOK;
     }
 
     fileNameFormat = (char *)malloc((strlen(fileNameFormatFormat) + numCharsToReprFILENAMEMAXLENGTH + 1) * sizeof(char));
     if (fileNameFormat == NULL)
     {
-        gp_ErrorMessage("Unable to allocate memory for file name format string.\n");
-
+        gp_ErrorMessage("Unable to allocate memory for file name format "
+                        "string.");
         return NOTOK;
     }
 
@@ -231,13 +224,11 @@ int TransformGraphMenu(void)
 
     while (1)
     {
-        gp_Message("Enter input file name:\n");
+        gp_Message("Enter input file name:");
         if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
         {
-            gp_ErrorMessage("Unable to read input file name from stdin.\n");
-
+            gp_ErrorMessage("Unable to read input file name from stdin.");
             Result = NOTOK;
-
             break;
         }
 
@@ -246,10 +237,11 @@ int TransformGraphMenu(void)
         if (strlen(lineBuff) == 0 || strlen(lineBuff) > FILENAMEMAXLENGTH ||
             sscanf(lineBuff, fileNameFormat, infileName) != 1 ||
             strlen(infileName) == 0)
-            gp_ErrorMessage("Invalid input file name.\n");
+            gp_Message("Invalid input file name; please retry.");
         else if (strncmp(infileName, "stdin", strlen("stdin")) == 0)
         {
-            gp_ErrorMessage("\n\tPlease choose an input file path: stdin not supported from menu.\n\n");
+            gp_Message("Please retry with an input file path: stdin not "
+                       "supported from menu.");
             memset(infileName, '\0', (FILENAMEMAXLENGTH + 1));
         }
         else
@@ -261,13 +253,12 @@ int TransformGraphMenu(void)
     {
         while (1)
         {
-            gp_Message("Enter output file name, or type \"stdout\" to output to console:\n");
+            gp_Message("Enter output file name, or type \"stdout\" to output "
+                       "to console:");
             if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
             {
-                gp_ErrorMessage("Unable to read output file name from stdin.\n");
-
+                gp_ErrorMessage("Unable to read output file name from stdin.");
                 Result = NOTOK;
-
                 break;
             }
 
@@ -276,7 +267,7 @@ int TransformGraphMenu(void)
             if (strlen(lineBuff) == 0 || strlen(lineBuff) > FILENAMEMAXLENGTH ||
                 sscanf(lineBuff, fileNameFormat, outfileName) != 1 ||
                 strlen(outfileName) == 0)
-                gp_ErrorMessage("Invalid output file name.\n");
+                gp_Message("Invalid output file name; please retry.");
             else
                 break;
 #pragma GCC diagnostic pop
@@ -291,23 +282,21 @@ int TransformGraphMenu(void)
             gp_Message("Enter output format: ");
             if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
             {
-                gp_ErrorMessage("Unable to read output format from stdin.\n");
-
+                gp_ErrorMessage("Unable to read output format from stdin.");
                 Result = NOTOK;
-
                 break;
             }
 
             if (strlen(lineBuff) != 1 ||
                 sscanf(lineBuff, " %c", &outputFormat) != 1 ||
                 !strchr(GetSupportedOutputFormats(), tolower(outputFormat)))
-                gp_ErrorMessage("Invalid choice for output format.\n");
+                gp_Message("Invalid choice for output format; please "
+                           "retry.");
             else
             {
                 if (sprintf(commandStr, "-%c", (char)tolower(outputFormat)) < 1)
                 {
-                    gp_ErrorMessage("Unable to construct commandStr.\n");
-
+                    gp_ErrorMessage("Unable to construct commandStr.");
                     Result = NOTOK;
                 }
 
@@ -352,7 +341,8 @@ int TestAllGraphsMenu(void)
 
     if (GetNumCharsToReprInt(COMMANDSTRINGMAXLENGTH, &numCharsToReprCOMMANDSTRINGMAXLENGTH) != OK)
     {
-        gp_ErrorMessage("Unable to determine number of characters required to represent COMMANDSTRINGMAXLENGTH.\n");
+        gp_ErrorMessage("Unable to determine number of characters required to "
+                        "represent COMMANDSTRINGMAXLENGTH.");
 
         return NOTOK;
     }
@@ -360,7 +350,8 @@ int TestAllGraphsMenu(void)
     commandStringFormat = (char *)malloc((strlen(commandStringFormatFormat) + numCharsToReprCOMMANDSTRINGMAXLENGTH + 1) * sizeof(char));
     if (commandStringFormat == NULL)
     {
-        gp_ErrorMessage("Unable to allocate memory for command string format string.\n");
+        gp_ErrorMessage("Unable to allocate memory for command string format "
+                        "string.");
 
         return NOTOK;
     }
@@ -372,7 +363,8 @@ int TestAllGraphsMenu(void)
 
     if (GetNumCharsToReprInt(FILENAMEMAXLENGTH, &numCharsToReprFILENAMEMAXLENGTH) != OK)
     {
-        gp_ErrorMessage("Unable to determine number of characters required to represent FILENAMEMAXLENGTH.\n");
+        gp_ErrorMessage("Unable to determine number of characters required to "
+                        "represent FILENAMEMAXLENGTH.");
 
         if (commandStringFormat != NULL)
         {
@@ -386,7 +378,8 @@ int TestAllGraphsMenu(void)
     fileNameFormat = (char *)malloc((strlen(fileNameFormatFormat) + numCharsToReprFILENAMEMAXLENGTH + 1) * sizeof(char));
     if (fileNameFormat == NULL)
     {
-        gp_ErrorMessage("Unable to allocate memory for file name format string.\n");
+        gp_ErrorMessage("Unable to allocate memory for file name format "
+                        "string.");
 
         if (commandStringFormat != NULL)
         {
@@ -403,13 +396,11 @@ int TestAllGraphsMenu(void)
 
     while (1)
     {
-        gp_Message("Enter input file name:\n");
+        gp_Message("Enter input file name:");
         if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
         {
-            gp_ErrorMessage("Unable to read input file name from stdin.\n");
-
+            gp_ErrorMessage("Unable to read input file name from stdin.");
             Result = NOTOK;
-
             break;
         }
 
@@ -418,10 +409,11 @@ int TestAllGraphsMenu(void)
         if (strlen(lineBuff) == 0 || strlen(lineBuff) > FILENAMEMAXLENGTH ||
             sscanf(lineBuff, fileNameFormat, infileName) != 1 ||
             strlen(infileName) == 0)
-            gp_ErrorMessage("Invalid input file name.\n");
+            gp_Message("Invalid input file name; please retry.");
         else if (strncmp(infileName, "stdin", strlen("stdin")) == 0)
         {
-            gp_ErrorMessage("\n\tPlease choose an input file path: stdin not supported from menu.\n\n");
+            gp_Message("Please retry with an input file path: stdin not "
+                       "supported from menu.");
             memset(infileName, '\0', (FILENAMEMAXLENGTH + 1));
         }
         else
@@ -433,13 +425,11 @@ int TestAllGraphsMenu(void)
     {
         while (1)
         {
-            gp_Message("Enter output file name, or type \"stdout\" to output to console:\n");
+            gp_Message("Enter output file name, or type \"stdout\" to output to console:");
             if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
             {
-                gp_ErrorMessage("Unable to read output file name from stdin.\n");
-
+                gp_ErrorMessage("Unable to read output file name from stdin.");
                 Result = NOTOK;
-
                 break;
             }
 
@@ -448,7 +438,7 @@ int TestAllGraphsMenu(void)
             if (strlen(lineBuff) == 0 || strlen(lineBuff) > FILENAMEMAXLENGTH ||
                 sscanf(lineBuff, fileNameFormat, outfileName) != 1 ||
                 strlen(outfileName) == 0)
-                gp_ErrorMessage("Invalid output file name.\n");
+                gp_Message("Invalid output file name; please retry.");
             else
                 break;
 #pragma GCC diagnostic pop
@@ -463,10 +453,9 @@ int TestAllGraphsMenu(void)
             gp_Message("Enter algorithm specifier (with optional modifier): ");
             if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
             {
-                gp_ErrorMessage("Unable to read command and optional modifier from stdin.\n");
-
+                gp_ErrorMessage("Unable to read command and optional modifier "
+                                "from stdin.");
                 Result = NOTOK;
-
                 break;
             }
 
@@ -475,7 +464,7 @@ int TestAllGraphsMenu(void)
             if (strlen(lineBuff) == 0 || strlen(lineBuff) > 2 ||
                 sscanf(lineBuff, commandStringFormat, commandString) != 1 ||
                 strlen(commandString) == 0)
-                gp_ErrorMessage("Invalid command and optional modifier.\n");
+                gp_ErrorMessage("Invalid command and optional modifier.");
             else
                 break;
 #pragma GCC diagnostic pop

--- a/c/planarityApp/planarityMenu.c
+++ b/c/planarityApp/planarityMenu.c
@@ -65,9 +65,9 @@ int menu(void)
                 "T. Perform an algorithm test on all graphs in .g6 input file\n"
                 "H. Help message for command line version\n"
                 "R. Reconfigure options\n"
-                "Q. Quit");
+                "Q. Quit\n");
 
-            gp_Message("Enter Choice: ");
+            gp_MessagePrompt("Enter Choice:");
 
             if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
             {
@@ -165,7 +165,7 @@ int menu(void)
                 break;
             }
 
-            gp_Message("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
+            gp_Message("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
             FlushConsole(stdout);
         }
     }
@@ -224,7 +224,7 @@ int TransformGraphMenu(void)
 
     while (1)
     {
-        gp_Message("Enter input file name:");
+        gp_MessagePrompt("Enter input file name:");
         if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
         {
             gp_ErrorMessage("Unable to read input file name from stdin.");
@@ -253,8 +253,8 @@ int TransformGraphMenu(void)
     {
         while (1)
         {
-            gp_Message("Enter output file name, or type \"stdout\" to output "
-                       "to console:");
+            gp_MessagePrompt("Enter output file name, or type \"stdout\" to "
+                             "output to console:");
             if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
             {
                 gp_ErrorMessage("Unable to read output file name from stdin.");
@@ -279,7 +279,7 @@ int TransformGraphMenu(void)
         while (1)
         {
             gp_Message("%s", GetSupportedOutputChoices());
-            gp_Message("Enter output format: ");
+            gp_MessagePrompt("Enter output format:");
             if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
             {
                 gp_ErrorMessage("Unable to read output format from stdin.");
@@ -396,7 +396,7 @@ int TestAllGraphsMenu(void)
 
     while (1)
     {
-        gp_Message("Enter input file name:");
+        gp_MessagePrompt("Enter input file name:");
         if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
         {
             gp_ErrorMessage("Unable to read input file name from stdin.");
@@ -425,7 +425,8 @@ int TestAllGraphsMenu(void)
     {
         while (1)
         {
-            gp_Message("Enter output file name, or type \"stdout\" to output to console:");
+            gp_MessagePrompt("Enter output file name, or type \"stdout\" to "
+                             "output to console:");
             if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
             {
                 gp_ErrorMessage("Unable to read output file name from stdin.");
@@ -450,7 +451,8 @@ int TestAllGraphsMenu(void)
         while (1)
         {
             gp_Message("%s", GetAlgorithmSpecifiers());
-            gp_Message("Enter algorithm specifier (with optional modifier): ");
+            gp_MessagePrompt("Enter algorithm specifier (with optional "
+                             "modifier):");
             if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
             {
                 gp_ErrorMessage("Unable to read command and optional modifier "

--- a/c/planarityApp/planarityRandomGraphs.c
+++ b/c/planarityApp/planarityRandomGraphs.c
@@ -399,7 +399,7 @@ int GetNumberIfZero(int *pNum, char const *prompt, int min, int max)
 
     while (*pNum == 0)
     {
-        gp_Message("%s", prompt);
+        gp_MessagePrompt("%s", prompt);
         if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
         {
             gp_ErrorMessage("Unable to read integer choice from stdin.");
@@ -645,16 +645,20 @@ int PromptSaveGraph(graphP theGraph, graphP origGraph, int extraEdges, int saveM
     switch (saveMode)
     {
     case WRITE_ADJLIST:
-        gp_Message("Do you want to save the generated graph in adjacency list format (y/n)?");
+        gp_MessagePrompt("Do you want to save the generated graph in adjacency "
+                         "list format (y/n)?");
         break;
     case WRITE_ADJMATRIX:
-        gp_Message("Do you want to save the generated graph in adjacency matrix format (y/n)?");
+        gp_MessagePrompt("Do you want to save the generated graph in adjacency "
+                         "matrix format (y/n)?");
         break;
     case WRITE_G6:
-        gp_Message("Do you want to save the generated graph in G6 format (y/n)?");
+        gp_MessagePrompt("Do you want to save the generated graph in G6 format "
+                         "(y/n)?");
         break;
     default:
-        gp_Message("Do you want to save the generated graph in edge list format (y/n)?");
+        gp_MessagePrompt("Do you want to save the generated graph in edge list "
+                         "format (y/n)?");
         break;
     }
     // Prompt the user
@@ -705,7 +709,7 @@ int PromptSaveGraph(graphP theGraph, graphP origGraph, int extraEdges, int saveM
         break;
     }
 
-    gp_Message("Saving original graph to \"%.*s\"",
+    gp_Message("Saving edge list format of original graph to \"%.*s\"",
                FILENAME_MAX, theFileName);
     SaveAsciiGraph(origGraph, theFileName);
 

--- a/c/planarityApp/planarityRandomGraphs.c
+++ b/c/planarityApp/planarityRandomGraphs.c
@@ -41,8 +41,8 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
 
     G6WriteIteratorP theG6WriteIterator = NULL;
 
-    char const g6WriterInitializationgp_ErrorMessage[] = "Unable to write random graphs to G6 outfile \"%.*s\" due to failure initializing G6WriteIterator.\n";
-    char const writegp_ErrorMessage[] = "Failed to write graph \"%.*s\".\nMake the directory if not present\n";
+    char const g6WriterInitializationgp_ErrorMessage[] = "Unable to write random graphs to G6 outfile \"%.*s\" due to failure initializing G6WriteIterator.";
+    char const writegp_ErrorMessage[] = "Failed to write graph \"%.*s\".\nMake the directory if not present.";
 
     char theFileName[FILENAMEMAXLENGTH + 1];
 
@@ -84,10 +84,8 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
     {
         gp_ErrorMessage("Unable to allocate and initialize graph datastructures "
                         "to contain randomly generated graphs.\n");
-
         gp_Free(&theGraph);
         gp_Free(&origGraph);
-
         return NOTOK;
     }
 
@@ -95,11 +93,9 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
     {
         if (g6_NewWriter((&theG6WriteIterator), theGraph) != OK)
         {
-            gp_ErrorMessage("Unable to allocate G6WriteIterator.\n");
-
+            gp_ErrorMessage("Unable to allocate G6WriteIterator.");
             gp_Free(&theGraph);
             gp_Free(&origGraph);
-
             return NOTOK;
         }
     }
@@ -109,11 +105,9 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
         if (g6_InitWriterWithFileName(theG6WriteIterator, outfileName) != OK)
         {
             gp_ErrorMessage(g6WriterInitializationgp_ErrorMessage, FILENAME_MAX, outfileName);
-
             g6_FreeWriter((&theG6WriteIterator));
             gp_Free(&theGraph);
             gp_Free(&origGraph);
-
             return NOTOK;
         }
     }
@@ -125,7 +119,8 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
         sprintf(theFileName, "random%cn%d.k%d.g6", FILE_DELIMITER, SizeOfGraphs, NumGraphs);
         if (g6_InitWriterWithFileName(theG6WriteIterator, theFileName) != OK)
         {
-            gp_ErrorMessage(g6WriterInitializationgp_ErrorMessage, FILENAME_MAX, theFileName);
+            gp_ErrorMessage(g6WriterInitializationgp_ErrorMessage,
+                            FILENAME_MAX, theFileName);
             g6_FreeWriter((&theG6WriteIterator));
             gp_Free(&theGraph);
             gp_Free(&origGraph);
@@ -163,7 +158,7 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
                 if ((writeResult = g6_WriteGraph(theG6WriteIterator)) != OK)
                 {
                     gp_ErrorMessage("Unable to write graph number %d using "
-                                    "G6WriteIterator.\n",
+                                    "G6WriteIterator.",
                                     K);
                     Result = writeResult;
                     break;
@@ -174,7 +169,8 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
                 sprintf(theFileName, "random%c%d.txt", FILE_DELIMITER, K % 10);
                 if ((writeResult = gp_Write(theGraph, theFileName, WRITE_ADJLIST)) != OK)
                 {
-                    gp_ErrorMessage(writegp_ErrorMessage, FILENAME_MAX, theFileName);
+                    gp_ErrorMessage(writegp_ErrorMessage,
+                                    FILENAME_MAX, theFileName);
                     Result = writeResult;
                     break;
                 }
@@ -182,8 +178,8 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
 
             if ((Result = gp_CopyGraph(origGraph, theGraph)) != OK)
             {
-                gp_ErrorMessage("Unable to make a copy of graph number %d before "
-                                "embedding.\n",
+                gp_ErrorMessage("Unable to make a copy of graph number %d "
+                                "before embedding.",
                                 K);
                 gp_Free(&theGraph);
                 gp_Free(&origGraph);
@@ -277,7 +273,7 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
         // Terminate loop on error
         if (Result != OK && Result != NONEMBEDDABLE)
         {
-            gp_ErrorMessage("\nError found\n");
+            gp_ErrorMessage("\nError found");
             Result = NOTOK;
             break;
         }
@@ -303,16 +299,16 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
     fprintf(stdout, "%d\n", NumGraphs);
     fflush(stdout);
 
-    gp_Message("\nDone (%.3lf seconds).\n", platform_GetDuration(start, end));
+    gp_Message("Done (%.3lf seconds).", platform_GetDuration(start, end));
 
     // Print some demographic results
     if (Result == OK || Result == NONEMBEDDABLE)
     {
-        gp_Message("\nNo Errors Found.\n");
+        gp_Message("No Errors Found.");
         // Report statistics for planar or outerplanar embedding
         if (embedFlags == EMBEDFLAGS_PLANAR || embedFlags == EMBEDFLAGS_OUTERPLANAR)
         {
-            gp_Message("Num Embedded=%d.\n", MainStatistic);
+            gp_Message("Num Embedded=%d.", MainStatistic);
 
             for (K = 0; K < 5; K++)
             {
@@ -320,7 +316,7 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
                 if (embedFlags == EMBEDFLAGS_OUTERPLANAR && (K == 2 || K == 3))
                     continue;
 
-                gp_Message("Minor %c = %d\n", K + 'A', ObstructionMinorFreqs[K]);
+                gp_Message("Minor %c = %d", K + 'A', ObstructionMinorFreqs[K]);
             }
 
             if (!(embedFlags & ~EMBEDFLAGS_PLANAR))
@@ -330,7 +326,7 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
 
                 for (K = 5; K < NUM_MINORS; K++)
                 {
-                    gp_Message("Minor E%d = %d\n",
+                    gp_Message("Minor E%d = %d",
                                K - 4, ObstructionMinorFreqs[K]);
                 }
             }
@@ -339,26 +335,26 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
         // Report statistics for graph drawing
         else if (embedFlags == EMBEDFLAGS_DRAWPLANAR)
         {
-            gp_Message("Num Graphs Embedded and Drawn=%d.\n", MainStatistic);
+            gp_Message("Num Graphs Embedded and Drawn=%d.", MainStatistic);
         }
 
         // Report statistics for subgraph homeomorphism algorithms
         else if (embedFlags == EMBEDFLAGS_SEARCHFORK23)
         {
             gp_Message("Of the generated graphs, %d did not contain a K_{2,3} "
-                       "homeomorph as a subgraph.\n",
+                       "homeomorph as a subgraph.",
                        MainStatistic);
         }
         else if (embedFlags == EMBEDFLAGS_SEARCHFORK33)
         {
             gp_Message("Of the generated graphs, %d did not contain a K_{3,3} "
-                       "homeomorph as a subgraph.\n",
+                       "homeomorph as a subgraph.",
                        MainStatistic);
         }
         else if (embedFlags == EMBEDFLAGS_SEARCHFORK4)
         {
             gp_Message("Of the generated graphs, %d did not contain a K_4 "
-                       "homeomorph as a subgraph.\n",
+                       "homeomorph as a subgraph.",
                        MainStatistic);
         }
     }
@@ -391,13 +387,13 @@ int GetNumberIfZero(int *pNum, char const *prompt, int min, int max)
 
     if (pNum == NULL)
     {
-        gp_ErrorMessage("Unable to get number, as pointer to int is NULL.\n");
+        gp_ErrorMessage("Unable to get number, as pointer to int is NULL.");
         return NOTOK;
     }
 
     if (prompt == NULL || strlen(prompt) == 0)
     {
-        gp_ErrorMessage("Invalid prompt supplied.\n");
+        gp_ErrorMessage("Invalid prompt supplied.");
         return NOTOK;
     }
 
@@ -406,14 +402,14 @@ int GetNumberIfZero(int *pNum, char const *prompt, int min, int max)
         gp_Message("%s", prompt);
         if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
         {
-            gp_ErrorMessage("Unable to read integer choice from stdin.\n");
+            gp_ErrorMessage("Unable to read integer choice from stdin.");
             return NOTOK;
         }
 
         if (strlen(lineBuff) == 0 ||
             sscanf(lineBuff, " %d", pNum) != 1)
         {
-            gp_ErrorMessage("Invalid integer choice.\n");
+            gp_ErrorMessage("Invalid integer choice.");
             (*pNum) = 0;
         }
     }
@@ -426,8 +422,8 @@ int GetNumberIfZero(int *pNum, char const *prompt, int min, int max)
     if (*pNum < min || *pNum > max)
     {
         *pNum = (max + min) / 2;
-        gp_ErrorMessage("Number out of range [%d, %d]; changed to %d\n",
-                        min, max, *pNum);
+        gp_Message("Number out of range [%d, %d]; changed to %d.",
+                   min, max, *pNum);
     }
 
     return OK;
@@ -445,7 +441,7 @@ graphP MakeGraph(int Size, char command)
 
     if ((theGraph = gp_New()) == NULL || gp_EnsureVertexCapacity(theGraph, Size) != OK)
     {
-        gp_ErrorMessage("Error creating space for a graph of the given size.\n");
+        gp_ErrorMessage("Error creating space for a graph of the given size.");
         gp_Free(&theGraph);
         return NULL;
     }
@@ -454,7 +450,8 @@ graphP MakeGraph(int Size, char command)
     {
         if (ExtendGraph(theGraph, command) != OK)
         {
-            gp_ErrorMessage("Unable to extend graph based on command '%c'\n", command);
+            gp_ErrorMessage("Unable to extend graph based on command '%c'",
+                            command);
             gp_Free(&theGraph);
         }
     }
@@ -496,21 +493,21 @@ int RandomGraph(char const *const commandString, int extraEdges, int numVertices
     if ((Result = GetCommandAndOptionalModifier(commandString, &command, &modifier)) != OK)
     {
         gp_ErrorMessage("Unable to extract command and optional modifier "
-                        "character from commandString.\n");
+                        "character from commandString.");
         return Result;
     }
 
     if ((Result = GetEmbedFlags(command, modifier, &embedFlags)) != OK)
     {
         gp_ErrorMessage("Unable to derive embedFlags from command and optional "
-                        "modifier character.\n");
+                        "modifier character.");
         return Result;
     }
 
     if ((Result = GetNumberIfZero(&numVertices, "Enter number of vertices:", 1, 10000000) != OK))
     {
         gp_ErrorMessage("Encountered unrecoverable error when prompting for "
-                        "numVertices.\n");
+                        "numVertices.");
         return Result;
     }
 
@@ -520,11 +517,11 @@ int RandomGraph(char const *const commandString, int extraEdges, int numVertices
     // Acceptable downcast of time_t to unsigned int (seeding benefits from the lower bits of now)
     srand((unsigned int)time(NULL));
 
-    gp_Message("Creating the random graph...\n");
+    gp_Message("Creating the random graph...");
     platform_GetTime(start);
     if (gp_CreateRandomGraphEx(theGraph, 3 * numVertices - 6 + extraEdges) != OK)
     {
-        gp_ErrorMessage("gp_CreateRandomGraphEx() failed\n");
+        gp_ErrorMessage("gp_CreateRandomGraphEx() failed");
         gp_Free(&theGraph);
         return NOTOK;
     }
@@ -539,7 +536,7 @@ int RandomGraph(char const *const commandString, int extraEdges, int numVertices
         if (gp_Write(theGraph, outfile2Name, WRITE_ADJLIST) != OK)
         {
             gp_ErrorMessage("Unable to write generated random graph before "
-                            "embedding.\n");
+                            "embedding.");
             gp_Free(&theGraph);
             return NOTOK;
         }
@@ -548,13 +545,13 @@ int RandomGraph(char const *const commandString, int extraEdges, int numVertices
     if ((origGraph = gp_DupGraph(theGraph)) == NULL)
     {
         gp_ErrorMessage("Unable to create copy of generated random graph before "
-                        "embedding.\n");
+                        "embedding.");
         gp_Free(&theGraph);
         return NOTOK;
     }
 
     // Do the requested algorithm on the randomly generated graph
-    gp_Message("Now processing\n");
+    gp_Message("Now processing...");
     FlushConsole(stdout);
 
     platform_GetTime(start);
@@ -563,7 +560,8 @@ int RandomGraph(char const *const commandString, int extraEdges, int numVertices
 
     if (Result != OK && Result != NONEMBEDDABLE)
     {
-        gp_ErrorMessage("Failed to embed or find embedding obstruction in randomly generated graph\n");
+        gp_ErrorMessage("Failed to embed or find embedding obstruction in "
+                        "randomly generated graph.");
 
         gp_Free(&theGraph);
         gp_Free(&origGraph);
@@ -573,7 +571,7 @@ int RandomGraph(char const *const commandString, int extraEdges, int numVertices
 
     if (gp_SortVertices(theGraph) != OK)
     {
-        gp_ErrorMessage("Unable to sort vertices of graph after processing\n");
+        gp_ErrorMessage("Unable to sort vertices of graph after processing");
 
         gp_Free(&theGraph);
         gp_Free(&origGraph);
@@ -596,7 +594,8 @@ int RandomGraph(char const *const commandString, int extraEdges, int numVertices
         {
             if (gp_Write(theGraph, outfileName, WRITE_ADJLIST) != OK)
             {
-                gp_ErrorMessage("Unable to write embedded graph as adjacency list.\n");
+                gp_ErrorMessage("Unable to write embedded graph as adjacency "
+                                "list.");
                 Result = NOTOK;
             }
         }
@@ -607,23 +606,23 @@ int RandomGraph(char const *const commandString, int extraEdges, int numVertices
         {
             if (PromptSaveGraph(theGraph, origGraph, extraEdges, 0) != OK)
             {
-                gp_ErrorMessage("Error saving graph in edge list format.\n");
+                gp_ErrorMessage("Error saving graph in edge list format.");
                 Result = NOTOK;
             }
             if (PromptSaveGraph(theGraph, origGraph, extraEdges, WRITE_ADJLIST) != OK)
             {
-                gp_ErrorMessage("Error saving graph in adjacency list format.\n");
+                gp_ErrorMessage("Error saving graph in adjacency list format.");
                 Result = NOTOK;
             }
             if (PromptSaveGraph(theGraph, origGraph, extraEdges, WRITE_G6) != OK)
             {
-                gp_ErrorMessage("Error saving graph in G6 format.\n");
+                gp_ErrorMessage("Error saving graph in G6 format.");
                 Result = NOTOK;
             }
         }
     }
     else
-        gp_ErrorMessage("Failure occurred.\n");
+        gp_ErrorMessage("Failure occurred.");
 
     gp_Free(&theGraph);
     gp_Free(&origGraph);
@@ -646,16 +645,16 @@ int PromptSaveGraph(graphP theGraph, graphP origGraph, int extraEdges, int saveM
     switch (saveMode)
     {
     case WRITE_ADJLIST:
-        gp_Message("\nDo you want to save the generated graph in adjacency list format (y/n)? ");
+        gp_Message("Do you want to save the generated graph in adjacency list format (y/n)?");
         break;
     case WRITE_ADJMATRIX:
-        gp_Message("\nDo you want to save the generated graph in adjacency matrix format (y/n)? ");
+        gp_Message("Do you want to save the generated graph in adjacency matrix format (y/n)?");
         break;
     case WRITE_G6:
-        gp_Message("\nDo you want to save the generated graph in G6 format (y/n)? ");
+        gp_Message("Do you want to save the generated graph in G6 format (y/n)?");
         break;
     default:
-        gp_Message("\nDo you want to save the generated graph in edge list format (y/n)? ");
+        gp_Message("Do you want to save the generated graph in edge list format (y/n)?");
         break;
     }
     // Prompt the user
@@ -663,14 +662,14 @@ int PromptSaveGraph(graphP theGraph, graphP origGraph, int extraEdges, int saveM
     {
         if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
         {
-            gp_ErrorMessage("Unable to read user input.\n");
+            gp_ErrorMessage("Unable to read user input.");
             return NOTOK;
         }
 
         if (strlen(lineBuff) != 1 ||
             sscanf(lineBuff, " %c", &saveGraph) != 1 ||
             !strchr(YESNOCHOICECHARS, saveGraph))
-            gp_ErrorMessage("Invalid choice, please try again (enter y/n).\n");
+            gp_Message("Invalid choice, please try again (enter y/n).");
         else
         {
             saveGraph = (char)tolower(lineBuff[0]);
@@ -706,24 +705,24 @@ int PromptSaveGraph(graphP theGraph, graphP origGraph, int extraEdges, int saveM
         break;
     }
 
-    gp_Message("Saving original graph to \"%.*s\"\n",
+    gp_Message("Saving original graph to \"%.*s\"",
                FILENAME_MAX, theFileName);
     SaveAsciiGraph(origGraph, theFileName);
 
     strcat(theFileName, ".out.txt");
-    gp_Message("Saving edge list format of result to \"%.*s\"\n",
+    gp_Message("Saving edge list format of result to \"%.*s\"",
                FILENAME_MAX, theFileName);
     SaveAsciiGraph(theGraph, theFileName);
 
     // Save the original graph
-    gp_Message("Saving original graph to \"%.*s\"\n",
+    gp_Message("Saving original graph to \"%.*s\"",
                FILENAME_MAX, theFileName);
 
     if (saveMode)
     {
         if (gp_Write(origGraph, theFileName, saveMode) != OK)
         {
-            gp_ErrorMessage("Failed to save original graph.\n");
+            gp_ErrorMessage("Failed to save original graph.");
             return NOTOK;
         }
 
@@ -733,7 +732,8 @@ int PromptSaveGraph(graphP theGraph, graphP origGraph, int extraEdges, int saveM
             strcpy(zeroBasedFileName, theFileName);
             strcat(zeroBasedFileName, ".0-based.txt");
             origGraph->graphFlags |= GRAPHFLAGS_ZEROBASEDIO;
-            gp_Message("    Also saving original graph in 0-based adjacency list format.\n");
+            gp_Message("Also saving original graph in 0-based adjacency "
+                       "list format.");
             gp_Write(origGraph, zeroBasedFileName, saveMode);
             origGraph->graphFlags &= ~GRAPHFLAGS_ZEROBASEDIO;
         }
@@ -747,14 +747,14 @@ int PromptSaveGraph(graphP theGraph, graphP origGraph, int extraEdges, int saveM
     else
         strcat(theFileName, ".out.txt");
 
-    gp_Message("Saving result graph to \"%.*s\"\n",
+    gp_Message("Saving result graph to \"%.*s\"",
                FILENAME_MAX, theFileName);
 
     if (saveMode)
     {
         if (gp_Write(theGraph, theFileName, saveMode) != OK)
         {
-            gp_ErrorMessage("Failed to save result graph.\n");
+            gp_ErrorMessage("Failed to save result graph.");
             return NOTOK;
         }
     }

--- a/c/planarityApp/planaritySpecificGraph.c
+++ b/c/planarityApp/planaritySpecificGraph.c
@@ -45,13 +45,15 @@ int SpecificGraph(
 
     if (GetCommandAndOptionalModifier(commandString, &command, &modifier) != OK)
     {
-        gp_ErrorMessage("Unable to derive command and modifier from commandString.\n");
+        gp_ErrorMessage("Unable to derive command and modifier from "
+                        "commandString.");
         return NOTOK;
     }
 
     if (GetEmbedFlags(command, modifier, &embedFlags) != OK)
     {
-        gp_ErrorMessage("Unable to derive embedFlags from command and optional modifier character.\n");
+        gp_ErrorMessage("Unable to derive embedFlags from command and optional "
+                        "modifier character.");
         return NOTOK;
     }
 
@@ -62,7 +64,7 @@ int SpecificGraph(
         {
             if ((infileName = ConstructInputFileName(infileName)) == NULL)
             {
-                gp_ErrorMessage("Error constructing input file name.\n");
+                gp_ErrorMessage("Error constructing input file name.");
                 Result = NOTOK;
             }
         }
@@ -73,7 +75,7 @@ int SpecificGraph(
                 infileName = ConstructInputFileName(infileName);
                 if (infileName == NULL || strlen(infileName) == 0)
                 {
-                    gp_ErrorMessage("Error constructing input file name.\n");
+                    gp_ErrorMessage("Error constructing input file name.");
                     Result = NOTOK;
 
                     break;
@@ -85,7 +87,8 @@ int SpecificGraph(
                     // prompting the user for the input file name, so there's no
                     // way you could have them enter stdin and reach this error
                     // from command-line
-                    gp_ErrorMessage("\n\tPlease choose an input file path: stdin not supported from menu.\n\n");
+                    gp_Message("Please retry with an input file "
+                               "path: stdin not supported from menu.");
 
                     infileName = NULL;
                 }
@@ -100,7 +103,7 @@ int SpecificGraph(
         // Create the graph and, if needed, attach the correct algorithm to it
         if ((theGraph = gp_New()) == NULL)
         {
-            gp_ErrorMessage("Unable to allocate graph.\n");
+            gp_ErrorMessage("Unable to allocate graph.");
             return NOTOK;
         }
 
@@ -114,7 +117,7 @@ int SpecificGraph(
     // If there was an unrecoverable error, report it and exit early.
     if (Result != OK)
     {
-        gp_ErrorMessage("Failed to read graph.\n");
+        gp_ErrorMessage("Failed to read graph.");
 
         gp_Free(&theGraph);
 
@@ -126,7 +129,7 @@ int SpecificGraph(
 
     if (origGraph == NULL)
     {
-        gp_ErrorMessage("Unable to duplicate original graph.\n");
+        gp_ErrorMessage("Unable to duplicate original graph.");
         gp_Free(&theGraph);
         return NOTOK;
     }
@@ -149,7 +152,7 @@ int SpecificGraph(
 
         if (Result != OK && Result != NONEMBEDDABLE)
         {
-            gp_ErrorMessage("Failed to embed graph.\n");
+            gp_ErrorMessage("Failed to embed graph.");
             gp_Free(&theGraph);
             gp_Free(&origGraph);
             return NOTOK;
@@ -173,7 +176,7 @@ int SpecificGraph(
     // Report an error, if there was one, free the graph, and return
     if (Result != OK && Result != NONEMBEDDABLE)
     {
-        gp_ErrorMessage("AN ERROR HAS BEEN DETECTED\n");
+        gp_ErrorMessage("AN ERROR HAS BEEN DETECTED");
         Result = NOTOK;
         //      gp_Write(theGraph, "debug.after.txt", WRITE_DEBUGINFO);
     }
@@ -184,7 +187,7 @@ int SpecificGraph(
         // Restore the vertex ordering of the original graph (undo DFS numbering)
         if (gp_SortVertices(theGraph) != OK)
         {
-            gp_ErrorMessage("Unable to restore original vertex ordering.\n");
+            gp_ErrorMessage("Unable to restore original vertex ordering.");
             gp_Free(&theGraph);
             return NOTOK;
         }
@@ -211,7 +214,7 @@ int SpecificGraph(
 
             if (writeResult != OK)
             {
-                gp_ErrorMessage("Failed to write graph to primary output file.\n");
+                gp_ErrorMessage("Failed to write graph to primary output file.");
                 Result = NOTOK;
             }
         }
@@ -257,7 +260,7 @@ int SpecificGraph(
 
             if (writeResult != OK)
             {
-                gp_ErrorMessage("Failed to write secondary output file.\n");
+                gp_ErrorMessage("Failed to write secondary output file.");
                 Result = NOTOK;
             }
         }

--- a/c/planarityApp/planarityTestAllGraphs.c
+++ b/c/planarityApp/planarityTestAllGraphs.c
@@ -48,11 +48,11 @@ int TestAllGraphs(char const *const commandString, char const *const infileName,
 
     if (infileName == NULL)
     {
-        gp_ErrorMessage("No input file provided.\n");
+        gp_ErrorMessage("No input file provided.");
         return NOTOK;
     }
 
-    gp_Message("Start testing all graphs in \"%.*s\".\n",
+    gp_Message("Start testing all graphs in \"%.*s\".",
                FILENAME_MAX,
                infileName);
 
@@ -67,14 +67,14 @@ int TestAllGraphs(char const *const commandString, char const *const infileName,
 
     if (Result != OK)
     {
-        gp_ErrorMessage("\nEncountered error while running command '%c' on all "
-                        "graphs in \"%.*s\".\n",
+        gp_ErrorMessage("Encountered error while running command '%c' on all "
+                        "graphs in \"%.*s\".",
                         command, FILENAME_MAX, infileName);
         Result = NOTOK;
     }
     else
     {
-        gp_Message("\nDone testing all graphs (%.3lf seconds).\n", stats.duration);
+        gp_Message("Done testing all graphs (%.3lf seconds).", stats.duration);
     }
 
     if (outputTestAllGraphsResults(command, modifier, &stats, infileName, outfileName, pOutputStr) != OK)
@@ -102,14 +102,14 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
 
     if (GetEmbedFlags(command, modifier, &embedFlags) != OK)
     {
-        gp_ErrorMessage("Invalid command or modifier.\n");
+        gp_ErrorMessage("Invalid command or modifier.");
         stats->errorFlag = TRUE;
         return NOTOK;
     }
 
     if ((origGraphRead = gp_New()) == NULL)
     {
-        gp_ErrorMessage("Unable to allocate graph for reading.\n");
+        gp_ErrorMessage("Unable to allocate graph for reading.");
         stats->errorFlag = TRUE;
         return NOTOK;
     }
@@ -117,7 +117,7 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
     if (g6_NewReader((&theG6ReadIterator), origGraphRead) != OK ||
         g6_InitReaderWithFileName(theG6ReadIterator, infileName) != OK)
     {
-        gp_ErrorMessage("Unable to allocate or initialize G6 read iterator.\n");
+        gp_ErrorMessage("Unable to allocate or initialize G6 read iterator.");
         gp_Free(&origGraphRead);
         g6_FreeReader((&theG6ReadIterator));
         stats->errorFlag = TRUE;
@@ -132,7 +132,7 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
     if ((graphForEmbedding = gp_New()) == NULL ||
         gp_EnsureVertexCapacity(graphForEmbedding, order) != OK)
     {
-        gp_ErrorMessage("Unable allocate graph for embedding.\n");
+        gp_ErrorMessage("Unable allocate graph for embedding.");
         g6_FreeReader((&theG6ReadIterator));
         gp_Free(&origGraphRead);
         gp_Free(&graphForEmbedding);
@@ -142,7 +142,7 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
 
     if (ExtendGraph(graphForEmbedding, command) != OK)
     {
-        gp_ErrorMessage("Unable to extend graph for embedding operation.\n");
+        gp_ErrorMessage("Unable to extend graph for embedding operation.");
         g6_FreeReader(&theG6ReadIterator);
         gp_Free(&origGraphRead);
         gp_Free(&graphForEmbedding);
@@ -155,7 +155,7 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
         lineNum++;
         if (g6_ReadGraph(theG6ReadIterator) != OK)
         {
-            gp_ErrorMessage("Unable to read graph on line %d.\n",
+            gp_ErrorMessage("Unable to read graph on line %d.",
                             lineNum);
             Result = NOTOK;
             break;
@@ -166,7 +166,7 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
 
         if (gp_CopyGraph(graphForEmbedding, origGraphRead) != OK)
         {
-            gp_ErrorMessage("Unable to copy graph.\n");
+            gp_ErrorMessage("Unable to copy graph.");
             Result = NOTOK;
             break;
         }
@@ -174,7 +174,7 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
         Result = gp_Embed(graphForEmbedding, embedFlags);
         if (Result != OK && Result != NONEMBEDDABLE)
         {
-            gp_ErrorMessage("Failed to embed graph on line %d for command '%c'.\n",
+            gp_ErrorMessage("Failed to embed graph on line %d for command '%c'.",
                             lineNum, command);
             Result = NOTOK;
         }
@@ -200,12 +200,12 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
         {
             if (modifier == '\0')
             {
-                gp_ErrorMessage("Command '%c' error on graph on line %d.\n",
+                gp_ErrorMessage("Command '%c' error on graph on line %d.",
                                 command, lineNum);
             }
             else
             {
-                gp_ErrorMessage("Command '%c%c' error on graph on line %d.\n",
+                gp_ErrorMessage("Command '%c%c' error on graph on line %d.",
                                 command, modifier, lineNum);
             }
             Result = NOTOK;
@@ -245,7 +245,8 @@ int outputTestAllGraphsResults(char command, char modifier, testAllStatsP stats,
 
     if (outfileName == NULL && (pOutputStr == NULL || *pOutputStr != NULL))
     {
-        gp_ErrorMessage("Invalid parameters: Must be able to output to file or memory.");
+        gp_ErrorMessage("Invalid parameters: Must be able to output to file or "
+                        "memory.");
         return NOTOK;
     }
 
@@ -259,8 +260,8 @@ int outputTestAllGraphsResults(char command, char modifier, testAllStatsP stats,
         GetNumCharsToReprInt(stats->numOK, &numCharsToReprNumOK) != OK ||
         GetNumCharsToReprInt(stats->numNONEMBEDDABLE, &numCharsToReprNumNONEMBEDDABLE) != OK)
     {
-        gp_ErrorMessage("Unable to determine the number of characters required to "
-                        "represent testAllGraphs stat values.\n");
+        gp_ErrorMessage("Unable to determine the number of characters required "
+                        "to represent testAllGraphs stat values.");
         return NOTOK;
     }
 
@@ -282,7 +283,7 @@ int outputTestAllGraphsResults(char command, char modifier, testAllStatsP stats,
     theOutputStr = (char *)malloc((headerStrLen + resultStrLen + 1) * sizeof(char));
     if (theOutputStr == NULL)
     {
-        gp_ErrorMessage("Unable allocate memory for the output.\n");
+        gp_ErrorMessage("Unable allocate memory for the output.");
         return NOTOK;
     }
 

--- a/c/planarityApp/planarityTestAllGraphs.c
+++ b/c/planarityApp/planarityTestAllGraphs.c
@@ -52,7 +52,7 @@ int TestAllGraphs(char const *const commandString, char const *const infileName,
         return NOTOK;
     }
 
-    gp_Message("Start testing all graphs in \"%.*s\".",
+    gp_Message("Starting to test all graphs in \"%.*s\".",
                FILENAME_MAX,
                infileName);
 

--- a/c/planarityApp/planarityTransformGraph.c
+++ b/c/planarityApp/planarityTransformGraph.c
@@ -32,7 +32,8 @@ int TransformGraph(char const *const commandString, char const *const infileName
 
     if (theGraph == NULL)
     {
-        gp_ErrorMessage("Unable to allocate graphP for input graph transformation target.\n");
+        gp_ErrorMessage("Unable to allocate graphP for input graph "
+                        "transformation target.");
         return NOTOK;
     }
 
@@ -46,10 +47,8 @@ int TransformGraph(char const *const commandString, char const *const infileName
             outputFormat = WRITE_ADJMATRIX;
         else
         {
-            gp_ErrorMessage("Invalid argument; only -(gam) is allowed.\n");
-
+            gp_ErrorMessage("Invalid argument; only -(gam) is allowed.");
             gp_Free(&theGraph);
-
             return NOTOK;
         }
 
@@ -60,7 +59,7 @@ int TransformGraph(char const *const commandString, char const *const infileName
 
         if (Result != OK)
         {
-            gp_ErrorMessage("Unable to transform input graph.\n");
+            gp_ErrorMessage("Unable to transform input graph.");
         }
         else
         {
@@ -75,12 +74,12 @@ int TransformGraph(char const *const commandString, char const *const infileName
                 Result = gp_Write(theGraph, outfileName, outputFormat);
 
             if (Result != OK)
-                gp_ErrorMessage("Unable to write graph.\n");
+                gp_ErrorMessage("Unable to write graph.");
         }
     }
     else
     {
-        gp_ErrorMessage("Invalid argument; must start with '-'.\n");
+        gp_ErrorMessage("Invalid argument; must start with '-'.");
         Result = NOTOK;
     }
 
@@ -95,7 +94,8 @@ int transformFile(graphP theGraph, char const *infileName)
     {
         if ((infileName = ConstructInputFileName(infileName)) == NULL)
         {
-            gp_ErrorMessage("Unable to construct input file name for graph to transform.\n");
+            gp_ErrorMessage("Unable to construct input file name for graph to "
+                            "transform.");
             return NOTOK;
         }
     }
@@ -107,7 +107,7 @@ int transformString(graphP theGraph, char *inputStr)
 {
     if (inputStr == NULL || strlen(inputStr) == 0)
     {
-        gp_ErrorMessage("Input string is null or empty.\n");
+        gp_ErrorMessage("Input string is null or empty.");
         return NOTOK;
     }
 

--- a/c/planarityApp/planarityUtils.c
+++ b/c/planarityApp/planarityUtils.c
@@ -34,7 +34,7 @@ int Reconfigure(void)
                          "  Randomly generate graphs (r),\n"
                          "  Specify a graph (s),\n"
                          "  Randomly generate a maximal planar graph (m), or\n"
-                         "  Randomly generate a non-planar graph (n)? ");
+                         "  Randomly generate a non-planar graph (n)?");
 
         if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
         {
@@ -61,7 +61,7 @@ int Reconfigure(void)
         while (1)
         {
             gp_MessagePrompt("Do you want original graphs in directory "
-                             "'random'? (y/n) ");
+                             "'random'? (y/n)");
             if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
             {
                 gp_ErrorMessage("Unable to fetch choice from stdin.");
@@ -86,7 +86,7 @@ int Reconfigure(void)
             {
                 gp_MessagePrompt("Do you want to output generated graphs to "
                                  "Adjacency List (last 10 only) or to G6 "
-                                 "(all)? (a/g) ");
+                                 "(all)? (a/g)");
                 if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
                 {
                     gp_ErrorMessage("Unable to fetch choice from stdin.");
@@ -112,7 +112,7 @@ int Reconfigure(void)
             {
                 gp_MessagePrompt("Do you want adj. matrix of embeddable graphs "
                                  "in directory 'embedded' (last 10 max))? "
-                                 "(y/n) ");
+                                 "(y/n)");
                 if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
                 {
                     gp_ErrorMessage("Unable to fetch choice from stdin.");
@@ -137,7 +137,7 @@ int Reconfigure(void)
             {
                 gp_MessagePrompt("Do you want adj. matrix of obstructed graphs "
                                  "in directory 'obstructed' (last 10 max)? "
-                                 "(y/n) ");
+                                 "(y/n)");
                 if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
                 {
                     gp_ErrorMessage("Unable to fetch choice from stdin.");
@@ -163,7 +163,7 @@ int Reconfigure(void)
             {
                 gp_MessagePrompt("Do you want adjacency list format of "
                                  "embeddings in directory 'adjlist' "
-                                 "(last 10 max)? (y/n) ");
+                                 "(last 10 max)? (y/n)");
                 if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
                 {
                     gp_ErrorMessage("Unable to fetch choice from stdin.");

--- a/c/planarityApp/planarityUtils.c
+++ b/c/planarityApp/planarityUtils.c
@@ -1005,38 +1005,42 @@ int ConstructTransformationExpectedResultFileName(char const *infileName, char *
 
 void WriteAlgorithmResults(graphP theGraph, int Result, char command, platform_time start, platform_time end, char const *infileName)
 {
-    gp_Message("The graph ");
+    char algorithmResults[2 * MAXLINE + 1];
+    char *target = algorithmResults;
+
+    target += sprintf(target, "The graph ");
     if (infileName)
     {
-        gp_Message("\"%.*s\" ", FILENAME_MAX, infileName);
+        target += sprintf(target, "\"%.*s\" ", FILENAME_MAX, infileName);
     }
 
     switch (command)
     {
     case 'p':
-        gp_Message("is%s planar.", Result == OK ? "" : " not");
+        target += sprintf(target, "is%s planar.", Result == OK ? "" : " not");
         break;
     case 'd':
-        gp_Message("is%s planar.", Result == OK ? "" : " not");
+        target += sprintf(target, "is%s planar.", Result == OK ? "" : " not");
         break;
     case 'o':
-        gp_Message("is%s outerplanar.", Result == OK ? "" : " not");
+        target += sprintf(target, "is%s outerplanar.", Result == OK ? "" : " not");
         break;
     case '2':
-        gp_Message("has %s subgraph homeomorphic to K_{2,3}.", Result == OK ? "no" : "a");
+        target += sprintf(target, "has %s subgraph homeomorphic to K_{2,3}.", Result == OK ? "no" : "a");
         break;
     case '3':
-        gp_Message("has %s subgraph homeomorphic to K_{3,3}.", Result == OK ? "no" : "a");
+        target += sprintf(target, "has %s subgraph homeomorphic to K_{3,3}.", Result == OK ? "no" : "a");
         break;
     case '4':
-        gp_Message("has %s subgraph homeomorphic to K_4.", Result == OK ? "no" : "a");
+        target += sprintf(target, "has %s subgraph homeomorphic to K_4.", Result == OK ? "no" : "a");
         break;
     default:
-        gp_Message("has not been processed due to unrecognized command.");
+        target += sprintf(target, "has not been processed due to unrecognized command.");
         break;
     }
 
-    gp_Message("Algorithm '%s' executed in %.3lf seconds.",
+    gp_Message("%s", algorithmResults);
+    gp_Message("Algorithm '%s' executed on graph in  in %.3lf seconds.",
                GetAlgorithmName(command), platform_GetDuration(start, end));
 }
 

--- a/c/planarityApp/planarityUtils.c
+++ b/c/planarityApp/planarityUtils.c
@@ -30,11 +30,11 @@ int Reconfigure(void)
 
     while (1)
     {
-        gp_Message("Do you want to \n"
-                   "  Randomly generate graphs (r),\n"
-                   "  Specify a graph (s),\n"
-                   "  Randomly generate a maximal planar graph (m), or\n"
-                   "  Randomly generate a non-planar graph (n)?");
+        gp_MessagePrompt("Do you want to \n"
+                         "  Randomly generate graphs (r),\n"
+                         "  Specify a graph (s),\n"
+                         "  Randomly generate a maximal planar graph (m), or\n"
+                         "  Randomly generate a non-planar graph (n)? ");
 
         if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
         {
@@ -60,8 +60,8 @@ int Reconfigure(void)
 
         while (1)
         {
-            gp_Message("Do you want original graphs in directory 'random'? "
-                       "(y/n)");
+            gp_MessagePrompt("Do you want original graphs in directory "
+                             "'random'? (y/n) ");
             if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
             {
                 gp_ErrorMessage("Unable to fetch choice from stdin.");
@@ -84,9 +84,9 @@ int Reconfigure(void)
         {
             while (1)
             {
-                gp_Message("Do you want to output generated graphs to "
-                           "Adjacency List (last 10 only) or to G6 (all)? "
-                           "(a/g)");
+                gp_MessagePrompt("Do you want to output generated graphs to "
+                                 "Adjacency List (last 10 only) or to G6 "
+                                 "(all)? (a/g) ");
                 if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
                 {
                     gp_ErrorMessage("Unable to fetch choice from stdin.");
@@ -110,7 +110,9 @@ int Reconfigure(void)
         {
             while (1)
             {
-                gp_Message("Do you want adj. matrix of embeddable graphs in directory 'embedded' (last 10 max))? (y/n) ");
+                gp_MessagePrompt("Do you want adj. matrix of embeddable graphs "
+                                 "in directory 'embedded' (last 10 max))? "
+                                 "(y/n) ");
                 if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
                 {
                     gp_ErrorMessage("Unable to fetch choice from stdin.");
@@ -133,7 +135,9 @@ int Reconfigure(void)
         {
             while (1)
             {
-                gp_Message("Do you want adj. matrix of obstructed graphs in directory 'obstructed' (last 10 max)? (y/n) ");
+                gp_MessagePrompt("Do you want adj. matrix of obstructed graphs "
+                                 "in directory 'obstructed' (last 10 max)? "
+                                 "(y/n) ");
                 if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
                 {
                     gp_ErrorMessage("Unable to fetch choice from stdin.");
@@ -157,7 +161,9 @@ int Reconfigure(void)
         {
             while (1)
             {
-                gp_Message("Do you want adjacency list format of embeddings in directory 'adjlist' (last 10 max)? (y/n) ");
+                gp_MessagePrompt("Do you want adjacency list format of "
+                                 "embeddings in directory 'adjlist' "
+                                 "(last 10 max)? (y/n) ");
                 if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
                 {
                     gp_ErrorMessage("Unable to fetch choice from stdin.");
@@ -229,8 +235,8 @@ void SaveAsciiGraph(graphP theGraph, char *fileName)
     // The fileName may specify a directory that doesn't exist
     if (outfile == NULL)
     {
-        gp_ErrorMessage("Failed to write to \"%.*s\"\nMake the directory if not "
-                        "present\n",
+        gp_ErrorMessage("Failed to write to \"%.*s\"\nMake the directory if "
+                        "not present.",
                         FILENAME_MAX, fileName);
         return;
     }
@@ -824,7 +830,7 @@ char *ConstructInputFileName(char const *infileName)
     {
         while (1)
         {
-            gp_Message("Enter graph file name: ");
+            gp_MessagePrompt("Enter graph file name: ");
             if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
             {
                 gp_ErrorMessage("Unable to read graph file name from stdin.");

--- a/c/planarityApp/planarityUtils.c
+++ b/c/planarityApp/planarityUtils.c
@@ -830,7 +830,7 @@ char *ConstructInputFileName(char const *infileName)
     {
         while (1)
         {
-            gp_MessagePrompt("Enter graph file name: ");
+            gp_MessagePrompt("Enter graph file name:");
             if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
             {
                 gp_ErrorMessage("Unable to read graph file name from stdin.");

--- a/c/planarityApp/planarityUtils.c
+++ b/c/planarityApp/planarityUtils.c
@@ -30,15 +30,15 @@ int Reconfigure(void)
 
     while (1)
     {
-        gp_Message("\nDo you want to \n"
+        gp_Message("Do you want to \n"
                    "  Randomly generate graphs (r),\n"
                    "  Specify a graph (s),\n"
                    "  Randomly generate a maximal planar graph (m), or\n"
-                   "  Randomly generate a non-planar graph (n)?\n\t");
+                   "  Randomly generate a non-planar graph (n)?");
 
         if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
         {
-            gp_ErrorMessage("Unable to fetch reconfigure choice from stdin.\n");
+            gp_ErrorMessage("Unable to fetch reconfigure choice from stdin.");
             Result = NOTOK;
             break;
         }
@@ -46,7 +46,7 @@ int Reconfigure(void)
         if (strlen(lineBuff) != 1 ||
             sscanf(lineBuff, " %c", &Mode) != 1 ||
             !strchr("rsmn", tolower(Mode)))
-            gp_ErrorMessage("Invalid choice for Mode.\n");
+            gp_Message("Invalid choice for Mode; please retry.");
         else
         {
             Mode = (char)tolower(Mode);
@@ -56,14 +56,15 @@ int Reconfigure(void)
 
     if (Result == OK && Mode == 'r')
     {
-        gp_Message("\nNOTE: The directories for the graphs you want must exist.\n\n");
+        gp_Message("NOTE: The directories for the graphs you want must exist.");
 
         while (1)
         {
-            gp_Message("Do you want original graphs in directory 'random'? (y/n) ");
+            gp_Message("Do you want original graphs in directory 'random'? "
+                       "(y/n)");
             if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
             {
-                gp_ErrorMessage("Unable to fetch choice from stdin.\n");
+                gp_ErrorMessage("Unable to fetch choice from stdin.");
                 Result = NOTOK;
                 break;
             }
@@ -71,7 +72,7 @@ int Reconfigure(void)
             if (strlen(lineBuff) != 1 ||
                 sscanf(lineBuff, " %c", &OrigOut) != 1 ||
                 !strchr(YESNOCHOICECHARS, OrigOut))
-                gp_ErrorMessage("Invalid choice.\n");
+                gp_Message("Invalid choice; please retry.");
             else
             {
                 OrigOut = (char)tolower(OrigOut);
@@ -83,10 +84,12 @@ int Reconfigure(void)
         {
             while (1)
             {
-                gp_Message("Do you want to output generated graphs to Adjacency List (last 10 only) or to G6 (all)? (a/g) ");
+                gp_Message("Do you want to output generated graphs to "
+                           "Adjacency List (last 10 only) or to G6 (all)? "
+                           "(a/g)");
                 if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
                 {
-                    gp_ErrorMessage("Unable to fetch choice from stdin.\n");
+                    gp_ErrorMessage("Unable to fetch choice from stdin.");
                     Result = NOTOK;
                     break;
                 }
@@ -94,7 +97,7 @@ int Reconfigure(void)
                 if (strlen(lineBuff) != 1 ||
                     sscanf(lineBuff, " %c", &OrigOutFormat) != 1 ||
                     !strchr("aAgG", OrigOutFormat))
-                    gp_ErrorMessage("Invalid choice.\n");
+                    gp_Message("Invalid choice; please retry.");
                 else
                 {
                     OrigOutFormat = (char)tolower(OrigOutFormat);
@@ -110,14 +113,14 @@ int Reconfigure(void)
                 gp_Message("Do you want adj. matrix of embeddable graphs in directory 'embedded' (last 10 max))? (y/n) ");
                 if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
                 {
-                    gp_ErrorMessage("Unable to fetch choice from stdin.\n");
+                    gp_ErrorMessage("Unable to fetch choice from stdin.");
                     Result = NOTOK;
                     break;
                 }
                 if (strlen(lineBuff) != 1 ||
                     sscanf(lineBuff, " %c", &EmbeddableOut) != 1 ||
                     !strchr(YESNOCHOICECHARS, EmbeddableOut))
-                    gp_ErrorMessage("Invalid choice.\n");
+                    gp_Message("Invalid choice; please retry.");
                 else
                 {
                     EmbeddableOut = (char)tolower(EmbeddableOut);
@@ -133,7 +136,7 @@ int Reconfigure(void)
                 gp_Message("Do you want adj. matrix of obstructed graphs in directory 'obstructed' (last 10 max)? (y/n) ");
                 if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
                 {
-                    gp_ErrorMessage("Unable to fetch choice from stdin.\n");
+                    gp_ErrorMessage("Unable to fetch choice from stdin.");
                     Result = NOTOK;
                     break;
                 }
@@ -141,7 +144,7 @@ int Reconfigure(void)
                 if (strlen(lineBuff) != 1 ||
                     sscanf(lineBuff, " %c", &ObstructedOut) != 1 ||
                     !strchr(YESNOCHOICECHARS, ObstructedOut))
-                    gp_ErrorMessage("Invalid choice.\n");
+                    gp_Message("Invalid choice; please retry.");
                 else
                 {
                     ObstructedOut = (char)tolower(ObstructedOut);
@@ -157,7 +160,7 @@ int Reconfigure(void)
                 gp_Message("Do you want adjacency list format of embeddings in directory 'adjlist' (last 10 max)? (y/n) ");
                 if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
                 {
-                    gp_ErrorMessage("Unable to fetch choice from stdin.\n");
+                    gp_ErrorMessage("Unable to fetch choice from stdin.");
                     Result = NOTOK;
                     break;
                 }
@@ -165,7 +168,7 @@ int Reconfigure(void)
                 if (strlen(lineBuff) != 1 ||
                     sscanf(lineBuff, " %c", &AdjListsForEmbeddingsOut) != 1 ||
                     !strchr(YESNOCHOICECHARS, AdjListsForEmbeddingsOut))
-                    gp_ErrorMessage("Invalid choice.\n");
+                    gp_Message("Invalid choice; please retry.");
                 else
                 {
                     AdjListsForEmbeddingsOut = (char)tolower(AdjListsForEmbeddingsOut);
@@ -184,7 +187,7 @@ int GetLineFromStdin(char *lineBuff, int lineBuffSize)
 {
     if (lineBuff == NULL)
     {
-        gp_ErrorMessage("Line buffer to populate is NULL.\n");
+        gp_ErrorMessage("Line buffer to populate is NULL.");
         return NOTOK;
     }
 
@@ -192,7 +195,7 @@ int GetLineFromStdin(char *lineBuff, int lineBuffSize)
 
     if (fgets(lineBuff, lineBuffSize, stdin) == NULL && ferror(stdin))
     {
-        gp_ErrorMessage("Call to fgets() from stdin failed.\n");
+        gp_ErrorMessage("Call to fgets() from stdin failed.");
         return NOTOK;
     }
 
@@ -275,9 +278,9 @@ char *ReadTextFileIntoString(char const *infileName)
     char *inputString = NULL;
 
     if (infileName == NULL || strlen(infileName) == 0)
-        gp_ErrorMessage("Unable to fopen() with NULL or empty infileName.\n");
+        gp_ErrorMessage("Unable to fopen() with NULL or empty infileName.");
     else if ((infile = fopen(infileName, "r")) == NULL)
-        gp_ErrorMessage("fopen() failed.\n");
+        gp_ErrorMessage("fopen() failed.");
     else
     {
         long filePos = ftell(infile);
@@ -501,8 +504,7 @@ char const *GetAlgorithmFlags(void)
            "    -o = Outerplanar embedding and obstruction isolation\n"
            "    -2 = Search for subgraph homeomorphic to K_{2,3}\n"
            "    -3 = Search for subgraph homeomorphic to K_{3,3}\n"
-           "    -4 = Search for subgraph homeomorphic to K_4\n"
-           "\n";
+           "    -4 = Search for subgraph homeomorphic to K_4\n";
 }
 
 char const *GetAlgorithmSpecifiers(void)
@@ -547,13 +549,14 @@ int GetCommandAndOptionalModifier(const char *commandString, char *command, char
 
     if (commandString == NULL || strlen(commandString) == 0)
     {
-        gp_ErrorMessage("Cannot get embed flags for empty command string.\n");
+        gp_ErrorMessage("Cannot get embed flags for empty command string.");
         return NOTOK;
     }
 
     if (command == NULL)
     {
-        gp_ErrorMessage("Pointer to character to which to write command is NULL.\n");
+        gp_ErrorMessage("Pointer to character to which to write command is "
+                        "NULL.");
         return NOTOK;
     }
 
@@ -591,7 +594,7 @@ int GetEmbedFlags(char command, char modifier, int *embedFlagsP)
 {
     if (embedFlagsP == NULL)
     {
-        gp_ErrorMessage("Pointer to embedFlags int is NULL.\n");
+        gp_ErrorMessage("Pointer to embedFlags int is NULL.");
         return NOTOK;
     }
 
@@ -619,7 +622,7 @@ int GetEmbedFlags(char command, char modifier, int *embedFlagsP)
         (*embedFlagsP) = EMBEDFLAGS_SEARCHFORK4;
         break;
     default:
-        gp_ErrorMessage("Unrecognized algorithm command specifier.\n");
+        gp_ErrorMessage("Unrecognized algorithm command specifier.");
         return NOTOK;
     }
 
@@ -630,7 +633,7 @@ int GetEmbedFlags(char command, char modifier, int *embedFlagsP)
     // specified modifier character, this check should be removed.
     if (modifier != '\0')
     {
-        gp_ErrorMessage("Algorithm modifiers currently not supported.\n");
+        gp_ErrorMessage("Algorithm modifiers currently not supported.");
         return NOTOK;
     }
 
@@ -745,7 +748,8 @@ int ExtendGraph(graphP theGraph, char command)
 {
     if (theGraph == NULL || theGraph->N <= 0)
     {
-        gp_ErrorMessage("Unable to extend graph with algorithm extension due to NULL or uninitialized graph.\n");
+        gp_ErrorMessage("Unable to extend graph with algorithm extension due "
+                        "to NULL or uninitialized graph.");
         return NOTOK;
     }
 
@@ -799,14 +803,16 @@ char *ConstructInputFileName(char const *infileName)
 
     if (GetNumCharsToReprInt(FILENAMEMAXLENGTH, &numCharsToReprFILENAMEMAXLENGTH) != OK)
     {
-        gp_ErrorMessage("Unable to determine number of characters required to represent FILENAMEMAXLENGTH.\n");
+        gp_ErrorMessage("Unable to determine number of characters required to "
+                        "represent FILENAMEMAXLENGTH.");
         return NULL;
     }
 
     fileNameFormat = (char *)malloc((strlen(fileNameFormatFormat) + numCharsToReprFILENAMEMAXLENGTH + 1) * sizeof(char));
     if (fileNameFormat == NULL)
     {
-        gp_ErrorMessage("Unable to allocate memory for file name format string.\n");
+        gp_ErrorMessage("Unable to allocate memory for file name format "
+                        "string.");
         return NULL;
     }
 
@@ -821,9 +827,8 @@ char *ConstructInputFileName(char const *infileName)
             gp_Message("Enter graph file name: ");
             if (GetLineFromStdin(lineBuff, MAXLINE) != OK)
             {
-                gp_ErrorMessage("Unable to read graph file name from stdin.\n");
+                gp_ErrorMessage("Unable to read graph file name from stdin.");
                 Result = NOTOK;
-
                 break;
             }
 
@@ -831,12 +836,13 @@ char *ConstructInputFileName(char const *infileName)
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
             if (strlen(lineBuff) == 0 || strlen(lineBuff) > FILENAMEMAXLENGTH ||
                 sscanf(lineBuff, fileNameFormat, theFileName) != 1)
-                gp_Message("Invalid input file name; retry.\n");
+                gp_Message("Invalid input file name; please retry.");
             else
             {
                 if (strncmp(theFileName, "stdin", strlen("stdin")) != 0 && !strchr(theFileName, '.'))
                 {
-                    gp_Message("Graph file name does not have extension; automatically appending \".txt\".\n");
+                    gp_Message("Graph file name does not have extension; "
+                               "automatically appending \".txt\".");
                     strcat(theFileName, ".txt");
                 }
                 break;
@@ -848,12 +854,12 @@ char *ConstructInputFileName(char const *infileName)
     {
         if (strlen(infileName) > FILENAMEMAXLENGTH)
         {
-            gp_ErrorMessage("File name is too long.\n");
+            gp_ErrorMessage("File name is too long.");
             Result = NOTOK;
         }
         else if (strlen(infileName) == 0)
         {
-            gp_ErrorMessage("File name is empty.\n");
+            gp_ErrorMessage("File name is empty.");
             Result = NOTOK;
         }
 
@@ -902,7 +908,8 @@ char *ConstructPrimaryOutputFileName(char const *infileName, char const *outfile
             strcat(theFileName, algorithmName);
         }
         else
-            gp_Message("Algorithm Name is too long, so it will not be used in output file name.\n");
+            gp_Message("Algorithm Name is too long, so it will not be used in "
+                       "output file name.");
 
         strcat(theFileName, ".out.txt");
     }
@@ -921,7 +928,9 @@ char *ConstructPrimaryOutputFileName(char const *infileName, char const *outfile
             }
             strcat(theFileName, ".out.txt");
 
-            gp_Message("Outfile file name is too long. Result placed in \"%.*s\"", FILENAME_MAX, theFileName);
+            gp_Message("Outfile file name is too long. Result placed in "
+                       "\"%.*s\"",
+                       FILENAME_MAX, theFileName);
         }
         else
         {
@@ -956,7 +965,8 @@ int ConstructTransformationExpectedResultFileName(char const *infileName, char *
 
     if (infileName == NULL || (infileNameLen = strlen(infileName)) < 1)
     {
-        gp_ErrorMessage("Cannot construct transformation output file name for empty infileName.\n");
+        gp_ErrorMessage("Cannot construct transformation output file name for "
+                        "empty infileName.");
         return NOTOK;
     }
 
@@ -969,7 +979,7 @@ int ConstructTransformationExpectedResultFileName(char const *infileName, char *
 
         if ((*outfileName) == NULL)
         {
-            gp_ErrorMessage("Unable to allocate memory for output file name.\n");
+            gp_ErrorMessage("Unable to allocate memory for output file name.");
             return NOTOK;
         }
 
@@ -982,7 +992,7 @@ int ConstructTransformationExpectedResultFileName(char const *infileName, char *
     }
     else
     {
-        gp_ErrorMessage("outfileName already allocated.\n");
+        gp_ErrorMessage("outfileName already allocated.");
         Result = NOTOK;
     }
 
@@ -1004,29 +1014,29 @@ void WriteAlgorithmResults(graphP theGraph, int Result, char command, platform_t
     switch (command)
     {
     case 'p':
-        gp_Message("is%s planar.\n", Result == OK ? "" : " not");
+        gp_Message("is%s planar.", Result == OK ? "" : " not");
         break;
     case 'd':
-        gp_Message("is%s planar.\n", Result == OK ? "" : " not");
+        gp_Message("is%s planar.", Result == OK ? "" : " not");
         break;
     case 'o':
-        gp_Message("is%s outerplanar.\n", Result == OK ? "" : " not");
+        gp_Message("is%s outerplanar.", Result == OK ? "" : " not");
         break;
     case '2':
-        gp_Message("has %s subgraph homeomorphic to K_{2,3}.\n", Result == OK ? "no" : "a");
+        gp_Message("has %s subgraph homeomorphic to K_{2,3}.", Result == OK ? "no" : "a");
         break;
     case '3':
-        gp_Message("has %s subgraph homeomorphic to K_{3,3}.\n", Result == OK ? "no" : "a");
+        gp_Message("has %s subgraph homeomorphic to K_{3,3}.", Result == OK ? "no" : "a");
         break;
     case '4':
-        gp_Message("has %s subgraph homeomorphic to K_4.\n", Result == OK ? "no" : "a");
+        gp_Message("has %s subgraph homeomorphic to K_4.", Result == OK ? "no" : "a");
         break;
     default:
-        gp_Message("has not been processed due to unrecognized command.\n");
+        gp_Message("has not been processed due to unrecognized command.");
         break;
     }
 
-    gp_Message("Algorithm '%s' executed in %.3lf seconds.\n",
+    gp_Message("Algorithm '%s' executed in %.3lf seconds.",
                GetAlgorithmName(command), platform_GetDuration(start, end));
 }
 

--- a/c/planarityApp/planarityUtils.c
+++ b/c/planarityApp/planarityUtils.c
@@ -1005,13 +1005,16 @@ int ConstructTransformationExpectedResultFileName(char const *infileName, char *
 
 void WriteAlgorithmResults(graphP theGraph, int Result, char command, platform_time start, platform_time end, char const *infileName)
 {
-    char algorithmResults[2 * MAXLINE + 1];
+    char algorithmResults[MAXLINE + 1];
     char *target = algorithmResults;
 
+    memset(algorithmResults, '\0', MAXLINE + 1);
+
     target += sprintf(target, "The graph ");
+
     if (infileName)
     {
-        target += sprintf(target, "\"%.*s\" ", FILENAME_MAX, infileName);
+        target += sprintf(target, "\"%.*s\" ", FILENAMEMAXLENGTH, infileName);
     }
 
     switch (command)


### PR DESCRIPTION
Resolves #225
## Type of change

Please check only relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes

### Added

* N/A

### Updated

* `c/graphLib/lowLevelUtils/apiutils.h` - changed `gp_ErrorMessage()` to a macro which now calls the new function `gp_LogErrorMessage()`, passing along the `__FILE__` and `__LINE__` info for where the macro replacement happened to give more context for the error message. Note now that the variable args come after the third parameter, `message`, hence `FORMAT_PRINTF` attribute had to be updated.
* `c/graphLib/lowLevelUtils/apiutils.c` - Added newline after each `gp_Message()`. Also, added function `gp_LogErrorMessage()` which will prepend any `gp_ErrorMessage()` with `[ERROR]`, then if `lineNum` and `srcFileName` are both provided, will append additional context for the message, and will always add a trailing `\n`.
* Updated every (?) instance of `gp_Message()` and `gp_ErrorMessage()` to remove trailing `\n` when appropriate 
* In places where user is being prompted for choices, changed some of the `gp_ErrorMessage()` to `gp_Message()` when needing to prompt user to retry rather than indicating an unrecoverable error state. Also changed some `gp_Message()` to `gp_MessagePrompt()` (which outputs an additional space to `stdout` after the prompt string) in `planarityUtils.c`, `planarityMenu.c`, and `planarityRandomGraphs.c`

### Removed

* N/A

## Testing

_Coming soon_

- [ ] Outline manual or automated tests performed and how it relates to the particular feature added or functionality changed
- [x] Upload logs or provide relevant snippets of terminal output to demo functionality

<details><summary>Checking help messages</summary>

```
wbkboyer@Wandas-MacBook-Pro edge-addition-planarity-suite-fork % ./Debug/planarity -h      

===================================================
The Edge Addition Planarity Suite version 5.0.0.0
based on libPlanarity graph library version 4:0:0
Copyright (c) 1997-2026 by John M. Boyer
All rights reserved.
See the LICENSE.TXT file for licensing information.
Contact info: jboyer at acm.org
===================================================

'planarity': if no command-line, then menu-driven
'planarity (-h|-help)': this message
'planarity (-h|-help) -menu': more help with menu-based command line
'planarity (-i|-info): copyright and license information
'planarity -test [-q] [samples dir]': runs tests (optional quiet mode)

Common usages
-------------
planarity -s -q -p infile.txt embedding.out [obstruction.out]
Process infile.txt in quiet mode (-q), putting planar embedding in 
embedding.out or (optionally) a Kuratowski subgraph in Obstruction.out
Process returns 0=planar, 1=nonplanar, -1=error

planarity -s -q -d infile.txt embedding.out [drawing.out]
If graph in infile.txt is planar, then put embedding in embedding.out 
and (optionally) an ASCII art drawing in drawing.out
Process returns 0=planar, 1=nonplanar, -1=error

	Press return key to exit...

wbkboyer@Wandas-MacBook-Pro edge-addition-planarity-suite-fork % ./Debug/planarity -h -menu

===================================================
The Edge Addition Planarity Suite version 5.0.0.0
based on libPlanarity graph library version 4:0:0
Copyright (c) 1997-2026 by John M. Boyer
All rights reserved.
See the LICENSE.TXT file for licensing information.
Contact info: jboyer at acm.org
===================================================

'planarity -r [-q] C K N [O]': Random graphs
'planarity -s [-q] C I O [O2]': Specific graph
'planarity -rm [-q] N O [O2]': Random maximal planar graph
'planarity -rn [-q] N O [O2]': Random nonplanar graph (maximal planar + edge)
'planarity -t [-q] C I O': Test algorithm on graph(s) in .g6 file
'planarity -x [-q] -(gam) I O': Transform graph to .g6 (g), Adjacency List (a), or Adjacency Matrix (m)
'planarity I O [-n O2]': Legacy command-line (default -s -p)

-q is for quiet mode (no messages to stdout and stderr)

C = command (algorithm implementation to run)
    -p = Planar embedding and Kuratowski subgraph isolation
    -d = Planar graph drawing by visibility representation
    -o = Outerplanar embedding and obstruction isolation
    -2 = Search for subgraph homeomorphic to K_{2,3}
    -3 = Search for subgraph homeomorphic to K_{3,3}
    -4 = Search for subgraph homeomorphic to K_4

K = # of graphs to randomly generate
N = # of vertices in each randomly generated graph
I = Input file (for work on a specific graph)
O = Primary output file
    For example, if C=-p then O receives the planar embedding
    If C=-3, then O receives a subgraph containing a K_{3,3}
O2= Secondary output file
    For -s, if C=-p or -o, then O2 receives the embedding obstruction
    For -s, if C=-d, then O2 receives a drawing of the planar graph
    For -rm and -rn, O2 contains the original randomly generated graph
planarity process results: 0=OK, -1=NOTOK, 1=NONEMBEDDABLE
    1 result only produced by specific graph mode (-s)
      with command -2,-3,-4: found K_{2,3}, K_{3,3} or K_4
      with command -p,-d: found planarity obstruction
      with command -o: found outerplanarity obstruction

	Press return key to exit...
```

</details>

<details>
<summary>-test output</summary>

```
 % ./Debug/planarity -test c/samples

	Starting 1-based Array Index Tests

The graph "maxPlanar5.txt" is planar.
Algorithm 'Planarity' executed on graph in  in 0.000 seconds.
Test succeeded (result equal to exemplar).
 
The graph "maxPlanar5.txt" is planar.
Algorithm 'DrawPlanar' executed on graph in  in 0.000 seconds.
Test succeeded (result equal to exemplar).
Test succeeded (secondary result equal to exemplar).
 
The graph "drawExample.txt" is planar.
Algorithm 'DrawPlanar' executed on graph in  in 0.000 seconds.
Test succeeded (result equal to exemplar).
Test succeeded (secondary result equal to exemplar).
 
The graph "Petersen.txt" is not planar.
Algorithm 'Planarity' executed on graph in  in 0.000 seconds.
Test succeeded (result equal to exemplar).
 
The graph "Petersen.txt" is not outerplanar.
Algorithm 'Outerplanarity' executed on graph in  in 0.000 seconds.
Test succeeded (result equal to exemplar).
 
The graph "Petersen.txt" has a subgraph homeomorphic to K_{2,3}.
Algorithm 'K23Search' executed on graph in  in 0.000 seconds.
Test succeeded (result equal to exemplar).
 
The graph "Petersen.txt" has a subgraph homeomorphic to K_{3,3}.
Algorithm 'K33Search' executed on graph in  in 0.000 seconds.
Test succeeded (result equal to exemplar).
 
The graph "Petersen.txt" has a subgraph homeomorphic to K_4.
Algorithm 'K4Search' executed on graph in  in 0.000 seconds.
Test succeeded (result equal to exemplar).
 
	Finished 1-based Array Index Tests.

The graph "maxPlanar5.0-based.txt" is planar.
Algorithm 'Planarity' executed on graph in  in 0.000 seconds.
Test succeeded (result equal to exemplar).
 
The graph "maxPlanar5.0-based.txt" is planar.
Algorithm 'DrawPlanar' executed on graph in  in 0.000 seconds.
Test succeeded (result equal to exemplar).
Test succeeded (secondary result equal to exemplar).
 
The graph "drawExample.0-based.txt" is planar.
Algorithm 'DrawPlanar' executed on graph in  in 0.000 seconds.
Test succeeded (result equal to exemplar).
Test succeeded (secondary result equal to exemplar).
 
The graph "Petersen.0-based.txt" is not planar.
Algorithm 'Planarity' executed on graph in  in 0.000 seconds.
Test succeeded (result equal to exemplar).
 
The graph "Petersen.0-based.txt" is not outerplanar.
Algorithm 'Outerplanarity' executed on graph in  in 0.000 seconds.
Test succeeded (result equal to exemplar).
 
The graph "Petersen.0-based.txt" has a subgraph homeomorphic to K_{2,3}.
Algorithm 'K23Search' executed on graph in  in 0.000 seconds.
Test succeeded (result equal to exemplar).
 
The graph "Petersen.0-based.txt" has a subgraph homeomorphic to K_{3,3}.
Algorithm 'K33Search' executed on graph in  in 0.000 seconds.
Test succeeded (result equal to exemplar).
 
The graph "Petersen.0-based.txt" has a subgraph homeomorphic to K_4.
Algorithm 'K4Search' executed on graph in  in 0.000 seconds.
Test succeeded (result equal to exemplar).
 
For the transformation -a on file "nauty_example.g6", actual output matched expected output file.
 
For the transformation -a on file "nauty_example.g6", actual output matched expected output file.
 
For the transformation -a on file "N5-all.g6", actual output matched expected output file.
 
For the transformation -a on file "N5-all.g6", actual output matched expected output file.
 
For the transformation -a on file "K10.g6", actual output matched expected output file.
 
For the transformation -a on file "K10.g6", actual output matched expected output file.
 
For the transformation -m on file "nauty_example.g6", actual output matched expected output file.
 
For the transformation -m on file "nauty_example.g6", actual output matched expected output file.
 
For the transformation -m on file "N5-all.g6", actual output matched expected output file.
 
For the transformation -m on file "N5-all.g6", actual output matched expected output file.
 
For the transformation -m on file "K10.g6", actual output matched expected output file.
 
For the transformation -m on file "K10.g6", actual output matched expected output file.
 
For the transformation -g on file "nauty_example.g6.0-based.AdjList.out.txt", actual output matched expected output file.
 
For the transformation -g on file "K10.g6.0-based.AdjList.out.txt", actual output matched expected output file.
 
Start testing all graphs in "n8.mALL.g6".
Done testing all graphs (0.267 seconds).
 
Start testing all graphs in "n8.mALL.g6".
Done testing all graphs (0.299 seconds).
 
Start testing all graphs in "n8.mALL.g6".
Done testing all graphs (0.233 seconds).
 
Start testing all graphs in "n8.mALL.g6".
Done testing all graphs (0.213 seconds).
 
Start testing all graphs in "n8.mALL.g6".
Done testing all graphs (0.265 seconds).
 
Start testing all graphs in "n8.mALL.g6".
Done testing all graphs (0.237 seconds).
 
============

All tests have succeeded.

	Press return key to exit...
```

</details>

<details>
<summary>RandomGraphs() for Planarity with N=100 K=1,000,000</summary>

```
% ./Debug/planarity
...
Enter Choice: 
r
Do you want to 
  Randomly generate graphs (r),
  Specify a graph (s),
  Randomly generate a maximal planar graph (m), or
  Randomly generate a non-planar graph (n)?
r
NOTE: The directories for the graphs you want must exist.
Do you want original graphs in directory 'random'? (y/n)
y
Do you want to output generated graphs to Adjacency List (last 10 only) or to G6 (all)? (a/g)
g
Do you want adj. matrix of embeddable graphs in directory 'embedded' (last 10 max))? (y/n) 
y
Do you want adj. matrix of obstructed graphs in directory 'obstructed' (last 10 max)? (y/n) 
y
Do you want adjacency list format of embeddings in directory 'adjlist' (last 10 max)? (y/n) 
y

...
Enter Choice: 
p
Enter number of graphs to generate:
1000000
Enter size of graphs:
100
1000000
Done (387.739 seconds).
No Errors Found.
Num Embedded=100052.
Minor A = 642973
Minor B = 193642
Minor C = 48643
Minor D = 591
Minor E = 14099

Note: E1 are added to C, E2 are added to A, and E=E3+E4+K5 homeomorphs.

Minor E1 = 37608
Minor E2 = 6834
Minor E3 = 13136
Minor E4 = 806

```

</details>
