### PR TITLE
Add hide/restore regression test

### DIFF
--- a/c/graphLib/graph.c
+++ b/c/graphLib/graph.c
@@ -2443,12 +2443,24 @@ int _HideVertex(graphP theGraph, int vertex)
     // Cycle through all the edges, pushing and hiding each
     while (gp_IsEdge(theGraph, e))
     {
+        if (sp_GetCurrentSize(theGraph->theStack) >= sp_GetCapacity(theGraph->theStack))
+        {
+            gp_ErrorMessage("_HideVertex() is attempting to push to a full stack.");
+            return NOTOK;
+        }
+
         sp_Push(theGraph->theStack, e);
         gp_HideEdge(theGraph, e);
         e = gp_GetNextEdge(theGraph, e);
     }
 
     // Push the additional integers needed by gp_RestoreVertex()
+    if (sp_GetCurrentSize(theGraph->theStack) + 7 > sp_GetCapacity(theGraph->theStack))
+    {
+        gp_ErrorMessage("_HideVertex() is attempting to push to a full stack.");
+        return NOTOK;
+    }
+
     sp_Push(theGraph->theStack, hiddenEdgeStackBottom);
     sp_Push(theGraph->theStack, NIL);
     sp_Push(theGraph->theStack, NIL);
@@ -2737,7 +2749,10 @@ int _RestoreVertex(graphP theGraph)
     int u, v, e_u_succ, e_u_pred, e_v_first, e_v_last, HESB, e;
 
     if (sp_GetCurrentSize(theGraph->theStack) < 7)
+    {
+        gp_ErrorMessage("_RestoreVertex() is attempting to pop from an empty stack.");
         return NOTOK;
+    }
 
     sp_Pop(theGraph->theStack, v);
     sp_Pop(theGraph->theStack, u);
@@ -2794,6 +2809,12 @@ int _RestoreVertex(graphP theGraph)
     }
 
     // Restore the hidden edges of v, if any
+    if (sp_IsEmpty(theGraph->theStack))
+    {
+        gp_ErrorMessage("_RestoreVertex() is attempting to pop from an empty stack.");
+        return NOTOK;
+    }
+
     sp_Pop(theGraph->theStack, HESB);
     return _RestoreHiddenEdges(theGraph, HESB);
 }

--- a/c/planarityApp/planarityCommandLine.c
+++ b/c/planarityApp/planarityCommandLine.c
@@ -26,9 +26,11 @@ int callTransformGraph(int argc, char *argv[]);
 int runSpecificGraphTests(void);
 int runGraphTransformationTests(void);
 int runTestAllGraphsTests(void);
+int runHideRestoreTests(void);
 int runSpecificGraphTest(char const *command, char const *infileName, int inputInMemFlag);
 int runGraphTransformationTest(char const *command, char const *infileName, int inputInMemFlag);
 int runTestAllGraphsTest(char const *commandString, char const *infileName);
+int runHideRestoreTest(graphP theGraph);
 int runDigraphTests(void);
 int testPetersenDigraph(void);
 
@@ -225,6 +227,8 @@ int runQuickRegressionTests(int argc, char *argv[])
     else if (runGraphTransformationTests() != OK)
         retVal = NOTOK;
     else if (runTestAllGraphsTests() != OK)
+        retVal = NOTOK;
+    else if (runHideRestoreTests() != OK)
         retVal = NOTOK;
     else if (runDigraphTests() != OK)
         retVal = NOTOK;
@@ -516,6 +520,128 @@ int runTestAllGraphsTests(void)
     }
 
     return retVal;
