### PR TITLE
Fix DrawPlanar non-planar writes

### DIFF
--- a/c/graphLib/planarityRelated/graphDrawPlanar.private.h
+++ b/c/graphLib/planarityRelated/graphDrawPlanar.private.h
@@ -70,6 +70,9 @@ extern "C"
                 // Helps distinguish initialize from re-initialize
                 int initialized;
 
+                // Indicates that the visibility representation data is valid
+                int drawingDataValid;
+
                 // The graph that this context augments
                 graphP theGraph;
 

--- a/c/graphLib/planarityRelated/graphDrawPlanar_Extensions.c
+++ b/c/graphLib/planarityRelated/graphDrawPlanar_Extensions.c
@@ -16,6 +16,9 @@ extern void _ClearVertexVisitedFlags(graphP theGraph, int);
 
 extern void _CollectDrawingData(DrawPlanarContext *context, int RootVertex, int W, int WPrevLink);
 extern int _BreakTie(DrawPlanarContext *context, int BicompRoot, int W, int WPrevLink);
+extern int _IsolateKuratowskiSubgraph(graphP theGraph, int v, int R);
+extern int _CheckKuratowskiSubgraphIntegrity(graphP theGraph);
+extern int _TestSubgraph(graphP theSubgraph, graphP theGraph);
 
 extern int _ComputeVisibilityRepresentation(DrawPlanarContext *context);
 extern int _CheckVisibilityRepresentationIntegrity(DrawPlanarContext *context);
@@ -33,6 +36,7 @@ void _DrawPlanar_InitVertexInfo(DrawPlanarContext *context, int v);
 
 int _DrawPlanar_MergeBicomps(graphP theGraph, int v, int RootVertex, int W, int WPrevLink);
 int _DrawPlanar_HandleInactiveVertex(graphP theGraph, int BicompRoot, int *pW, int *pWPrevLink);
+int _DrawPlanar_HandleBlockedBicomp(graphP theGraph, int v, int RootVertex, int R);
 int _DrawPlanar_EmbedPostprocess(graphP theGraph, int v, int edgeEmbeddingResult);
 int _DrawPlanar_CheckEmbeddingIntegrity(graphP theGraph, graphP origGraph);
 int _DrawPlanar_CheckObstructionIntegrity(graphP theGraph, graphP origGraph);
@@ -106,6 +110,7 @@ int gp_ExtendWith_DrawPlanar(graphP theGraph)
 
     // First, tell the context that it is not initialized
     context->initialized = 0;
+    context->drawingDataValid = FALSE;
 
     // Save a pointer to theGraph in the context
     context->theGraph = theGraph;
@@ -117,6 +122,7 @@ int gp_ExtendWith_DrawPlanar(graphP theGraph)
 
     context->functions.fpMergeBicomps = _DrawPlanar_MergeBicomps;
     context->functions.fpHandleInactiveVertex = _DrawPlanar_HandleInactiveVertex;
+    context->functions.fpHandleBlockedBicomp = _DrawPlanar_HandleBlockedBicomp;
     context->functions.fpEmbedPostprocess = _DrawPlanar_EmbedPostprocess;
     context->functions.fpCheckEmbeddingIntegrity = _DrawPlanar_CheckEmbeddingIntegrity;
     context->functions.fpCheckObstructionIntegrity = _DrawPlanar_CheckObstructionIntegrity;
