### PR TITLE
Promote visited index to DFSUtils

### DIFF
--- a/c/graphLib/graph.c
+++ b/c/graphLib/graph.c
@@ -53,7 +53,7 @@ void _ClearEdgeVisitedFlags(graphP theGraph);
 int _ClearAllVisitedFlagsInBicomp(graphP theGraph, int BicompRoot);
 int _ClearAllVisitedFlagsInOtherBicomps(graphP theGraph, int BicompRoot);
 void _ClearEdgeVisitedFlagsInUnembeddedEdges(graphP theGraph);
-int _FillVertexVisitedInfoInBicomp(graphP theGraph, int BicompRoot, int FillValue);
+int _FillVertexVisitedIndexInBicomp(graphP theGraph, int BicompRoot, int FillValue);
 int _ClearObstructionMarksInBicomp(graphP theGraph, int BicompRoot);
 
 int _gp_FindEdge(graphP theGraph, int u, int v);
@@ -502,7 +502,7 @@ void _InitVertexInfo(graphP theGraph, int v)
     gp_SetVertexLeastAncestor(theGraph, v, NIL);
     gp_SetVertexLowpoint(theGraph, v, NIL);
 
-    gp_SetVertexVisitedInfo(theGraph, v, NIL);
+    gp_SetVertexVisitedIndex(theGraph, v, NIL);
     gp_SetVertexPertinentEdge(theGraph, v, NIL);
     gp_SetVertexPertinentRootsList(theGraph, v, NIL);
     gp_SetVertexFuturePertinentChild(theGraph, v, NIL);
@@ -751,9 +751,9 @@ int _SetAllVisitedFlagsOnPath(graphP theGraph, int u, int v, int w, int x)
 }
 
 /********************************************************************
- _FillVertexVisitedInfoInBicomp()
+ _FillVertexVisitedIndexInBicomp()
 
- Places the FillValue into the visitedInfo of the non-virtual vertices
+ Places the FillValue into the visitedIndex of the non-virtual vertices
  in the bicomp rooted by BicompRoot.
 
  This method uses the stack but preserves whatever may have been
@@ -763,7 +763,7 @@ int _SetAllVisitedFlagsOnPath(graphP theGraph, int u, int v, int w, int x)
  Returns OK on success, NOTOK on implementation failure.
  ********************************************************************/
 
