### PR TITLE
Add identify/contract regression test

### DIFF
--- a/c/graphLib/graph.c
+++ b/c/graphLib/graph.c
@@ -2505,6 +2505,13 @@ int _ContractEdge(graphP theGraph, int e)
     v = gp_GetNeighbor(theGraph, e);
 
     eBefore = gp_GetNextEdge(theGraph, e);
+
+    if (sp_GetCurrentSize(theGraph->theStack) >= sp_GetCapacity(theGraph->theStack))
+    {
+        gp_ErrorMessage("_ContractEdge() is attempting to push to a full stack.");
+        return NOTOK;
+    }
+
     sp_Push(theGraph->theStack, e);
     gp_HideEdge(theGraph, e);
 
@@ -2571,6 +2578,11 @@ int _IdentifyVertices(graphP theGraph, int u, int v, int eBefore)
     if (gp_IsEdge(theGraph, e))
     {
         int result = gp_ContractEdge(theGraph, e);
+        int hiddenEdgesStackBottomIndex;
+        int hiddenEdgesStackBottomValue;
+
+        if (result != OK)
+            return result;
 
         // The edge contraction operation pushes one hidden edge then
         // recursively calls this method. This method then pushes K
@@ -2583,8 +2595,8 @@ int _IdentifyVertices(graphP theGraph, int u, int v, int eBefore)
         // six more integers to indicate edges that were moved from
         // v to u, so the "hidden edges stackBottom" is in the next
         // position down.
-        int hiddenEdgesStackBottomIndex = sp_GetCurrentSize(theGraph->theStack) - 7;
-        int hiddenEdgesStackBottomValue = sp_Get(theGraph->theStack, hiddenEdgesStackBottomIndex);
+        hiddenEdgesStackBottomIndex = sp_GetCurrentSize(theGraph->theStack) - 7;
+        hiddenEdgesStackBottomValue = sp_Get(theGraph->theStack, hiddenEdgesStackBottomIndex);
 
         sp_Set(theGraph->theStack, hiddenEdgesStackBottomIndex, hiddenEdgesStackBottomValue - 1);
 
@@ -2614,6 +2626,18 @@ int _IdentifyVertices(graphP theGraph, int u, int v, int eBefore)
     {
         if (gp_GetVisited(theGraph, gp_GetNeighbor(theGraph, e)))
         {
+            if (sp_GetCurrentSize(theGraph->theStack) >= sp_GetCapacity(theGraph->theStack))
+            {
+                gp_ErrorMessage("_IdentifyVertices() is attempting to push to a full stack.");
+                e = gp_GetFirstEdge(theGraph, u);
+                while (gp_IsEdge(theGraph, e))
+                {
+                    gp_ClearVisited(theGraph, gp_GetNeighbor(theGraph, e));
+                    e = gp_GetNextEdge(theGraph, e);
+                }
+                return NOTOK;
+            }
+
             sp_Push(theGraph->theStack, e);
             gp_HideEdge(theGraph, e);
         }
@@ -2630,6 +2654,12 @@ int _IdentifyVertices(graphP theGraph, int u, int v, int eBefore)
 
     // Push the hiddenEdgeStackBottom as a record of how many hidden
     // edges were pushed (also, see above for Contract Edge adjustment)
+    if (sp_GetCurrentSize(theGraph->theStack) + 7 > sp_GetCapacity(theGraph->theStack))
+    {
+        gp_ErrorMessage("_IdentifyVertices() is attempting to push to a full stack.");
+        return NOTOK;
+    }
+
     sp_Push(theGraph->theStack, hiddenEdgeStackBottom);
 
     // Moving v's adjacency list to u is aided by knowing the predecessor
@@ -2796,7 +2826,7 @@ int _RestoreVertex(graphP theGraph)
         if (gp_IsEdge(theGraph, e_v_first))
             gp_SetPrevEdge(theGraph, e_v_first, NIL);
         if (gp_IsEdge(theGraph, e_v_last))
-            gp_SetPrevEdge(theGraph, e_v_last, NIL);
+            gp_SetNextEdge(theGraph, e_v_last, NIL);
 
         // For each edge record restored to v's adjacency list, reassign the 'v' member
         //    of each twin edge record to indicate v rather than u.

--- a/c/planarityApp/planarityCommandLine.c
+++ b/c/planarityApp/planarityCommandLine.c
@@ -27,10 +27,12 @@ int runSpecificGraphTests(void);
 int runGraphTransformationTests(void);
 int runTestAllGraphsTests(void);
 int runHideRestoreTests(void);
+int runIdentifyContractTests(void);
 int runSpecificGraphTest(char const *command, char const *infileName, int inputInMemFlag);
 int runGraphTransformationTest(char const *command, char const *infileName, int inputInMemFlag);
 int runTestAllGraphsTest(char const *commandString, char const *infileName);
 int runHideRestoreTest(graphP theGraph);
+int runIdentifyContractTest(graphP theGraph);
 int runDigraphTests(void);
 int testPetersenDigraph(void);
 
@@ -229,6 +231,8 @@ int runQuickRegressionTests(int argc, char *argv[])
     else if (runTestAllGraphsTests() != OK)
         retVal = NOTOK;
     else if (runHideRestoreTests() != OK)
+        retVal = NOTOK;
+    else if (runIdentifyContractTests() != OK)
         retVal = NOTOK;
     else if (runDigraphTests() != OK)
         retVal = NOTOK;
@@ -626,6 +630,147 @@ int runHideRestoreTest(graphP theGraph)
     if (Result == OK && strcmp(beforeStr, afterStr) != 0)
     {
         gp_ErrorMessage("Graph changed after hide/restore test.");
+        Result = NOTOK;
+    }
+
+    if (beforeStr != NULL)
+    {
+        free(beforeStr);
+        beforeStr = NULL;
+    }
+
+    if (afterStr != NULL)
+    {
+        free(afterStr);
+        afterStr = NULL;
+    }
+
+    return Result;
+}
+
+int runIdentifyContractTests(void)
+{
+    graphP theGraph = NULL;
+    G6ReadIteratorP theG6ReadIterator = NULL;
+    platform_time start, end;
+    int Result = OK;
+    int lineNum = 0;
+
+    gp_Message("Starting Identify/Contract Tests");
+    platform_GetTime(start);
+
+    if ((theGraph = gp_New()) == NULL)
+    {
+        gp_ErrorMessage("Unable to allocate graph for identify/contract tests.");
+        return NOTOK;
+    }
+
+    if (g6_NewReader((&theG6ReadIterator), theGraph) != OK ||
+        g6_InitReaderWithFileName(theG6ReadIterator, "n8.mALL.g6") != OK)
+    {
+        gp_ErrorMessage("Unable to allocate or initialize G6 read iterator for identify/contract tests.");
+        Result = NOTOK;
+    }
+
+    while (Result == OK)
+    {
+        if (g6_ReadGraph(theG6ReadIterator) != OK)
+        {
+            gp_ErrorMessage("Unable to read graph on line %d for identify/contract tests.", lineNum + 1);
+            Result = NOTOK;
+            break;
+        }
+
+        if (g6_EndReached(theG6ReadIterator))
+            break;
+
+        lineNum++;
+
+        if (runIdentifyContractTest(theGraph) != OK)
+        {
+            gp_ErrorMessage("Identify/contract test failed for graph on line %d.", lineNum);
+            Result = NOTOK;
+            break;
+        }
+    }
+
+    platform_GetTime(end);
+
+    if (Result == OK)
+        gp_Message("Done running Identify/Contract Tests (%.3lf seconds).", platform_GetDuration(start, end));
+
+    gp_Message(" ");
+
+    g6_FreeReader((&theG6ReadIterator));
+    gp_Free(&theGraph);
+
+    return Result;
+}
+
+int runIdentifyContractTest(graphP theGraph)
+{
+    char *beforeStr = NULL, *afterStr = NULL;
+    int Result = OK;
+    int vertexOffset;
+    int pairs[7][2];
+    int i;
+
+    if (theGraph == NULL)
+    {
+        gp_ErrorMessage("runIdentifyContractTest() received NULL graph.");
+        return NOTOK;
+    }
+
+    vertexOffset = gp_LowerBoundVertices(theGraph);
+
+    pairs[0][0] = vertexOffset;
+    pairs[0][1] = vertexOffset + 1;
+    pairs[1][0] = vertexOffset + 2;
+    pairs[1][1] = vertexOffset + 3;
+    pairs[2][0] = vertexOffset + 4;
+    pairs[2][1] = vertexOffset + 5;
+    pairs[3][0] = vertexOffset + 6;
+    pairs[3][1] = vertexOffset + 7;
+    pairs[4][0] = vertexOffset;
+    pairs[4][1] = vertexOffset + 2;
+    pairs[5][0] = vertexOffset + 4;
+    pairs[5][1] = vertexOffset + 6;
+    pairs[6][0] = vertexOffset;
+    pairs[6][1] = vertexOffset + 4;
+
+    if (gp_WriteToString(theGraph, &beforeStr, WRITE_ADJLIST) != OK || beforeStr == NULL)
+    {
+        gp_ErrorMessage("Unable to write graph to string before identify/contract test.");
+        Result = NOTOK;
+    }
+
+    for (i = 0; Result == OK && i < 7; i++)
+    {
+        if (gp_IdentifyVertices(theGraph, pairs[i][0], pairs[i][1], NIL) != OK)
+        {
+            gp_ErrorMessage("gp_IdentifyVertices() failed during identify/contract test.");
+            Result = NOTOK;
+        }
+    }
+
+    if (Result == OK && gp_RestoreVertices(theGraph) != OK)
+    {
+        gp_ErrorMessage("gp_RestoreVertices() failed during identify/contract test.");
+        Result = NOTOK;
+    }
+
+    if (Result == OK)
+    {
+        if (gp_WriteToString(theGraph, &afterStr, WRITE_ADJLIST) != OK || afterStr == NULL)
+        {
+            gp_ErrorMessage("Unable to write graph to string after identify/contract test.");
+            Result = NOTOK;
+        }
+    }
+
+    if (Result == OK && strcmp(beforeStr, afterStr) != 0)
+    {
+        gp_ErrorMessage("Graph changed after identify/contract test.");
         Result = NOTOK;
     }
 


### PR DESCRIPTION
## Summary
- Add an identify/contract regression pass to `planarity -test` over `n8.mALL.g6`
- Verify `gp_IdentifyVertices()` / `gp_RestoreVertices()` preserve the adjacency-list representation after reducing each graph to one vertex
- Add stack-capacity checks before identify/contract stack pushes
- Fix restored vertex adjacency lists so the restored last edge has `next` reset to `NIL`

Fixes #250

## Tests
- `git diff --check`
- `gcc -std=c99 -I c -I c\graphLib -I c\graphLib\lowLevelUtils -I c\graphLib\io -I c\graphLib\extensionSystem -I c\graphLib\planarityRelated -I c\graphLib\homeomorphSearch -I c\planarityApp <all c/graphLib and c/planarityApp .c files> -o %TEMP%\eaps-planarity-check-250\planarity.exe`
- `%TEMP%\eaps-planarity-check-250\planarity.exe -test ./c/samples/`
- `clang -std=c99 -I c -I c\graphLib -I c\graphLib\lowLevelUtils -I c\graphLib\io -I c\graphLib\extensionSystem -I c\graphLib\planarityRelated -I c\graphLib\homeomorphSearch -I c\planarityApp <all c/graphLib and c/planarityApp .c files> -o %TEMP%\eaps-planarity-check-250-clang\planarity.exe`
- `%TEMP%\eaps-planarity-check-250-clang\planarity.exe -test ./c/samples/`

Note: I could not run the repository's full autotools CI flow locally because this Windows/MSYS environment does not have `autoreconf` installed.