### PR TITLE
Allow extension immediately after graph creation

### DIFF
--- a/c/graphLib/graphDFSUtils.c
+++ b/c/graphLib/graphDFSUtils.c
@@ -40,7 +40,7 @@ extern void _ClearVertexVisitedFlags(graphP theGraph, int);
 
 int gp_ExtendWith_DFSUtils(graphP theGraph)
 {
-    if (theGraph == NULL || gp_GetN(theGraph) <= 0)
+    if (theGraph == NULL)
         return NOTOK;
 
     // if the Graph has already been extended with DFS Utils,

--- a/c/graphLib/homeomorphSearch/graphK23Search_Extensions.c
+++ b/c/graphLib/homeomorphSearch/graphK23Search_Extensions.c
@@ -51,7 +51,7 @@ int gp_ExtendWith_K23Search(graphP theGraph)
 {
     K23SearchContext *context = NULL;
 
-    if (theGraph == NULL || gp_GetN(theGraph) <= 0)
+    if (theGraph == NULL)
         return NOTOK;
 
     // If the K2,3 search feature has already been attached to the graph

--- a/c/graphLib/homeomorphSearch/graphK33Search_Extensions.c
+++ b/c/graphLib/homeomorphSearch/graphK33Search_Extensions.c
@@ -72,7 +72,7 @@ int gp_ExtendWith_K33Search(graphP theGraph)
 {
     K33SearchContext *context = NULL;
 
-    if (theGraph == NULL || gp_GetN(theGraph) <= 0)
+    if (theGraph == NULL)
         return NOTOK;
 
     // If the K3,3 search feature has already been attached to the graph,

--- a/c/graphLib/homeomorphSearch/graphK4Search_Extensions.c
+++ b/c/graphLib/homeomorphSearch/graphK4Search_Extensions.c
@@ -65,7 +65,7 @@ int gp_ExtendWith_K4Search(graphP theGraph)
 {
     K4SearchContext *context = NULL;
 
-    if (theGraph == NULL || gp_GetN(theGraph) <= 0)
+    if (theGraph == NULL)
         return NOTOK;
 
     // If the K4 search feature has already been attached to the graph,

--- a/c/graphLib/planarityRelated/graphDrawPlanar_Extensions.c
+++ b/c/graphLib/planarityRelated/graphDrawPlanar_Extensions.c
@@ -82,7 +82,7 @@ int gp_ExtendWith_DrawPlanar(graphP theGraph)
 {
     DrawPlanarContext *context = NULL;
 
-    if (theGraph == NULL || gp_GetN(theGraph) <= 0)
+    if (theGraph == NULL)
         return NOTOK;
 
     // If the drawing feature has already been attached to the graph,

--- a/c/graphLib/planarityRelated/graphOuterplanarity_Extensions.c
+++ b/c/graphLib/planarityRelated/graphOuterplanarity_Extensions.c
@@ -24,7 +24,7 @@ See the LICENSE.TXT file for licensing information.
 
 int gp_ExtendWith_Outerplanarity(graphP theGraph)
 {
-    if (theGraph == NULL || gp_GetN(theGraph) <= 0)
+    if (theGraph == NULL)
         return NOTOK;
 
     // If the Graph has already been extended with Outerplanarity,

--- a/c/graphLib/planarityRelated/graphPlanarity_Extensions.c
+++ b/c/graphLib/planarityRelated/graphPlanarity_Extensions.c
@@ -24,7 +24,7 @@ See the LICENSE.TXT file for licensing information.
 
 int gp_ExtendWith_Planarity(graphP theGraph)
 {
-    if (theGraph == NULL || gp_GetN(theGraph) <= 0)
+    if (theGraph == NULL)
         return NOTOK;
 
     // If the Graph has already been extended with Planarity,

--- a/c/planarityApp/planarityTestAllGraphs.c
+++ b/c/planarityApp/planarityTestAllGraphs.c
@@ -139,7 +139,7 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
     order = gp_GetN(origGraphRead);
 
     if ((graphForEmbedding = gp_New()) == NULL ||
-        gp_EnsureVertexCapacity(graphForEmbedding, order) != OK)
+        ExtendGraph(graphForEmbedding, command) != OK)
     {
         gp_ErrorMessage("Unable allocate graph for embedding.");
         g6_FreeReader((&theG6ReadIterator));
@@ -149,9 +149,9 @@ int testAllGraphs(char command, char modifier, char const *const infileName, tes
         return NOTOK;
     }
 
-    if (ExtendGraph(graphForEmbedding, command) != OK)
+    if (gp_EnsureVertexCapacity(graphForEmbedding, order) != OK)
     {
-        gp_ErrorMessage("Unable to extend graph for embedding operation.");
+        gp_ErrorMessage("Unable to expand graph storage for expected number of vertices.");
         g6_FreeReader(&theG6ReadIterator);
         gp_Free(&origGraphRead);
         gp_Free(&graphForEmbedding);

--- a/c/planarityApp/planarityUtils.c
+++ b/c/planarityApp/planarityUtils.c
@@ -752,10 +752,9 @@ char const *GetBaseName(int baseFlag)
 
 int ExtendGraph(graphP theGraph, char command)
 {
-    if (theGraph == NULL || gp_GetN(theGraph) <= 0)
+    if (theGraph == NULL)
     {
-        gp_ErrorMessage("Unable to extend graph with algorithm extension due "
-                        "to NULL or uninitialized graph.");
+        gp_ErrorMessage("Unable to extend graph with algorithm extension due to NULL graph.");
         return NOTOK;
     }
 


### PR DESCRIPTION
## Summary

Fixes #236.

This allows the graph extension functions to be called immediately after `gp_New()` by removing the `N > 0` precondition from the seven `gp_ExtendWith...()` entry points and from the planarity app's `ExtendGraph()` helper.

The `testAllGraphs()` path now extends `graphForEmbedding` before calling `gp_EnsureVertexCapacity()`, so `planarity -test` covers the new supported call order while other paths continue to exercise the existing order.

## Tests

- `git diff --check`
- Direct GCC build of `planarity.exe`
- `/tmp/eaps-planarity-check-236/planarity.exe -test ./c/samples/`
- API smoke test calling each `gp_ExtendWith...()` immediately after `gp_New()` and before capacity expansion

## Safety

The extension initialization paths already defer vertex-capacity-dependent allocation to later operations. This change only removes the early `N <= 0` rejection and adds test coverage for the intended order.