-int _FillVertexVisitedInfoInBicomp(graphP theGraph, int BicompRoot, int FillValue)
+int _FillVertexVisitedIndexInBicomp(graphP theGraph, int BicompRoot, int FillValue)
 {
     int v, e;
     int stackBottom = sp_GetCurrentSize(theGraph->theStack);
@@ -774,7 +774,7 @@ int _FillVertexVisitedInfoInBicomp(graphP theGraph, int BicompRoot, int FillValu
         sp_Pop(theGraph->theStack, v);
 
         if (gp_IsNotVirtualVertex(theGraph, v))
-            gp_SetVertexVisitedInfo(theGraph, v, FillValue);
+            gp_SetVertexVisitedIndex(theGraph, v, FillValue);
 
         e = gp_GetFirstEdge(theGraph, v);
         while (gp_IsEdge(theGraph, e))

--- a/c/graphLib/graphDFSUtils.c
+++ b/c/graphLib/graphDFSUtils.c
@@ -590,6 +590,27 @@ int gp_GetParent(graphP theGraph, int v)
 }
 
 /********************************************************************
+ gp_GetVisitedIndex()
+
+ This method returns the visited index of the given vertex v.
+ Returns NIL on error, such as invalid parameters.
+ ********************************************************************/
+int gp_GetVisitedIndex(graphP theGraph, int v)
+{
+    if (theGraph == NULL ||
+        v < gp_LowerBoundVertices(theGraph) || v >= gp_UpperBoundVertices(theGraph))
+    {
+#ifdef DEBUG
+        NOTOK;
+        ;
+#endif
+        return NIL;
+    }
+
+    return gp_GetVertexVisitedIndex(theGraph, v);
+}
+
+/********************************************************************
  gp_GetLeastAncestor()
 
  Once the least ancestors have been computed in the graph, which

--- a/c/graphLib/graphDFSUtils.h
+++ b/c/graphLib/graphDFSUtils.h
@@ -46,6 +46,7 @@ extern "C"
         // one or more of the above methods have been called to create a DFS tree,
         // sort vertices and/or compute least ancestor and lowpoint values
         int gp_GetParent(graphP theGraph, int v);
+        int gp_GetVisitedIndex(graphP theGraph, int v);
         int gp_GetLeastAncestor(graphP theGraph, int v);
         int gp_GetLowpoint(graphP theGraph, int v);
 

--- a/c/graphLib/graphDFSUtils.private.h
+++ b/c/graphLib/graphDFSUtils.private.h
@@ -24,11 +24,16 @@ extern "C"
         parent: The DFI of the DFS tree parent of this vertex
         leastAncestor: min(DFI of neighbors connected by backedge)
         lowpoint: min(leastAncestor, min(lowpoint of DFS Children))
+        visitedIndex: enables algorithms to manage vertex visitation with more than
+                    just a flag.  For example, the planarity test flags visitation
+                    as a step number that implicitly resets on each step, whereas
+                    part of the planar drawing method signifies a first visitation
+                    by storing the index of the first edge used to reach a vertex
     */
 
     struct DFSUtils_VertexInfo
     {
-        int parent, leastAncestor, lowpoint;
+        int parent, leastAncestor, lowpoint, visitedIndex;
     };
 
     typedef struct DFSUtils_VertexInfo DFSUtils_VertexInfo;
@@ -46,6 +51,9 @@ extern "C"
 
 #define gp_GetVertexLowpoint(theGraph, v) (theGraphDVI(theGraph)[v].lowpoint)
 #define gp_SetVertexLowpoint(theGraph, v, theLowpoint) (theGraphDVI(theGraph)[v].lowpoint = theLowpoint)
+
+#define gp_GetVertexVisitedIndex(theGraph, v) (theGraphDVI(theGraph)[v].visitedIndex)
+#define gp_SetVertexVisitedIndex(theGraph, v, newVisitedIndex) (theGraphDVI(theGraph)[v].visitedIndex = newVisitedIndex)
 
 #ifdef __cplusplus
 }

--- a/c/graphLib/graphDFSUtils.private.h
+++ b/c/graphLib/graphDFSUtils.private.h
@@ -25,10 +25,13 @@ extern "C"
         leastAncestor: min(DFI of neighbors connected by backedge)
         lowpoint: min(leastAncestor, min(lowpoint of DFS Children))
         visitedIndex: enables algorithms to manage vertex visitation with more than
-                    just a flag.  For example, the planarity test flags visitation
-                    as a step number that implicitly resets on each step, whereas
-                    part of the planar drawing method signifies a first visitation
-                    by storing the index of the first edge used to reach a vertex
+                    just a flag. In a directed depth-first search, the vertex index
+                    indicates the discovery time, so visitedIndex is needed for the
+                    finish time. The planarity test uses this member to flag
+                    visitation as a step number so that it implicitly resets on each
+                    vertex step of embedding. The planar graph drawing method
+                    signifies a first visitation by storing the index of the first
+                    _edge_ used to reach a vertex.
     */
 
     struct DFSUtils_VertexInfo

--- a/c/graphLib/homeomorphSearch/graphK33Search.c
+++ b/c/graphLib/homeomorphSearch/graphK33Search.c
@@ -13,7 +13,7 @@ See the LICENSE.TXT file for licensing information.
 extern int _ClearAllVisitedFlagsInBicomp(graphP theGraph, int BicompRoot);
 extern int _ClearAllVisitedFlagsInOtherBicomps(graphP theGraph, int BicompRoot);
 extern void _ClearEdgeVisitedFlagsInUnembeddedEdges(graphP theGraph);
-extern int _FillVertexVisitedInfoInBicomp(graphP theGraph, int BicompRoot, int FillValue);
+extern int _FillVertexVisitedIndexInBicomp(graphP theGraph, int BicompRoot, int FillValue);
 
 // extern int  _GetBicompSize(graphP theGraph, int BicompRoot);
 extern int _HideInternalEdges(graphP theGraph, int vertex);
