### PR TITLE
Fix 0-based digraph adjacency list reads

### DIFF
--- a/c/graphLib/io/graphIO.c
+++ b/c/graphLib/io/graphIO.c
@@ -133,7 +133,7 @@ int _ReadAdjList(graphP theGraph, strOrFileP inputContainer)
     int ErrorCode = OK;
 
     int N = 0, v = NIL, W = NIL, adjList = NIL, e = NIL, indexValue = NIL;
-    int zeroBased = FALSE;
+    int zeroBased = FALSE, inputOffset = NIL, inputTerminatorLowerBound = NIL;
 
     if (!sf_IsValidStrOrFile(inputContainer))
         return NOTOK;
@@ -174,15 +174,19 @@ int _ReadAdjList(graphP theGraph, strOrFileP inputContainer)
         if (sf_ReadSkipWhitespace(inputContainer) != OK)
             return NOTOK;
 
-        if (indexValue == 0 && v == gp_LowerBoundVertexStorage(theGraph))
-            zeroBased = TRUE;
+        if (v == gp_LowerBoundVertexStorage(theGraph))
+        {
+            // Infer whether the input file is zero-based or one-based from
+            // the first vertex label, then convert file labels to storage indices.
+            // A zero-based file terminates adjacency lists with any negative
+            // value; a one-based file terminates them with any value below 1.
+            zeroBased = indexValue == 0;
+            inputOffset = gp_LowerBoundVertexStorage(theGraph) - (zeroBased ? 0 : 1);
+            inputTerminatorLowerBound = zeroBased ? 0 : 1;
+        }
 
-        // If we are reading a zero-based input file, then we have to add to the
-        // indexValue for v the offset of the first vertex in storage, which is
-        // usually 1 (because we compile with USE_1BASEDARRAYS by default) but
-        // which may be 0 if this library was compiled with USE_0BASEDARRAYS.
-        if (zeroBased)
-            indexValue += gp_LowerBoundVertexStorage(theGraph);
+        // Convert the file vertex label to the corresponding storage location.
+        indexValue += inputOffset;
 
         // The vertices are expected to be in numeric ascending order
         if (indexValue != v)
@@ -236,17 +240,16 @@ int _ReadAdjList(graphP theGraph, strOrFileP inputContainer)
             if (sf_ReadSkipWhitespace(inputContainer) != OK)
                 return NOTOK;
 
-            // If we are reading a zero-based input file, then we have to add to W
-            // the offset of the first vertex in storage, which is usually 1
-            // (because we compile with USE_1BASEDARRAYS by default) but which may
-            // be 0 if this library was compiled with USE_0BASEDARRAYS.
-            if (zeroBased)
-                W += gp_LowerBoundVertexStorage(theGraph);
-
-            // A value below the valid range indicates the adjacency list end
-            // This was written before gp_IsNotVertex() existed
-            if (W < gp_LowerBoundVertices(theGraph))
+            // The adjacency list terminator belongs to the input numbering base,
+            // so detect it before converting labels to storage locations.
+            if (W < inputTerminatorLowerBound)
                 break;
+
+            W += inputOffset;
+
+            // A value outside the valid range is an error.
+            if (W < gp_LowerBoundVertices(theGraph))
+                return NOTOK;
 
             // A value above the valid range is an error
             if (W >= gp_UpperBoundVertices(theGraph))


### PR DESCRIPTION
## Summary
- normalize adjacency-list vertex labels from the input file base before storage-range checks
- allow `USE_0BASEDARRAYS` builds to read the existing 1-based `Petersen.digraph.txt` fixture
- preserve support for zero-based adjacency-list files that use any negative value as the list terminator

Fixes #272.

## Reproduction
- `gcc -std=c99 -DUSE_0BASEDARRAYS -Werror -Wdeclaration-after-statement -I c -I c\graphLib -I c\graphLib\lowLevelUtils -I c\graphLib\io -I c\graphLib\extensionSystem -I c\graphLib\planarityRelated -I c\graphLib\homeomorphSearch -I c\planarityApp <graphLib and planarityApp sources> -o %TEMP%\eaps-planarity-check-272-repro\planarity-0based.exe`
- `%TEMP%\eaps-planarity-check-272-repro\planarity-0based.exe -test ./c/samples/` failed before the fix at `gp_Read(G, "Petersen.digraph.txt")` in `testPetersenDigraph()`

## Tests
- `git diff --check`
- default strict build: `gcc -std=c99 -Werror -Wdeclaration-after-statement ... -o %TEMP%\eaps-planarity-check-272-1based\planarity.exe`
- `USE_0BASEDARRAYS` strict build: `gcc -std=c99 -DUSE_0BASEDARRAYS -Werror -Wdeclaration-after-statement ... -o %TEMP%\eaps-planarity-check-272-0based\planarity.exe`
- `%TEMP%\eaps-planarity-check-272-1based\planarity.exe -test ./c/samples/`
- `%TEMP%\eaps-planarity-check-272-0based\planarity.exe -test ./c/samples/`
- focused adjacency-list read smoke compiled and ran against graphLib sources in both default and `USE_0BASEDARRAYS` modes, covering `Petersen.digraph.txt` and `drawExample.0-based.txt`
