### PR TITLE
Add dynamic edge insertion

### DIFF
--- a/c/graphLib/graph.c
+++ b/c/graphLib/graph.c
@@ -2041,6 +2041,53 @@ int gp_DynamicAddEdge(graphP theGraph, int u, int ulink, int v, int vlink)
 }
 
 /********************************************************************
+ gp_DynamicInsertEdge()
+ Refer to documentation for gp_InsertEdge() for parameter description.
+
+ Calls gp_InsertEdge(); if AT_EDGE_CAPACITY_LIMIT, doubles the edge
+ capacity using gp_EnsureEdgeCapacity(), then retries gp_InsertEdge().
+
+ Returns OK on success, NOTOK on failure.
+ ********************************************************************/
+int gp_DynamicInsertEdge(graphP theGraph, int u, int e_u, int e_ulink,
+                         int v, int e_v, int e_vlink)
+{
+    int Result = OK;
+
+    Result = gp_InsertEdge(theGraph, u, e_u, e_ulink, v, e_v, e_vlink);
+
+    if (Result == AT_EDGE_CAPACITY_LIMIT)
+    {
+        // The candidate edge capacity is double the current capacity
+        int candidateEdgeCapacity = gp_GetEdgeCapacity(theGraph) << 1;
+        int N = gp_GetN(theGraph);
+        int newEdgeCapacity = candidateEdgeCapacity;
+
+        // If the candidate edge capacity exceeds the number of edges
+        // needed in an undirected clique on N vertices, then attempt
+        // to use that as the new edge capacity.
+        if (candidateEdgeCapacity > ((N * (N - 1)) >> 1))
+            newEdgeCapacity = ((N * (N - 1)) >> 1);
+
+        // However, if the edge capacity is already greater than or
+        // equal to that maximum capacity needed for an undirected
+        // clique on N vertices, then we allow the capacity to double
+        // beyond the simple undirected graph limit.
+        if (newEdgeCapacity <= gp_GetEdgeCapacity(theGraph))
+            newEdgeCapacity = candidateEdgeCapacity;
+
+        Result = gp_EnsureEdgeCapacity(theGraph, newEdgeCapacity);
+
+        if (Result != OK)
+            return NOTOK;
+
+        Result = gp_InsertEdge(theGraph, u, e_u, e_ulink, v, e_v, e_vlink);
+    }
+
+    return Result != OK ? NOTOK : Result;
+}
+
+/********************************************************************
  gp_InsertEdge()
 
  This function adds the edge (u, v) such that the edge record added

--- a/c/graphLib/graph.h
+++ b/c/graphLib/graph.h
@@ -67,6 +67,8 @@ extern "C"
     int gp_DynamicAddEdge(graphP theGraph, int u, int ulink, int v, int vlink);
     int gp_InsertEdge(graphP theGraph, int u, int e_u, int e_ulink,
                       int v, int e_v, int e_vlink);
+    int gp_DynamicInsertEdge(graphP theGraph, int u, int e_u, int e_ulink,
+                             int v, int e_v, int e_vlink);
     int gp_DeleteEdge(graphP theGraph, int e);
     int gp_ClearEdgeDirectionFlags(graphP theGraph);
 
@@ -425,7 +427,7 @@ extern "C"
 
 // This value is returned by gp_AddEdge() and gp_InsertEdge() if adding or inserting
 // the edge would exceed the edge capacity limit. The limit can be increased by
-// calling gp_EnsureEdgeCapacity(), or by calling gp_DynamicAddEdge().
+// calling gp_EnsureEdgeCapacity(), gp_DynamicAddEdge(), or gp_DynamicInsertEdge().
 #define AT_EDGE_CAPACITY_LIMIT -1
 
 // A bounds-checking version of gp_IsEdge() for DEBUG mode compilation


### PR DESCRIPTION
## Summary

Fixes #242.

This adds `gp_DynamicInsertEdge()` as the dynamic-capacity counterpart to `gp_InsertEdge()`. The new function first calls `gp_InsertEdge()` directly, and only expands edge capacity when that call returns `AT_EDGE_CAPACITY_LIMIT`; after expanding, it retries insertion through `gp_InsertEdge()`.

The public graph header now declares the new API and the capacity-limit comment mentions both dynamic edge helpers.

## Tests

- `git diff --check`
- API smoke test that sets edge capacity to 1, confirms `gp_InsertEdge()` reaches `AT_EDGE_CAPACITY_LIMIT`, then verifies `gp_DynamicInsertEdge()` expands capacity and inserts successfully
- Direct GCC build of `planarity.exe`
- `/tmp/eaps-planarity-check-242/planarity.exe -test ./c/samples/`

## Safety

The expansion logic matches `gp_DynamicAddEdge()`, and the insertion path always goes through `gp_InsertEdge()` as requested.