@@ -205,10 +205,10 @@ int _SearchForK33InBicomp(graphP theGraph, K33SearchContext *context, int v, int
     if (_ReduceBicomp(theGraph, context, R) != OK)
         return NOTOK;
 
-    /* Set visitedInfo values in the bicomp to the initialized state so the planarity
+    /* Set visitedIndex values in the bicomp to the initialized state so the planarity
         algorithm can properly do the Walkup procedure in future steps */
 
-    if (_FillVertexVisitedInfoInBicomp(theGraph, IC->r, gp_GetN(theGraph)) != OK)
+    if (_FillVertexVisitedIndexInBicomp(theGraph, IC->r, gp_GetN(theGraph)) != OK)
         return NOTOK;
 
     /* We now intend to ignore the pertinence of W (conceptually eliminating
@@ -830,7 +830,7 @@ int _FindK33WithMergeBlocker(graphP theGraph, K33SearchContext *context, int v, 
 
     for (v = gp_LowerBoundVertices(theGraph); v < gp_UpperBoundVertices(theGraph); ++v)
     {
-        gp_SetVertexVisitedInfo(theGraph, v, gp_GetN(theGraph));
+        gp_SetVertexVisitedIndex(theGraph, v, gp_GetN(theGraph));
         gp_SetVertexPertinentEdge(theGraph, v, NIL);
         gp_SetVertexPertinentRootsList(theGraph, v, NIL);
 
@@ -928,12 +928,12 @@ int _FindK33WithMergeBlocker(graphP theGraph, K33SearchContext *context, int v, 
 
  The depth first search has to "mark" the vertices it has seen as visited,
  but the visited flags are already in use to distinguish the X-Y path.
- So, we reuse the visitedInfo setting of each vertex. The core planarity
+ So, we reuse the visitedIndex setting of each vertex. The core planarity
  algorithm makes settings between 0 and N, so we will regard all of those
  as indicating 'unvisited' by this method, and use -1 to indicate visited.
  These markings need not be cleaned up because, if the desired path is found
  the a K_{3,3} is isolated and if the desired path is not found then the
- bicomp is reduced and the visitedInfo in the remaining vertices are set
+ bicomp is reduced and the visitedIndex in the remaining vertices are set
  appropriately for future Walkup processing of the core planarity algorithm.
 
  For each vertex we visit, if it is an internal vertex on the X-Y path
@@ -941,7 +941,7 @@ int _FindK33WithMergeBlocker(graphP theGraph, K33SearchContext *context, int v, 
  and unroll the stack to obtain the desired path (described below). If the
  vertex is internal but not on the X-Y path (i.e. visited flag clear and
  obstruction type unknown), then we want to visit its neighbors, except
- those already marked visited by this method (i.e. those with visitedInfo
+ those already marked visited by this method (i.e. those with visitedIndex
  of -1) and those with a known obstruction type.
 
  We want to manage the stack so that it when the desired vertex is found,
@@ -950,7 +950,7 @@ int _FindK33WithMergeBlocker(graphP theGraph, K33SearchContext *context, int v, 
  some vertex-edge pair (v, e), we push *only* the next edge after e in
  v's adjacency list (starting with the first if e is NIL) that leads to a
  new 'eligible' vertex.  An eligible vertex is one whose obstruction type
- is unknown and whose visitedInfo is other than -1 (so, internal and not
+ is unknown and whose visitedIndex is other than -1 (so, internal and not
  yet processed by this method). Second, when we decide a new vertex w
  adjacent to v is eligible, we push not only (v, e) but also (w, NIL).
  When we later pop the vertex-edge pair containing NIL, we know that
@@ -964,7 +964,7 @@ int _FindK33WithMergeBlocker(graphP theGraph, K33SearchContext *context, int v, 
  is not the desired connection endpoint to the X-Y path.  We need to process
  all paths extending from it, but we don't want any of those paths to cycle
  back to this vertex, so we mark it as ineligible by putting -1 in its
- visitedInfo member.  This is also the case in which the _first_ edge record e
+ visitedIndex member.  This is also the case in which the _first_ edge record e
  leading from v to an eligible vertex w is obtained, whereupon we push both
  (v, e) and (w, NIL).  Eventually all paths leading from w to eligible
  vertices will be explored, and if none find the desired vertex connection
@@ -1003,7 +1003,7 @@ int _TestForZtoWPath(graphP theGraph)
 
             // Mark this vertex as being visited by this method (i.e. ineligible
             // to have processing started on it again)
-            gp_SetVertexVisitedInfo(theGraph, v, -1);
+            gp_SetVertexVisitedIndex(theGraph, v, -1);
 
             e = gp_GetFirstEdge(theGraph, v);
         }
@@ -1021,7 +1021,7 @@ int _TestForZtoWPath(graphP theGraph)
             // The test for w being a virtual vertex is just safeguarding the two subsequent calls,
             // but it can never happen due to the obstructing X-Y path.
             if (gp_IsNotVirtualVertex(theGraph, w) &&
-                gp_GetVertexVisitedInfo(theGraph, w) != -1 &&
+                gp_GetVertexVisitedIndex(theGraph, w) != -1 &&
                 gp_GetObstructionMark(theGraph, w) == ANYVERTEX_OBSTRUCTIONMARK_UNMARKED)
             {
                 sp_Push2(theGraph->theStack, v, e);

--- a/c/graphLib/homeomorphSearch/graphK4Search.c
+++ b/c/graphLib/homeomorphSearch/graphK4Search.c
@@ -879,7 +879,7 @@ int _K4_ReduceBicompToEdge(graphP theGraph, K4SearchContext *context, int R, int
 
     // Finally, set the visited info state of W to unvisited so that
     // the core embedder (esp. Walkup) will not have any problems.
-    gp_SetVertexVisitedInfo(theGraph, W, gp_GetN(theGraph));
+    gp_SetVertexVisitedIndex(theGraph, W, gp_GetN(theGraph));
 
     return OK;
 }
@@ -980,7 +980,7 @@ int _K4_ReducePathComponent(graphP theGraph, K4SearchContext *context, int R, in
     // will remain in the embedding, and the core embedder (Walkup) uses a
     // value greater than the current vertex to indicate an unvisited vertex
     _K4_ClearVisitedInPathComponent(theGraph, R, prevLink, A);
-    gp_SetVertexVisitedInfo(theGraph, A, gp_GetN(theGraph));
+    gp_SetVertexVisitedIndex(theGraph, A, gp_GetN(theGraph));
 
     // Find the component's remaining edges e_A and e_R incident to A and R
     ZPrevLink = prevLink;

--- a/c/graphLib/planarityRelated/graphDrawPlanar.c
+++ b/c/graphLib/planarityRelated/graphDrawPlanar.c
@@ -329,7 +329,7 @@ void _LogEdgeList(graphP theEmbedding, listCollectionP edgeList, int edgeListHea
   advances through the vertices according to their assigned
   vertical positions.
 
-  The 'visitedInfo' member of each vertex is used to indicate the
+  The 'visitedIndex' member of each vertex is used to indicate the
   location in the edge order list of the generator edge for the vertex.
   The generator edge is the first edge used to visit the vertex from
   a higher vertex in the drawing (i.e. a vertex with an earlier, or
@@ -379,7 +379,7 @@ int _ComputeEdgePositions(DrawPlanarContext *context)
     // Each vertex starts out with a NIL generator edge.
 
     for (v = gp_LowerBoundVertices(theEmbedding); v < gp_UpperBoundVertices(theEmbedding); ++v)
-        gp_SetVertexVisitedInfo(theEmbedding, v, NIL);
+        gp_SetVertexVisitedIndex(theEmbedding, v, NIL);
 
     // Perform the vertical sweep of the combinatorial embedding, using
     // the vertex ordering to guide the sweep.
@@ -405,7 +405,7 @@ int _ComputeEdgePositions(DrawPlanarContext *context)
             // a vertex with no generator edge when its neighbors are visited
             // This way, an edge from a neighbor won't get recorded as the
             // generator edge of the DFS tree root.
-            gp_SetVertexVisitedInfo(theEmbedding, v, NIL - 1);
+            gp_SetVertexVisitedIndex(theEmbedding, v, NIL - 1);
 
             // Now we traverse the adjacency list of the DFS tree root and
             // record each edge as the generator edge of the neighbors
@@ -419,7 +419,7 @@ int _ComputeEdgePositions(DrawPlanarContext *context)
                                             gp_GetIndex(theEmbedding, v), gp_GetIndex(theEmbedding, gp_GetNeighbor(theEmbedding, e))));
 
                 // Set the generator edge for the root's neighbor
-                gp_SetVertexVisitedInfo(theEmbedding, gp_GetNeighbor(theEmbedding, e), e);
+                gp_SetVertexVisitedIndex(theEmbedding, gp_GetNeighbor(theEmbedding, e), e);
 
                 // Go to the next node of the root's adj list
                 e = gp_GetNextEdge(theEmbedding, e);
@@ -431,7 +431,7 @@ int _ComputeEdgePositions(DrawPlanarContext *context)
         {
             // Get the generator edge of the vertex
             // Note that this never gets the false generator edge of a DFS tree root
-            eTwin = gp_GetVertexVisitedInfo(theEmbedding, v);
+            eTwin = gp_GetVertexVisitedIndex(theEmbedding, v);
             if (gp_IsNotEdge(theEmbedding, eTwin))
                 return NOTOK;
             e = gp_GetTwin(theEmbedding, eTwin);
@@ -465,9 +465,9 @@ int _ComputeEdgePositions(DrawPlanarContext *context)
                     // If the vertex does not yet have a generator edge, then set it.
                     // Note that a DFS tree root has a false generator edge, so this if
                     // test avoids setting a generator edge for a DFS tree root
-                    if (gp_IsNotEdge(theEmbedding, gp_GetVertexVisitedInfo(theEmbedding, gp_GetNeighbor(theEmbedding, eCur))))
+                    if (gp_IsNotEdge(theEmbedding, gp_GetVertexVisitedIndex(theEmbedding, gp_GetNeighbor(theEmbedding, eCur))))
                     {
-                        gp_SetVertexVisitedInfo(theEmbedding, gp_GetNeighbor(theEmbedding, eCur), eCur);
+                        gp_SetVertexVisitedIndex(theEmbedding, gp_GetNeighbor(theEmbedding, eCur), eCur);
                         _gp_LogLine(_gp_MakeLogStr2("Generator edge (%d, %d)",
                                                     gp_GetIndex(theEmbedding, gp_GetNeighbor(theEmbedding, gp_GetTwin(theEmbedding, e))),
                                                     gp_GetIndex(theEmbedding, gp_GetNeighbor(theEmbedding, eCur))));

--- a/c/graphLib/planarityRelated/graphEmbed.c
+++ b/c/graphLib/planarityRelated/graphEmbed.c
@@ -410,7 +410,7 @@ int _EmbeddingInitialize(graphP theGraph)
     for (v = gp_UpperBoundVertices(theGraph) - 1; v >= gp_LowerBoundVertices(theGraph); --v)
     {
         // (7) Initialize for pertinence management
-        gp_SetVertexVisitedInfo(theGraph, v, gp_GetN(theGraph));
+        gp_SetVertexVisitedIndex(theGraph, v, gp_GetN(theGraph));
 
         // (7) Initialize for future pertinence management
         child = gp_GetVertexSortedDFSChildList(theGraph, v);
@@ -789,7 +789,7 @@ void _WalkUp(graphP theGraph, int v, int e)
         {
             // If the current vertex along the external face was visited in this step v,
             // then the bicomp root and its ancestor roots have already been added.
-            if (gp_GetVertexVisitedInfo(theGraph, Zig) == v)
+            if (gp_GetVertexVisitedIndex(theGraph, Zig) == v)
                 break;
 
             // Store the bicomp root that was found
@@ -802,28 +802,28 @@ void _WalkUp(graphP theGraph, int v, int e)
 
             // If the opposing vertex was already marked visited in this step, then a prior
             // Walkup already recorded as pertinent the bicomp root and its ancestor roots.
-            if (gp_GetVertexVisitedInfo(theGraph, nextZag) == v)
+            if (gp_GetVertexVisitedIndex(theGraph, nextZag) == v)
                 break;
         }
 
         // Obtain the next vertex in the parallel direction and perform the analogous logic
         else if (gp_IsVirtualVertex(theGraph, (nextZag = gp_GetExtFaceVertex(theGraph, Zag, 1 ^ ZagPrevLink))))
         {
-            if (gp_GetVertexVisitedInfo(theGraph, Zag) == v)
+            if (gp_GetVertexVisitedIndex(theGraph, Zag) == v)
                 break;
             R = nextZag;
             nextZig = gp_GetExtFaceVertex(theGraph, R,
                                           gp_GetExtFaceVertex(theGraph, R, 0) == Zag ? 1 : 0);
-            if (gp_GetVertexVisitedInfo(theGraph, nextZig) == v)
+            if (gp_GetVertexVisitedIndex(theGraph, nextZig) == v)
                 break;
         }
 
         // The bicomp root was not found in either direction.
         else
         {
-            if (gp_GetVertexVisitedInfo(theGraph, Zig) == v)
+            if (gp_GetVertexVisitedIndex(theGraph, Zig) == v)
                 break;
-            if (gp_GetVertexVisitedInfo(theGraph, Zag) == v)
+            if (gp_GetVertexVisitedIndex(theGraph, Zag) == v)
                 break;
             R = NIL;
         }
@@ -831,8 +831,8 @@ void _WalkUp(graphP theGraph, int v, int e)
         // This Walkup has now finished with another vertex along each of the parallel
         // paths, so they are marked visited in step v so that future Walkups in this
         // step v can break if these vertices are encountered again.
-        gp_SetVertexVisitedInfo(theGraph, Zig, v);
-        gp_SetVertexVisitedInfo(theGraph, Zag, v);
+        gp_SetVertexVisitedIndex(theGraph, Zig, v);
+        gp_SetVertexVisitedIndex(theGraph, Zag, v);
 
         // If both directions found new non-root vertices, then proceed with parallel external face traversal
         if (gp_IsNotVirtualVertex(theGraph, R))

--- a/c/graphLib/planarityRelated/graphPlanarity.private.h
+++ b/c/graphLib/planarityRelated/graphPlanarity.private.h
@@ -74,11 +74,6 @@ extern "C"
     //
     Planarity-specific additional vertex information.
 
-        visitedInfo: enables algorithms to manage vertex visitation with more than
-                    just a flag.  For example, the planarity test flags visitation
-                    as a step number that implicitly resets on each step, whereas
-                    part of the planar drawing method signifies a first visitation
-                    by storing the index of the first edge used to reach a vertex
         pertinentEdge: Used by the planarity method; during Walkup, each vertex
                     that is directly adjacent via a back edge to the vertex v
                     currently being embedded will have the forward edge's index
@@ -113,8 +108,6 @@ extern "C"
 
     struct Planarity_VertexInfo
     {
-        int visitedInfo;
-
         int pertinentEdge,
             pertinentRoots,
             futurePertinentChild,
@@ -124,9 +117,6 @@ extern "C"
 
     typedef struct Planarity_VertexInfo Planarity_VertexInfo;
     typedef Planarity_VertexInfo *Planarity_VertexInfoP;
-
-#define gp_GetVertexVisitedInfo(theGraph, v) (theGraphPVI(theGraph)[v].visitedInfo)
-#define gp_SetVertexVisitedInfo(theGraph, v, theVisitedInfo) (theGraphPVI(theGraph)[v].visitedInfo = theVisitedInfo)
 
 #define gp_GetVertexPertinentEdge(theGraph, v) (theGraphPVI(theGraph)[v].pertinentEdge)
 #define gp_SetVertexPertinentEdge(theGraph, v, e) (theGraphPVI(theGraph)[v].pertinentEdge = e)


### PR DESCRIPTION
## Summary
- Move the DFS visitation bookkeeping field from planarity-specific vertex info to DFSUtils vertex info
- Rename the internal field/accessors from `visitedInfo` to `visitedIndex`
- Add public `gp_GetVisitedIndex()` next to `gp_GetParent()`
- Update internal callers and comments to use the new DFSUtils-level visited-index naming

Fixes #269

## Tests
- `git diff --check`
- `gcc -std=c99 -Werror -Wdeclaration-after-statement -I c -I c\graphLib -I c\graphLib\lowLevelUtils -I c\graphLib\io -I c\graphLib\extensionSystem -I c\graphLib\planarityRelated -I c\graphLib\homeomorphSearch -I c\planarityApp <all c/graphLib and c/planarityApp .c files> -o %TEMP%\eaps-planarity-check-269-werror\planarity.exe`
- `%TEMP%\eaps-planarity-check-269-werror\planarity.exe -test ./c/samples/`
- Public header smoke compile for `gp_GetVisitedIndex()` through `c/graphLib/graphLib.h` with `-Werror=implicit-function-declaration`

## Safety
This keeps the existing visitation behavior intact and only moves the storage/accessor layer to DFSUtils, where the upcoming DFSUtils-level digraph DFS can use it.