### PR TITLE
Use graph order accessor in planarity app

### DIFF
--- a/c/planarityApp/planarityRandomGraphs.c
+++ b/c/planarityApp/planarityRandomGraphs.c
@@ -471,7 +471,7 @@ void ResetGraphStorage(graphP *pGraph, int ReuseGraphs, char command)
         gp_ResetGraphStorage(*pGraph);
     else
     {
-        graphP newGraph = MakeGraph((*pGraph)->N, command);
+        graphP newGraph = MakeGraph(gp_GetN(*pGraph), command);
         gp_Free(pGraph);
         *pGraph = newGraph;
     }

--- a/c/planarityApp/planarityUtils.c
+++ b/c/planarityApp/planarityUtils.c
@@ -752,7 +752,7 @@ char const *GetBaseName(int baseFlag)
 
 int ExtendGraph(graphP theGraph, char command)
 {
-    if (theGraph == NULL || theGraph->N <= 0)
+    if (theGraph == NULL || gp_GetN(theGraph) <= 0)
     {
         gp_ErrorMessage("Unable to extend graph with algorithm extension due "
                         "to NULL or uninitialized graph.");


### PR DESCRIPTION
Resolves #168

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Changes

### Added

* None

### Updated

* `c/planarityApp/planarityRandomGraphs.c` - uses `gp_GetN(*pGraph)` when preserving graph order during graph storage reset.
* `c/planarityApp/planarityUtils.c` - uses `gp_GetN(theGraph)` when checking whether a graph is initialized before extension.

### Removed

* None

## Testing

- Confirmed there are no remaining direct `->N` reads in `c/planarityApp` with `rg -n -S -- ->N c/planarityApp`.
- `git diff --check`
- `gcc -fsyntax-only` on the two changed app files with repository include paths.
- `gcc -fsyntax-only` on the full C source list from `Makefile.am` with repository include paths.

<details><summary>Validation notes</summary>

```text
git diff --check
# no output

rg -n -S -- ->N c/planarityApp
# no output

gcc -fsyntax-only ... c/planarityApp/planarityRandomGraphs.c c/planarityApp/planarityUtils.c
# no output

gcc -fsyntax-only ... <all C sources from Makefile.am>
# no output
```

I could not run the full autotools build locally because this Windows/MSYS2 environment has `gcc` and `make`, but does not have `autoreconf`, `autoconf`, `automake`, or `libtoolize` installed to generate `configure`/`Makefile.in`.

</details>