### PR TITLE
Implement extension lookup table

### DIFF
--- a/c/graphLib/extensionSystem/graphExtensions.c
+++ b/c/graphLib/extensionSystem/graphExtensions.c
@@ -8,6 +8,7 @@ See the LICENSE.TXT file for licensing information.
 #include <string.h>
 
 #include "../lowLevelUtils/appconst.h"
+#include "../graph.private.h"
 
 #include "graphExtensions.private.h"
 #include "graphExtensions.h"
@@ -182,7 +183,12 @@ int gp_AddExtension(graphP theGraph,
 
     if (theGraph == NULL || pModuleID == NULL ||
         context == NULL || copyData == NULL || freeContext == NULL ||
-        functions == NULL)
+        functions == NULL || theGraph->extensionLookupTable == NULL)
+    {
+        return NOTOK;
+    }
+
+    if (*pModuleID < 0 || *pModuleID > MAXNUMSUPPORTEDEXTENSIONS)
     {
         return NOTOK;
     }
@@ -196,6 +202,10 @@ int gp_AddExtension(graphP theGraph,
     // Assign a unique ID to the extension if it does not already have one
     if (*pModuleID == 0)
     {
+        if (moduleIDGenerator >= MAXNUMSUPPORTEDEXTENSIONS)
+        {
+            return NOTOK;
+        }
         *pModuleID = ++moduleIDGenerator;
     }
 
@@ -218,6 +228,7 @@ int gp_AddExtension(graphP theGraph,
     // Make the new linkages
     newExtension->next = (struct graphExtensionStruct *)theGraph->extensions;
     theGraph->extensions = newExtension;
+    theGraph->extensionLookupTable[newExtension->moduleID] = newExtension;
 
     // The new extension was successfully added
     return OK;
@@ -273,32 +284,28 @@ void _OverloadFunctions(graphP theGraph, graphFunctionTableP functions)
 
 int gp_FindExtension(graphP theGraph, int moduleID, void **pContext)
 {
-    graphExtensionP first = NULL, next = NULL;
+    graphExtensionP extension = NULL;
 
     if (pContext != NULL)
     {
         *pContext = NULL;
     }
 
-    if (theGraph == NULL || moduleID == 0)
+    if (theGraph == NULL || moduleID <= 0 ||
+        moduleID > MAXNUMSUPPORTEDEXTENSIONS ||
+        theGraph->extensionLookupTable == NULL)
     {
         return FALSE;
     }
 
-    first = theGraph->extensions;
-
-    while (first != NULL)
+    extension = theGraph->extensionLookupTable[moduleID];
+    if (extension != NULL)
     {
-        next = (graphExtensionP)first->next;
-        if (first->moduleID == moduleID)
+        if (pContext != NULL)
         {
-            if (pContext != NULL)
-            {
-                *pContext = first->context;
-            }
-            return TRUE;
+            *pContext = extension->context;
         }
-        first = next;
+        return TRUE;
     }
 
     return FALSE;
@@ -342,7 +349,9 @@ int gp_RemoveExtension(graphP theGraph, int moduleID)
 {
     graphExtensionP prev = NULL, curr = NULL, next = NULL;
 
-    if (theGraph == NULL || moduleID == 0)
+    if (theGraph == NULL || moduleID <= 0 ||
+        moduleID > MAXNUMSUPPORTEDEXTENSIONS ||
+        theGraph->extensionLookupTable == NULL)
         return NOTOK;
 
     curr = theGraph->extensions;
@@ -372,6 +381,7 @@ int gp_RemoveExtension(graphP theGraph, int moduleID)
             theGraph->extensions = next;
 
         // Free the curr extension
+        theGraph->extensionLookupTable[curr->moduleID] = NULL;
         _FreeExtension(curr);
     }
 
@@ -448,7 +458,8 @@ int gp_DupExtensions(graphP dstGraph, graphP srcGraph)
 {
     graphExtensionP next = NULL, newNext = NULL, newLast = NULL;
 
-    if (srcGraph == NULL || dstGraph == NULL)
+    if (srcGraph == NULL || dstGraph == NULL ||
+        dstGraph->extensionLookupTable == NULL)
         return NOTOK;
 
     gp_FreeExtensions(dstGraph);
@@ -457,6 +468,12 @@ int gp_DupExtensions(graphP dstGraph, graphP srcGraph)
 
     while (next != NULL)
     {
+        if (next->moduleID <= 0 || next->moduleID > MAXNUMSUPPORTEDEXTENSIONS)
+        {
+            gp_FreeExtensions(dstGraph);
+            return NOTOK;
+        }
+
         if ((newNext = (graphExtensionP)malloc(sizeof(graphExtensionStruct))) == NULL)
         {
             gp_FreeExtensions(dstGraph);
@@ -471,6 +488,10 @@ int gp_DupExtensions(graphP dstGraph, graphP srcGraph)
         newNext->functions = next->functions;
         newNext->next = NULL;
 
+        // Add the new extension to the dstGraph extension lookup table
+        dstGraph->extensionLookupTable[newNext->moduleID] = newNext;
+
+        // Add the new extension to the dstGraph extensions linked list
         if (newLast != NULL)
             newLast->next = (struct graphExtensionStruct *)newNext;
         else
@@ -488,37 +509,17 @@ int gp_DupExtensions(graphP dstGraph, graphP srcGraph)
  gp_CopyExtensions()
  ********************************************************************/
 
-// This number can just be made bigger if ever needed
-#define MAXNUMSUPPORTEDEXTENSIONS 32
-
 int gp_CopyExtensions(graphP dstGraph, graphP srcGraph)
 {
     graphExtensionP dstExtension = NULL, srcExtension = NULL;
-    graphExtensionP srcExtensionIDMap[MAXNUMSUPPORTEDEXTENSIONS+1];
 
-    if (srcGraph == NULL || dstGraph == NULL)
+    if (srcGraph == NULL || dstGraph == NULL ||
+        srcGraph->extensionLookupTable == NULL ||
+        dstGraph->extensionLookupTable == NULL)
         return NOTOK;
 
     if (gp_GetN(dstGraph) != gp_GetN(srcGraph) || gp_GetN(dstGraph) == 0)
         return NOTOK;
-
-    // NULL out the pointers in the srcExtensionIDMap
-    memset(srcExtensionIDMap, 0, (MAXNUMSUPPORTEDEXTENSIONS+1)*sizeof(graphExtensionP));
-
-    // Run through the srcGraph extensions linked list and put the pointer to 
-    // each extension in the srcExtensionIDMap at the index location indicated
-    // by the extension module ID. This mapping is needed because the srcGraph
-    // may have been extended with the extensions in a different order than the
-    // dstGraph, but the moduleID for each extension is the same across graphs. 
-    srcExtension = srcGraph->extensions;
-    while (srcExtension != NULL)
-    {
-        if (srcExtension->moduleID < 0 || srcExtension->moduleID > MAXNUMSUPPORTEDEXTENSIONS)
-            return NOTOK;
-
-        srcExtensionIDMap[srcExtension->moduleID] = srcExtension;
-        srcExtension = (graphExtensionP)srcExtension->next;        
-    }
 
     // For each extension in the dstGraph, if the srcGraph has the same extension,
     // then we invoke the extension's copyData to copy from srcGraph to dstGraph.
@@ -528,7 +529,11 @@ int gp_CopyExtensions(graphP dstGraph, graphP srcGraph)
     dstExtension = dstGraph->extensions;
     while (dstExtension != NULL)
     {
-        srcExtension = srcExtensionIDMap[dstExtension->moduleID];
+        if (dstExtension->moduleID <= 0 ||
+            dstExtension->moduleID > MAXNUMSUPPORTEDEXTENSIONS)
+            return NOTOK;
+
+        srcExtension = srcGraph->extensionLookupTable[dstExtension->moduleID];
         if (dstExtension->copyData(dstExtension->context, srcExtension ? srcExtension->context : NULL) != OK)
             return NOTOK;
 
@@ -562,6 +567,10 @@ void gp_FreeExtensions(graphP theGraph)
         }
 
         theGraph->extensions = NULL;
+        if (theGraph->extensionLookupTable != NULL)
+        {
+            memset(theGraph->extensionLookupTable, 0, (MAXNUMSUPPORTEDEXTENSIONS+1)*sizeof(graphExtensionP));
+        }
         _InitFunctionTable(theGraph);
     }
 }

--- a/c/graphLib/graph.c
+++ b/c/graphLib/graph.c
@@ -113,10 +113,13 @@ graphP gp_New(void)
     graphP theGraph = (graphP)calloc(1, sizeof(graphStruct));
     graphFunctionTableP functionTable = (graphFunctionTableP)calloc(1, sizeof(graphFunctionTableStruct));
     graphPrivateDataP theGraphPrivateData = (graphPrivateDataP)calloc(1, sizeof(graphPrivateDataStruct));
+    graphExtensionP *extensionLookupTable = (graphExtensionP *)calloc(MAXNUMSUPPORTEDEXTENSIONS+1, sizeof(graphExtensionP));
 
-    if (theGraph != NULL && functionTable != NULL && theGraphPrivateData != NULL)
+    if (theGraph != NULL && functionTable != NULL &&
+        theGraphPrivateData != NULL && extensionLookupTable != NULL)
     {
         theGraph->privateData = (void *)theGraphPrivateData;
+        theGraph->extensionLookupTable = extensionLookupTable;
 
         theGraph->functions = functionTable;
         _InitFunctionTable(theGraph);
@@ -139,6 +142,11 @@ graphP gp_New(void)
         {
             free(theGraphPrivateData);
             theGraphPrivateData = NULL;
+        }
+        if (extensionLookupTable != NULL)
+        {
+            free(extensionLookupTable);
+            extensionLookupTable = NULL;
         }
     }
 
@@ -917,6 +925,11 @@ void gp_Free(graphP *pGraph)
     {
         free((*pGraph)->privateData);
         (*pGraph)->privateData = NULL;
+    }
+    if ((*pGraph)->extensionLookupTable != NULL)
+    {
+        free((*pGraph)->extensionLookupTable);
+        (*pGraph)->extensionLookupTable = NULL;
     }
 
     free(*pGraph);

--- a/c/graphLib/graph.private.h
+++ b/c/graphLib/graph.private.h
@@ -206,4 +206,7 @@ extern "C"
 }
 #endif
 
+// This number can just be made bigger if ever needed
+#define MAXNUMSUPPORTEDEXTENSIONS 32
+
 #endif /* GRAPHUTILS_PRIVATE_H */


### PR DESCRIPTION
﻿## Summary
- allocate and free `extensionLookupTable` with each graph instance
- maintain the lookup table when extensions are added, removed, duplicated, copied, and freed
- replace the temporary `srcExtensionIDMap` copy helper with the source graph lookup table

Closes #239.

## Testing
- `git diff --check`
- `gcc -O2 -Wall -Wextra -Werror -Wno-unused-parameter -o ./planarity.exe <all planarityApp + graphLib C sources>`
- `./planarity.exe -test ./c/samples/`
- `./planarity.exe -r -3 100000 20`
- `gcc -O2 -Wall -Wextra -Werror -Wno-unused-parameter -DUSE_0BASEDARRAYS -o ./planarity-0based.exe <all planarityApp + graphLib C sources>`
- `./planarity-0based.exe -r -3 100000 20`
- default and `USE_0BASEDARRAYS` stdin-fed graphLib smoke harnesses for `gp_CopyGraph()` and `gp_DupGraph()` with K3,3/K4 extensions attached in different source/destination orders

Note: a full `USE_0BASEDARRAYS` `./planarity-0based.exe -test ./c/samples/` run still reaches the known Petersen digraph failure covered by #272/#275; the focused extension stress checks above pass.