+}
+
+int runHideRestoreTests(void)
+{
+    graphP theGraph = NULL;
+    G6ReadIteratorP theG6ReadIterator = NULL;
+    platform_time start, end;
+    int Result = OK;
+    int lineNum = 0;
+
+    gp_Message("Starting Hide/Restore Tests");
+    platform_GetTime(start);
+
+    if ((theGraph = gp_New()) == NULL)
+    {
+        gp_ErrorMessage("Unable to allocate graph for hide/restore tests.");
+        return NOTOK;
+    }
+
+    if (g6_NewReader((&theG6ReadIterator), theGraph) != OK ||
+        g6_InitReaderWithFileName(theG6ReadIterator, "n8.mALL.g6") != OK)
+    {
+        gp_ErrorMessage("Unable to allocate or initialize G6 read iterator for hide/restore tests.");
+        Result = NOTOK;
+    }
+
+    while (Result == OK)
+    {
+        if (g6_ReadGraph(theG6ReadIterator) != OK)
+        {
+            gp_ErrorMessage("Unable to read graph on line %d for hide/restore tests.", lineNum + 1);
+            Result = NOTOK;
+            break;
+        }
+
+        if (g6_EndReached(theG6ReadIterator))
+            break;
+
+        lineNum++;
+
+        if (runHideRestoreTest(theGraph) != OK)
+        {
+            gp_ErrorMessage("Hide/restore test failed for graph on line %d.", lineNum);
+            Result = NOTOK;
+            break;
+        }
+    }
+
+    platform_GetTime(end);
+
+    if (Result == OK)
+        gp_Message("Done running Hide/Restore Tests (%.3lf seconds).", platform_GetDuration(start, end));
+
+    gp_Message(" ");
+
+    g6_FreeReader((&theG6ReadIterator));
+    gp_Free(&theGraph);
+
+    return Result;
+}
+
+int runHideRestoreTest(graphP theGraph)
+{
+    char *beforeStr = NULL, *afterStr = NULL;
+    int Result = OK;
+    int v;
+
+    if (theGraph == NULL)
+    {
+        gp_ErrorMessage("runHideRestoreTest() received NULL graph.");
+        return NOTOK;
+    }
+
+    if (gp_WriteToString(theGraph, &beforeStr, WRITE_ADJLIST) != OK || beforeStr == NULL)
+    {
+        gp_ErrorMessage("Unable to write graph to string before hide/restore test.");
+        Result = NOTOK;
+    }
+
+    for (v = gp_LowerBoundVertices(theGraph); Result == OK && v < gp_UpperBoundVertices(theGraph); ++v)
+    {
+        if (gp_HideVertex(theGraph, v) != OK)
+        {
+            gp_ErrorMessage("gp_HideVertex() failed during hide/restore test.");
+            Result = NOTOK;
+        }
+    }
+
+    if (Result == OK && gp_RestoreVertices(theGraph) != OK)
+    {
+        gp_ErrorMessage("gp_RestoreVertices() failed during hide/restore test.");
+        Result = NOTOK;
+    }
+
+    if (Result == OK)
+    {
+        if (gp_WriteToString(theGraph, &afterStr, WRITE_ADJLIST) != OK || afterStr == NULL)
+        {
+            gp_ErrorMessage("Unable to write graph to string after hide/restore test.");
+            Result = NOTOK;
+        }
+    }
+
+    if (Result == OK && strcmp(beforeStr, afterStr) != 0)
+    {
+        gp_ErrorMessage("Graph changed after hide/restore test.");
+        Result = NOTOK;
+    }
+
+    if (beforeStr != NULL)
+    {
+        free(beforeStr);
+        beforeStr = NULL;
+    }
+
+    if (afterStr != NULL)
+    {
+        free(afterStr);
+        afterStr = NULL;
+    }
+
+    return Result;
 }
 
 int runTestAllGraphsTest(char const *commandString, char const *infileName)


### PR DESCRIPTION
## Summary

Fixes #249.

This adds a hide/restore regression pass to `planarity -test`. The new test reads each graph from `n8.mALL.g6`, writes the graph to an adjacency-list string, hides every vertex, restores all vertices, writes the graph again, and verifies the before/after strings match.

It also adds the requested stack safety checks around `_HideVertex()` pushes and `_RestoreVertex()` pops so malformed or overfull stack states produce a clear `gp_ErrorMessage()` instead of silently relying on unchecked stack operations.

## Tests

- `git diff --check`
- Direct GCC build of `planarity.exe`
- `%TEMP%\eaps-planarity-check-249\planarity.exe -test ./c/samples/`

## Safety

The new test runs only through the existing `planarity -test` regression path. The graph library changes are guard checks only; they do not change hide/restore behavior when stack capacity and contents are valid.