### PR TITLE
Remediate DFSUtils macro accessors

### DIFF
--- a/c/graphLib/graph.c
+++ b/c/graphLib/graph.c
@@ -2797,8 +2797,8 @@ int gp_RestoreVertices(graphP theGraph)
 
 int _ComputeEdgeRecordType(graphP theGraph, int a, int b, int edgeType)
 {
-    a = gp_IsVirtualVertex(theGraph, a) ? gp_GetVertexFromBicompRoot(theGraph, a) : a;
-    b = gp_IsVirtualVertex(theGraph, b) ? gp_GetVertexFromBicompRoot(theGraph, b) : b;
+    a = gp_IsVirtualVertex(theGraph, a) ? _gp_GetVertexFromBicompRoot(theGraph, a) : a;
+    b = gp_IsVirtualVertex(theGraph, b) ? _gp_GetVertexFromBicompRoot(theGraph, b) : b;
 
     if (a < b)
         return edgeType == EDGE_TYPE_PARENT || edgeType == EDGE_TYPE_CHILD ? EDGE_TYPE_CHILD : EDGE_TYPE_FORWARD;
@@ -2821,8 +2821,8 @@ int _RestoreEdgeType(graphP theGraph, int u, int v)
     int e, eTwin, u_orig, v_orig;
 
     // If u or v is a virtual vertex (a root copy), then get the non-virtual counterpart.
-    u_orig = gp_IsVirtualVertex(theGraph, u) ? (gp_GetVertexFromBicompRoot(theGraph, u)) : u;
-    v_orig = gp_IsVirtualVertex(theGraph, v) ? (gp_GetVertexFromBicompRoot(theGraph, v)) : v;
+    u_orig = gp_IsVirtualVertex(theGraph, u) ? (_gp_GetVertexFromBicompRoot(theGraph, u)) : u;
+    v_orig = gp_IsVirtualVertex(theGraph, v) ? (_gp_GetVertexFromBicompRoot(theGraph, v)) : v;
 
     // Get the edge for which we will set the type
 

--- a/c/graphLib/graphDFSUtils.c
+++ b/c/graphLib/graphDFSUtils.c
@@ -138,7 +138,7 @@ int gp_DepthFirstSearch(graphP theGraph)
 
     for (DFI = v = gp_LowerBoundVertices(theGraph); v < gp_UpperBoundVertices(theGraph); ++v)
     {
-        if (gp_IsNotDFSTreeRoot(theGraph, v))
+        if (_gp_IsNotDFSTreeRoot(theGraph, v))
             continue;
 
         sp_Push2(theStack, NIL, NIL);
@@ -286,7 +286,7 @@ int _SortVertices(graphP theGraph)
     /* Convert DFSParent from v to DFI(v) or vice versa */
 
     for (v = gp_LowerBoundVertices(theGraph); v < gp_UpperBoundVertices(theGraph); ++v)
-        if (gp_IsNotDFSTreeRoot(theGraph, v))
+        if (_gp_IsNotDFSTreeRoot(theGraph, v))
             gp_SetVertexParent(theGraph, v, gp_GetIndex(theGraph, gp_GetVertexParent(theGraph, v)));
 
     /* Sort by 'v using constant time random access. Move each vertex to its

--- a/c/graphLib/graphDFSUtils.h
+++ b/c/graphLib/graphDFSUtils.h
@@ -51,8 +51,8 @@ extern "C"
 
 // A DFS tree root is one that has no DFS parent. There is one DFS tree root
 // per connected component of a graph (connected, not biconnected; component, not bicomp)
-#define gp_IsDFSTreeRoot(theGraph, v) gp_IsNotVertex(theGraph, gp_GetVertexParent(theGraph, v))
-#define gp_IsNotDFSTreeRoot(theGraph, v) gp_IsVertex(theGraph, gp_GetVertexParent(theGraph, v))
+#define gp_IsDFSTreeRoot(theGraph, v) gp_IsNotVertex(theGraph, gp_GetParent(theGraph, v))
+#define gp_IsNotDFSTreeRoot(theGraph, v) gp_IsVertex(theGraph, gp_GetParent(theGraph, v))
 
 // Mapping between bicomp roots and virtual vertex locations used to store them.
 // A cut vertex v separates one or more of its DFS children, say c1 and c2, from
@@ -70,7 +70,7 @@ extern "C"
 // pairs of vertices in, respectively, T(c1) and T(c2).
 #define gp_GetBicompRootFromDFSChild(theGraph, c) ((c) + gp_GetN(theGraph))
 #define gp_GetDFSChildFromBicompRoot(theGraph, R) ((R) - gp_GetN(theGraph))
-#define gp_GetVertexFromBicompRoot(theGraph, R) gp_GetVertexParent(theGraph, gp_GetDFSChildFromBicompRoot(theGraph, R))
+#define gp_GetVertexFromBicompRoot(theGraph, R) gp_GetParent(theGraph, gp_GetDFSChildFromBicompRoot(theGraph, R))
 #define gp_IsBicompRoot(theGraph, v) ((v) >= gp_LowerBoundVirtualVertices(theGraph))
 
 // If a vertex v is a cut vertex that separates one of its DFS children, say c,

--- a/c/graphLib/graphDFSUtils.private.h
+++ b/c/graphLib/graphDFSUtils.private.h
@@ -52,6 +52,10 @@ extern "C"
 #define gp_GetVertexParent(theGraph, v) (theGraphDVI(theGraph)[v].parent)
 #define gp_SetVertexParent(theGraph, v, theParent) (theGraphDVI(theGraph)[v].parent = theParent)
 
+#define _gp_IsDFSTreeRoot(theGraph, v) gp_IsNotVertex(theGraph, gp_GetVertexParent(theGraph, v))
+#define _gp_IsNotDFSTreeRoot(theGraph, v) gp_IsVertex(theGraph, gp_GetVertexParent(theGraph, v))
+#define _gp_GetVertexFromBicompRoot(theGraph, R) gp_GetVertexParent(theGraph, (R) - gp_GetN(theGraph))
+
 #define gp_GetVertexLeastAncestor(theGraph, v) (theGraphDVI(theGraph)[v].leastAncestor)
 #define gp_SetVertexLeastAncestor(theGraph, v, theLeastAncestor) (theGraphDVI(theGraph)[v].leastAncestor = theLeastAncestor)
 

--- a/c/graphLib/graphDFSUtils.private.h
+++ b/c/graphLib/graphDFSUtils.private.h
@@ -8,6 +8,7 @@ See the LICENSE.TXT file for licensing information.
 #define GRAPHDFSUTILS_PRIVATE_H
 
 #include "graph.private.h"
+#include "graphDFSUtils.h"
 
 #ifdef __cplusplus
 extern "C"
@@ -54,7 +55,7 @@ extern "C"
 
 #define _gp_IsDFSTreeRoot(theGraph, v) gp_IsNotVertex(theGraph, gp_GetVertexParent(theGraph, v))
 #define _gp_IsNotDFSTreeRoot(theGraph, v) gp_IsVertex(theGraph, gp_GetVertexParent(theGraph, v))
-#define _gp_GetVertexFromBicompRoot(theGraph, R) gp_GetVertexParent(theGraph, (R) - gp_GetN(theGraph))
+#define _gp_GetVertexFromBicompRoot(theGraph, R) gp_GetVertexParent(theGraph, gp_GetDFSChildFromBicompRoot(theGraph, R))
 
 #define gp_GetVertexLeastAncestor(theGraph, v) (theGraphDVI(theGraph)[v].leastAncestor)
 #define gp_SetVertexLeastAncestor(theGraph, v, theLeastAncestor) (theGraphDVI(theGraph)[v].leastAncestor = theLeastAncestor)

--- a/c/graphLib/homeomorphSearch/graphK33Search.c
+++ b/c/graphLib/homeomorphSearch/graphK33Search.c
@@ -824,7 +824,7 @@ int _FindK33WithMergeBlocker(graphP theGraph, K33SearchContext *context, int v, 
     /* Switch the 'current step' variable v to be equal to the
       non-virtual counterpart of the bicomp root. */
 
-    IC->v = gp_GetVertexFromBicompRoot(theGraph, R);
+    IC->v = _gp_GetVertexFromBicompRoot(theGraph, R);
 
     /* Reset the visitation, pertinence and future pertinence settings from step u_max for step v */
 
@@ -1846,7 +1846,7 @@ int _MarkStraddlingBridgePath(graphP theGraph, int u_min, int u_max, int u_d, in
         if (gp_IsVirtualVertex(theGraph, p))
         {
             gp_SetVisited(theGraph, p);
-            p = gp_GetVertexFromBicompRoot(theGraph, p);
+            p = _gp_GetVertexFromBicompRoot(theGraph, p);
         }
     }
 
@@ -1878,7 +1878,7 @@ int _MarkStraddlingBridgePath(graphP theGraph, int u_min, int u_max, int u_d, in
 
         if (gp_IsVirtualVertex(theGraph, p))
         {
-            p = gp_GetVertexFromBicompRoot(theGraph, p);
+            p = _gp_GetVertexFromBicompRoot(theGraph, p);
             gp_ClearVisited(theGraph, p);
         }
     }

--- a/c/graphLib/homeomorphSearch/graphK4Search.c
+++ b/c/graphLib/homeomorphSearch/graphK4Search.c
@@ -460,7 +460,7 @@ int _K4_ChooseTypeOfNonOuterplanarityMinor(graphP theGraph, int v, int R)
 
     // If the root copy is not a root copy of the current vertex v,
     // then the Walkdown terminated on a descendant bicomp, which is Minor A.
-    if (gp_GetVertexFromBicompRoot(theGraph, R) != v)
+    if (_gp_GetVertexFromBicompRoot(theGraph, R) != v)
         theGraphIC(theGraph)->minorType |= MINORTYPE_A;
 
     // If W has a pertinent child bicomp, then we've found Minor B.
@@ -1076,7 +1076,7 @@ int _K4_GetCumulativeOrientationOnDFSPath(graphP theGraph, int ancestor, int des
        copy before starting the loop */
 
     if (gp_IsVirtualVertex(theGraph, descendant))
-        descendant = gp_GetVertexFromBicompRoot(theGraph, descendant);
+        descendant = _gp_GetVertexFromBicompRoot(theGraph, descendant);
 
     while (descendant != ancestor)
     {
@@ -1086,7 +1086,7 @@ int _K4_GetCumulativeOrientationOnDFSPath(graphP theGraph, int ancestor, int des
         // If we are at a bicomp root, then ascend to its parent copy
         if (gp_IsVirtualVertex(theGraph, descendant))
         {
-            parent = gp_GetVertexFromBicompRoot(theGraph, descendant);
+            parent = _gp_GetVertexFromBicompRoot(theGraph, descendant);
         }
 
         // If we are on a regular, non-virtual vertex then get the edge to the parent

--- a/c/graphLib/planarityRelated/graphDrawPlanar.c
+++ b/c/graphLib/planarityRelated/graphDrawPlanar.c
@@ -91,7 +91,7 @@ int _ComputeVertexPositions(DrawPlanarContext *context)
     {
         // For each DFS tree root in the embedding, we
         // compute the vertex positions
-        if (gp_IsDFSTreeRoot(theEmbedding, v))
+        if (_gp_IsDFSTreeRoot(theEmbedding, v))
         {
             if (_ComputeVertexPositionsInComponent(context, v, &vertpos) != OK)
                 return NOTOK;
@@ -399,7 +399,7 @@ int _ComputeEdgePositions(DrawPlanarContext *context)
         // false generator edge so that it is still "visited" and then
         // all of its edges are generators for its neighbor vertices because
         // they all have greater numbers in the vertex order.
-        if (gp_IsDFSTreeRoot(theEmbedding, v))
+        if (_gp_IsDFSTreeRoot(theEmbedding, v))
         {
             // Set a false generator edge, so the vertex is distinguishable from
             // a vertex with no generator edge when its neighbors are visited
@@ -753,7 +753,7 @@ int _BreakTie(DrawPlanarContext *context, int BicompRoot, int W, int WPrevLink)
             or 'beyond' its parent relative to what. */
 
         context->VI[DFSChild].ancestorChild = gp_GetDFSChildFromBicompRoot(theEmbedding, BicompRoot);
-        context->VI[DFSChild].ancestor = gp_GetVertexFromBicompRoot(theEmbedding, BicompRoot);
+        context->VI[DFSChild].ancestor = _gp_GetVertexFromBicompRoot(theEmbedding, BicompRoot);
 
         _gp_LogLine(_gp_MakeLogStr4("V[child=%d]=.ancestorChild = %d, V[child=%d]=.ancestor = %d",
                                     DFSChild, context->VI[DFSChild].ancestorChild, DFSChild, context->VI[DFSChild].ancestor));
@@ -1242,4 +1242,3 @@ int gp_DrawPlanar_GetEdgeEnd(graphP theEmbedding, int e)
 
     return  context->E[e].end;
 }
-

--- a/c/graphLib/planarityRelated/graphEmbed.c
+++ b/c/graphLib/planarityRelated/graphEmbed.c
@@ -428,7 +428,7 @@ int _EmbeddingInitialize(graphP theGraph)
         // (8) Create the DFS tree embedding using the child edge records stored in the virtual vertices
         //     For each vertex v that is a DFS child, the virtual vertex R that will represent v's parent
         //     in the singleton bicomp with v is at location v + N in the vertex array.
-        if (gp_IsDFSTreeRoot(theGraph, v))
+        if (_gp_IsDFSTreeRoot(theGraph, v))
         {
             gp_SetFirstEdge(theGraph, v, NIL);
             gp_SetLastEdge(theGraph, v, NIL);
@@ -486,7 +486,7 @@ void _EmbedBackEdgeToDescendant(graphP theGraph, int RootSide, int RootVertex, i
 
     /* The forward edge record is removed from the fwdEdgeList of the root's parent copy. */
 
-    parentCopy = gp_GetVertexFromBicompRoot(theGraph, RootVertex);
+    parentCopy = _gp_GetVertexFromBicompRoot(theGraph, RootVertex);
 
     _gp_LogLine(_gp_MakeLogStr5("graphEmbed.c/_EmbedBackEdgeToDescendant() V=%d, R=%d, R_out=%d, W=%d, W_in=%d",
                                 parentCopy, RootVertex, RootSide, W, WPrevLink));
@@ -851,7 +851,7 @@ void _WalkUp(graphP theGraph, int v, int e)
             // Step up from the bicomp root vertex (virtual) to the parent copy of
             // the vertex (non-virtual; called parent copy because it is the one that
             // is in a bicomp with a virtual or non-virtual copy of its DFS parent)
-            Zig = Zag = gp_GetVertexFromBicompRoot(theGraph, R);
+            Zig = Zag = _gp_GetVertexFromBicompRoot(theGraph, R);
             ZigPrevLink = 1;
             ZagPrevLink = 0;
 
@@ -1397,7 +1397,7 @@ int _JoinBicomps(graphP theGraph)
         // If the bicomp root is still active (i.e. an in-use virtual vertex)
         // then merge it with its parent copy vertex (non-virtual)
         if (gp_VirtualVertexInUse(theGraph, R))
-            _MergeVertex(theGraph, gp_GetVertexFromBicompRoot(theGraph, R), 0, R);
+            _MergeVertex(theGraph, _gp_GetVertexFromBicompRoot(theGraph, R), 0, R);
     }
 
     return OK;

--- a/c/graphLib/planarityRelated/graphIsolator.c
+++ b/c/graphLib/planarityRelated/graphIsolator.c
@@ -619,7 +619,7 @@ int _MarkDFSPath(graphP theGraph, int ancestor, int descendant)
     // If we are marking from a root (virtual) vertex upward, then go up to the
     // non-virtual parent copy before starting the loop
     if (gp_IsVirtualVertex(theGraph, descendant))
-        descendant = gp_GetVertexFromBicompRoot(theGraph, descendant);
+        descendant = _gp_GetVertexFromBicompRoot(theGraph, descendant);
 
     // Mark the lowest vertex (the one with the highest number).
     gp_SetVisited(theGraph, descendant);
@@ -637,7 +637,7 @@ int _MarkDFSPath(graphP theGraph, int ancestor, int descendant)
         // counterpart, so that can also be marked as visited.
         if (gp_IsVirtualVertex(theGraph, descendant))
         {
-            parent = gp_GetVertexFromBicompRoot(theGraph, descendant);
+            parent = _gp_GetVertexFromBicompRoot(theGraph, descendant);
         }
 
         // If we are on a regular, non-virtual vertex then get the edge to the parent,

--- a/c/graphLib/planarityRelated/graphNonplanar.c
+++ b/c/graphLib/planarityRelated/graphNonplanar.c
@@ -71,7 +71,7 @@ int _ChooseTypeOfNonplanarityMinor(graphP theGraph, int v, int R)
             then the Walkdown terminated because it couldn't find
             a viable path along a child bicomp, which is Minor A. */
 
-    if (gp_GetVertexFromBicompRoot(theGraph, R) != v)
+    if (_gp_GetVertexFromBicompRoot(theGraph, R) != v)
     {
         theGraphIC(theGraph)->minorType |= MINORTYPE_A;
         return OK;
@@ -202,7 +202,7 @@ int _InitializeNonplanarityContext(graphP theGraph, int v, int R)
     // NOTE: We do not need to set up for xy path identification when we
     //       have minor A, which occurs when the parent copy vertex of
     //       bicomp root R is a descendant of v (not v).
-    if (gp_GetVertexFromBicompRoot(theGraph, R) == v)
+    if (_gp_GetVertexFromBicompRoot(theGraph, R) == v)
     {
         if (_SetVertexTypesForMarkingXYPath(theGraph) != OK)
             return NOTOK;

--- a/c/graphLib/planarityRelated/graphOuterplanarObstruction.c
+++ b/c/graphLib/planarityRelated/graphOuterplanarObstruction.c
@@ -59,7 +59,7 @@ int _ChooseTypeOfNonOuterplanarityMinor(graphP theGraph, int v, int R)
 
     // If the root copy is not a root copy of the current vertex v,
     // then the Walkdown terminated on a descendant bicomp, which is Minor A.
-    if (gp_GetVertexFromBicompRoot(theGraph, R) != v)
+    if (_gp_GetVertexFromBicompRoot(theGraph, R) != v)
     {
         theGraphIC(theGraph)->minorType |= MINORTYPE_A;
         return OK;

--- a/c/graphLib/planarityRelated/graphTests.c
+++ b/c/graphLib/planarityRelated/graphTests.c
@@ -240,7 +240,7 @@ int _CheckEmbeddingFacialIntegrity(graphP theGraph)
     connectedComponents = 0;
     for (v = gp_LowerBoundVertices(theGraph); v < gp_UpperBoundVertices(theGraph); ++v)
     {
-        if (gp_IsDFSTreeRoot(theGraph, v))
+        if (_gp_IsDFSTreeRoot(theGraph, v))
         {
             if (gp_GetVertexDegree(theGraph, v) > 0)
                 NumFaces--;
@@ -282,7 +282,7 @@ int _CheckAllVerticesOnExternalFace(graphP theGraph)
     // mark the vertices as visited
     for (v = gp_LowerBoundVertices(theGraph); v < gp_UpperBoundVertices(theGraph); ++v)
     {
-        if (gp_IsDFSTreeRoot(theGraph, v))
+        if (_gp_IsDFSTreeRoot(theGraph, v))
             _MarkExternalFaceVertices(theGraph, v);
     }
 


### PR DESCRIPTION
## Summary

Fixes #261.

This updates the public DFSUtils macros to use the public `gp_GetParent()` accessor instead of the package-private `gp_GetVertexParent()` macro. For graphLib internals, this adds private underscore-prefixed macro copies and updates internal call sites to use those private versions.

The private `_gp_GetVertexFromBicompRoot()` macro computes the DFS child location directly, so `graphDFSUtils.private.h` remains usable without depending on the public DFSUtils header macro.

## Tests

- `git diff --check`
- Public-header syntax smoke check using `c/graphLib/graphLib.h` with `-Werror=implicit-function-declaration`
- Private-header syntax smoke check using `c/graphLib/graphDFSUtils.private.h` with `-Werror=implicit-function-declaration`
- Direct GCC build of `planarity.exe`
- `/tmp/eaps-planarity-check/planarity.exe -test ./c/samples/`

## Safety

This keeps the existing internal behavior while avoiding private accessor leakage through the installed public header. The change is limited to DFSUtils macro boundaries and internal graphLib call sites.