@@ -242,11 +248,15 @@ int _DrawPlanar_CreateStructures(DrawPlanarContext *context)
  ********************************************************************/
 int _DrawPlanar_InitStructures(DrawPlanarContext *context)
 {
+#ifndef USE_1BASEDARRAYS
+    graphP theGraph = context->theGraph;
+#endif
+
+    context->drawingDataValid = FALSE;
+
 #ifdef USE_1BASEDARRAYS
     memset(context->VI, NIL_CHAR, gp_UpperBoundVertices(context->theGraph) * sizeof(DrawPlanar_VertexInfo));
 #else
-    graphP theGraph = context->theGraph;
-
     if (gp_GetN(theGraph) <= 0)
         return NOTOK;
 
@@ -315,6 +325,8 @@ int _DrawPlanar_CopyData(void *dstContext, void *srcContext)
         return _DrawPlanar_InitStructures(dstDrawPlanarContext);
 
     // ELSE: If there is also a srcContext, then we copy data from it
+    dstDrawPlanarContext->drawingDataValid = srcDrawPlanarContext->drawingDataValid;
+
     dstEdgeStorage = gp_UpperBoundEdgeStorage(dstDrawPlanarContext->theGraph);
     srcEdgeStorage = gp_UpperBoundEdgeStorage(srcDrawPlanarContext->theGraph);
 
@@ -565,6 +577,37 @@ int _DrawPlanar_HandleInactiveVertex(graphP theGraph, int BicompRoot, int *pW, i
 /********************************************************************
  ********************************************************************/
 
+int _DrawPlanar_HandleBlockedBicomp(graphP theGraph, int v, int RootVertex, int R)
+{
+    DrawPlanarContext *context = NULL;
+    gp_FindExtension(theGraph, DRAWPLANAR_ID, (void *)&context);
+
+    if (context != NULL)
+    {
+        if (gp_GetEmbedFlags(theGraph) == EMBEDFLAGS_DRAWPLANAR)
+        {
+            int RetVal = NONEMBEDDABLE;
+
+            context->drawingDataValid = FALSE;
+
+            if (R != RootVertex)
+                sp_Push2(theGraph->theStack, R, 0);
+
+            if (_IsolateKuratowskiSubgraph(theGraph, v, RootVertex) != OK)
+                RetVal = NOTOK;
+
+            return RetVal;
+        }
+
+        return context->functions.fpHandleBlockedBicomp(theGraph, v, RootVertex, R);
+    }
+
+    return NOTOK;
+}
+
+/********************************************************************
+ ********************************************************************/
+
 void _DrawPlanar_InitEdgeRec(DrawPlanarContext *context, int e)
 {
     context->E[e].pos = 0;
@@ -602,9 +645,13 @@ int _DrawPlanar_EmbedPostprocess(graphP theGraph, int v, int edgeEmbeddingResult
 
         if (gp_GetEmbedFlags(theGraph) == EMBEDFLAGS_DRAWPLANAR)
         {
+            context->drawingDataValid = FALSE;
+
             if (RetVal == OK)
             {
                 RetVal = _ComputeVisibilityRepresentation(context);
+                if (RetVal == OK)
+                    context->drawingDataValid = TRUE;
             }
         }
 
@@ -638,7 +685,23 @@ int _DrawPlanar_CheckEmbeddingIntegrity(graphP theGraph, graphP origGraph)
 
 int _DrawPlanar_CheckObstructionIntegrity(graphP theGraph, graphP origGraph)
 {
-    return OK;
+    DrawPlanarContext *context = NULL;
+    gp_FindExtension(theGraph, DRAWPLANAR_ID, (void *)&context);
+
+    if (context != NULL)
+    {
+        if (gp_GetEmbedFlags(theGraph) == EMBEDFLAGS_DRAWPLANAR)
+        {
+            if (_TestSubgraph(theGraph, origGraph) != TRUE)
+                return NOTOK;
+
+            return _CheckKuratowskiSubgraphIntegrity(theGraph);
+        }
+
+        return context->functions.fpCheckObstructionIntegrity(theGraph, origGraph);
+    }
+
+    return NOTOK;
 }
 
 /********************************************************************
@@ -690,6 +753,8 @@ int _DrawPlanar_ReadPostprocess(graphP theGraph, char *extraData)
 
                 extraData = strchr(extraData, '\n') + 1;
             }
+
+            context->drawingDataValid = TRUE;
         }
 
         return OK;
@@ -725,9 +790,14 @@ int _DrawPlanar_WritePostprocess(graphP theGraph, char **pExtraData)
             int v, e;
             char line[64];
             int maxLineSize = 64, extraDataPos = 0;
-            char *extraData = (char *)calloc((1 + gp_GetN(theGraph) + 2 * gp_GetM(theGraph) + 1) * maxLineSize, sizeof(char));
+            char *extraData = NULL;
             int zeroBasedVertexOffset = 0;
             int zeroBasedEdgeOffset = 0;
+
+            if (!context->drawingDataValid)
+                return OK;
+
+            extraData = (char *)calloc((1 + gp_GetN(theGraph) + 2 * gp_GetM(theGraph) + 1) * maxLineSize, sizeof(char));
 
             if (extraData == NULL)
                 return NOTOK;

--- a/c/graphLib/planarityRelated/graphDrawPlanar_Extensions.c
+++ b/c/graphLib/planarityRelated/graphDrawPlanar_Extensions.c
@@ -140,8 +140,8 @@ int gp_ExtendWith_DrawPlanar(graphP theGraph)
     // Store the Draw context, including the data structure and the
     // function pointers, as an extension of the graph
     if (gp_AddExtension(theGraph, &DRAWPLANAR_ID, (void *)context,
-                        _DrawPlanar_DupContext, 
-                        _DrawPlanar_CopyData, 
+                        _DrawPlanar_DupContext,
+                        _DrawPlanar_CopyData,
                         _DrawPlanar_FreeContext,
                         &context->functions) != OK)
     {
@@ -200,6 +200,8 @@ void _DrawPlanar_ClearStructures(DrawPlanarContext *context)
         context->E = NULL;
         context->VI = NULL;
 
+        context->drawingDataValid = FALSE;
+
         context->initialized = 1;
     }
     else
@@ -214,6 +216,8 @@ void _DrawPlanar_ClearStructures(DrawPlanarContext *context)
             free(context->VI);
             context->VI = NULL;
         }
+
+        context->drawingDataValid = FALSE;
     }
 }
 
@@ -248,15 +252,10 @@ int _DrawPlanar_CreateStructures(DrawPlanarContext *context)
  ********************************************************************/
 int _DrawPlanar_InitStructures(DrawPlanarContext *context)
 {
-#ifndef USE_1BASEDARRAYS
-    graphP theGraph = context->theGraph;
-#endif
-
-    context->drawingDataValid = FALSE;
-
 #ifdef USE_1BASEDARRAYS
     memset(context->VI, NIL_CHAR, gp_UpperBoundVertices(context->theGraph) * sizeof(DrawPlanar_VertexInfo));
 #else
+    graphP theGraph = context->theGraph;
     if (gp_GetN(theGraph) <= 0)
         return NOTOK;
 
@@ -265,6 +264,8 @@ int _DrawPlanar_InitStructures(DrawPlanarContext *context)
 #endif
 
     memset(context->E, 0, gp_UpperBoundEdgeStorage(context->theGraph) * sizeof(DrawPlanar_EdgeRec));
+
+    context->drawingDataValid = FALSE;
 
     return OK;
 }

--- a/c/planarityApp/planarityCommandLine.c
+++ b/c/planarityApp/planarityCommandLine.c
@@ -34,6 +34,7 @@ int runTestAllGraphsTest(char const *commandString, char const *infileName);
 int runHideRestoreTest(graphP theGraph);
 int runIdentifyContractTest(graphP theGraph);
 int runDigraphTests(void);
+int runDrawPlanarNonplanarWriteTest(void);
 int testPetersenDigraph(void);
 
 /****************************************************************************
@@ -280,6 +281,12 @@ int runSpecificGraphTests(void)
         retVal = NOTOK;
     }
 
+    if (runDrawPlanarNonplanarWriteTest() != OK)
+    {
+        gp_ErrorMessage("DrawPlanar non-planar write test on Petersen.txt failed.");
+        retVal = NOTOK;
+    }
+
     if (runSpecificGraphTest("-o", "Petersen.txt", TRUE) != OK)
     {
         gp_ErrorMessage("Outerplanarity test on Petersen.txt failed.");
@@ -356,6 +363,63 @@ int runSpecificGraphTests(void)
     }
 
     return retVal;
+}
+
+int runDrawPlanarNonplanarWriteTest(void)
+{
+    int Result = OK;
+    graphP theGraph = NULL, origGraph = NULL;
+    char *actualOutput = NULL;
+
+    if ((theGraph = gp_New()) == NULL)
+        return NOTOK;
+
+    if (gp_Read(theGraph, "Petersen.txt") != OK)
+        Result = NOTOK;
+
+    if (Result == OK)
+    {
+        origGraph = gp_DupGraph(theGraph);
+        if (origGraph == NULL)
+            Result = NOTOK;
+    }
+
+    if (Result == OK && gp_ExtendWith_DrawPlanar(theGraph) != OK)
+        Result = NOTOK;
+
+    if (Result == OK)
+    {
+        Result = gp_Embed(theGraph, EMBEDFLAGS_DRAWPLANAR);
+        if (Result != NONEMBEDDABLE)
+            Result = NOTOK;
+    }
+
+    if (Result == NONEMBEDDABLE)
+    {
+        Result = gp_TestEmbedResultIntegrity(theGraph, origGraph, Result);
+        if (Result != NONEMBEDDABLE)
+            Result = NOTOK;
+    }
+
+    if (Result == NONEMBEDDABLE && gp_SortVertices(theGraph) != OK)
+        Result = NOTOK;
+
+    if (Result == NONEMBEDDABLE)
+    {
+        if (gp_WriteToString(theGraph, &actualOutput, WRITE_ADJLIST) != OK ||
+            TextFileMatchesString("Petersen.txt.Planarity.out.txt", actualOutput) != TRUE)
+        {
+            Result = NOTOK;
+        }
+    }
+
+    if (actualOutput != NULL)
+        free(actualOutput);
+
+    gp_Free(&origGraph);
+    gp_Free(&theGraph);
+
+    return Result == NONEMBEDDABLE ? OK : Result;
 }
 
 int runGraphTransformationTests(void)

--- a/c/planarityApp/planarityCommandLine.c
+++ b/c/planarityApp/planarityCommandLine.c
@@ -371,18 +371,16 @@ int runDrawPlanarNonplanarWriteTest(void)
     graphP theGraph = NULL, origGraph = NULL;
     char *actualOutput = NULL;
 
-    if ((theGraph = gp_New()) == NULL)
-        return NOTOK;
+    gp_Message("Calling DrawPlanar Algorithm on a non-planar graph.");
 
-    if (gp_Read(theGraph, "Petersen.txt") != OK)
+    if ((theGraph = gp_New()) == NULL)
         Result = NOTOK;
 
-    if (Result == OK)
-    {
-        origGraph = gp_DupGraph(theGraph);
-        if (origGraph == NULL)
-            Result = NOTOK;
-    }
+    if (Result == OK && gp_Read(theGraph, "Petersen.txt") != OK)
+        Result = NOTOK;
+
+    if (Result == OK && (origGraph = gp_DupGraph(theGraph)) == NULL)
+        Result = NOTOK;
 
     if (Result == OK && gp_ExtendWith_DrawPlanar(theGraph) != OK)
         Result = NOTOK;
@@ -411,6 +409,8 @@ int runDrawPlanarNonplanarWriteTest(void)
         {
             Result = NOTOK;
         }
+        else
+            gp_Message("Test succeeded.\n");
     }
 
     if (actualOutput != NULL)
@@ -1097,14 +1097,14 @@ int runGraphTransformationTest(char const *command, char const *infileName, int 
 
                 if (Result == TRUE)
                 {
-                    gp_Message("For the transformation %s on file \"%.*s\", "
+                    gp_Message("For the transformation %s on \"%.*s\", "
                                "actual output matched expected output file.",
                                command, FILENAME_MAX, infileName);
                     Result = OK;
                 }
                 else
                 {
-                    gp_ErrorMessage("For the transformation %s on file \"%.*s\", "
+                    gp_ErrorMessage("For the transformation %s on \"%.*s\", "
                                     "actual output did not match expected "
                                     "output file.",
                                     command, FILENAME_MAX, infileName);


### PR DESCRIPTION
﻿## Summary
- route DrawPlanar blocked-bicomp handling through the same Kuratowski obstruction isolation used by Planarity
- track when DrawPlanar visibility data is valid, and suppress DrawPlanar extra output for non-planar obstruction writes
- add a `planarity -test` regression that runs DrawPlanar on `Petersen.txt` and compares the written obstruction to `Petersen.txt.Planarity.out.txt`

Fixes #262.

## Root cause
DrawPlanar uses `EMBEDFLAGS_DRAWPLANAR`, so the base blocked-bicomp path did not run the exact-`EMBEDFLAGS_PLANAR` Kuratowski isolation branch. Its obstruction integrity hook also returned success without checking the core obstruction, and the write postprocess always appended DrawPlanar visibility data even when no planar drawing existed.

## Validation
- `git diff --check`
- default strict build: `gcc -std=c99 -Werror -Wdeclaration-after-statement ... -o %TEMP%\eaps-planarity-check-262-final\planarity.exe`
- `%TEMP%\eaps-planarity-check-262-final\planarity.exe -test .\c\samples\`
- `USE_0BASEDARRAYS` strict build: `gcc -std=c99 -DUSE_0BASEDARRAYS -Werror -Wdeclaration-after-statement ... -o %TEMP%\eaps-planarity-check-262-0based\planarity.exe`
- focused default graphLib smoke for DrawPlanar on `Petersen.txt`: `gp_Embed()` returned `NONEMBEDDABLE`, `gp_TestEmbedResultIntegrity()` returned `NONEMBEDDABLE`, `gp_WriteToString()` succeeded, and the output had no `<DrawPlanar>` block
- focused `USE_0BASEDARRAYS` smoke for DrawPlanar on `Petersen.0-based.txt`: write succeeded and produced no `<DrawPlanar>` block

Note: I did not run the full sample suite under `USE_0BASEDARRAYS` because upstream `master` still has the separate digraph adjacency-list issue tracked by #272 / PR #275.
