### PR TITLE
Overload gp_DeleteEdge

### DIFF
--- a/c/graphLib/extensionSystem/graphExtensions.c
+++ b/c/graphLib/extensionSystem/graphExtensions.c
@@ -95,15 +95,11 @@ static int moduleIDGenerator = 0;
      if your feature is attached but not active or if your feature
      augments the base behavior rather than replacing it.
 
-     a) If extra data must be maintained at the graph, vertex or edge 
-        levels, then fpEnsureVertexCapacity(), fpEnsureEdgeCapacity(), 
-        and fpResetGraphStorage() must be overloaded.
+     a) If extra data must be maintained at the graph, vertex or edge
+        levels, then fpEnsureVertexCapacity(), fpEnsureEdgeCapacity(),
+        fpDeleteEdge(), and fpResetGraphStorage() must be overloaded.
 
-     b) For a parallel array of edge data, the extension must currently
-        provides its own _Feature_DeleteEdge() that initializes its edge
-        extension data along with calling gp_DeleteEdge().
-
-     c) If any data must be persisted in the file format, then overloads
+     b) If any data must be persisted in the file format, then overloads
         of fpReadPostprocess() and fpWritePostprocess() are needed.
 
   7) Define internal functions for _Feature_ClearStructures(),

--- a/c/graphLib/extensionSystem/graphFunctionTable.h
+++ b/c/graphLib/extensionSystem/graphFunctionTable.h
@@ -48,6 +48,7 @@ extern "C"
         int (*fpReadPostprocess)(graphP, char *);
         int (*fpWritePostprocess)(graphP, char **);
 
+        int (*fpDeleteEdge)(graphP, int);
         void (*fpHideEdge)(graphP, int);
         void (*fpRestoreEdge)(graphP, int);
         int (*fpHideVertex)(graphP, int);

--- a/c/graphLib/graph.c
+++ b/c/graphLib/graph.c
@@ -91,6 +91,7 @@ int _hasUnprocessedChild(graphP theGraph, int parent);
 void _AttachEdgeRecord(graphP theGraph, int v, int e, int link, int newEdge);
 void _DetachEdgeRecord(graphP theGraph, int e);
 void _RestoreEdgeRecord(graphP theGraph, int e);
+int _DeleteEdge(graphP theGraph, int e);
 
 /* Private functions for which there are FUNCTION POINTERS */
 
@@ -184,6 +185,7 @@ void _InitFunctionTable(graphP theGraph)
         theGraph->functions->fpReadPostprocess = _ReadPostprocess;
         theGraph->functions->fpWritePostprocess = _WritePostprocess;
 
+        theGraph->functions->fpDeleteEdge = _DeleteEdge;
         theGraph->functions->fpHideEdge = _HideEdge;
         theGraph->functions->fpRestoreEdge = _RestoreEdge;
         theGraph->functions->fpHideVertex = _HideVertex;
@@ -2169,10 +2171,7 @@ int gp_InsertEdge(graphP theGraph, int u, int e_u, int e_ulink,
 
  NOTE: This method reinitializes the edge records for e and its twin
        in the base graph data structure. Extensions having parallel
-       edge record extension data elements must implement and use their
-       own edge deletion methods, which must then call gp_DeleteEdge().
-       Calling gp_DeleteEdge() does not currently clear data in extension
-       data structures.
+       edge record extension data elements must overload gp_DeleteEdge().
 
  Returns OK on success, NOTOK on failure
  ****************************************************************************/
@@ -2185,6 +2184,11 @@ int gp_DeleteEdge(graphP theGraph, int e)
         gp_EdgeNotInUse(theGraph, e))
         return NOTOK;
 
+    return theGraph->functions->fpDeleteEdge(theGraph, e);
+}
+
+int _DeleteEdge(graphP theGraph, int e)
+{
     // Delete the edge records e and eTwin from their adjacency lists.
     _DetachEdgeRecord(theGraph, e);
     _DetachEdgeRecord(theGraph, gp_GetTwin(theGraph, e));

--- a/c/graphLib/graph.c
+++ b/c/graphLib/graph.c
@@ -2219,7 +2219,7 @@ int _DeleteEdge(graphP theGraph, int e)
     theGraph->M--;
 
     // If records e and eTwin were not the last in the edge record array,
-    // then record a new hole in the edge array. */
+    // then record a new hole in the edge array. 
     if (e < gp_UpperBoundEdges(theGraph))
     {
         if (theGraph->edgeHoles->size + 1 >= theGraph->edgeHoles->capacity)

--- a/c/graphLib/homeomorphSearch/graphK33Search.c
+++ b/c/graphLib/homeomorphSearch/graphK33Search.c
@@ -78,7 +78,6 @@ int _FindK33WithMergeBlocker(graphP theGraph, K33SearchContext *context, int v, 
 int _TestForZtoWPath(graphP theGraph);
 int _TestForStraddlingBridge(graphP theGraph, K33SearchContext *context, int u_max);
 int _K33Search_DeleteUnmarkedEdgesInBicomp(graphP theGraph, K33SearchContext *context, int BicompRoot);
-int _K33Search_DeleteEdge(graphP theGraph, K33SearchContext *context, int e);
 int _ReduceBicomp(graphP theGraph, K33SearchContext *context, int R);
 int _ReduceExternalFacePathToEdge(graphP theGraph, K33SearchContext *context, int u, int x, int edgeType);
 int _ReduceXYPathToEdge(graphP theGraph, K33SearchContext *context, int u, int x, int edgeType);
@@ -1409,22 +1408,6 @@ int _ReduceBicomp(graphP theGraph, K33SearchContext *context, int R)
 }
 
 /********************************************************************
- Edge deletion that occurs during a reduction or restoration of a
- reduction is augmented by clearing the K_{3,3} search-specific
- data members.  This is augmentation is not needed in the delete edge
- operations that happen once a K_{3,3} homeomorph has been found and
- marked for isolation.
- ********************************************************************/
-
-int _K33Search_DeleteEdge(graphP theGraph, K33SearchContext *context, int e)
-{
-    _K33Search_InitEdgeRec(context, e);
-    _K33Search_InitEdgeRec(context, gp_GetTwin(theGraph, e));
-
-    return gp_DeleteEdge(theGraph, e);
-}
-
-/********************************************************************
  _K33Search_DeleteUnmarkedEdgesInBicomp()
 
  This function deletes from a given biconnected component all edges
@@ -1435,7 +1418,7 @@ int _K33Search_DeleteEdge(graphP theGraph, K33SearchContext *context, int e)
  per vertex in the bicomp.
 
  This is the same as _DeleteUnmarkedEdgesInBicomp(), except it calls
- the overloaded _K33_DeleteEdge() rather than gp_DeleteEdge()
+ the overloaded gp_DeleteEdge()
 
  Returns OK on success, NOTOK on implementation failure
  ********************************************************************/
@@ -1458,7 +1441,7 @@ int _K33Search_DeleteUnmarkedEdgesInBicomp(graphP theGraph, K33SearchContext *co
 
             eNext = gp_GetNextEdge(theGraph, e);
             if (!gp_GetEdgeVisited(theGraph, e))
-                _K33Search_DeleteEdge(theGraph, context, e);
+                gp_DeleteEdge(theGraph, e);
             e = eNext;
         }
     }
@@ -1508,7 +1491,7 @@ int _ReduceExternalFacePathToEdge(graphP theGraph, K33SearchContext *context, in
         e = gp_GetFirstEdge(theGraph, u);
         v = gp_GetNeighbor(theGraph, e);
     }
-    _K33Search_DeleteEdge(theGraph, context, e);
+    gp_DeleteEdge(theGraph, e);
 
     e = gp_GetLastEdge(theGraph, x);
     // An edge e is a reduction edge if it has a pathConnector vertex set
@@ -1519,7 +1502,7 @@ int _ReduceExternalFacePathToEdge(graphP theGraph, K33SearchContext *context, in
         e = gp_GetLastEdge(theGraph, x);
         w = gp_GetNeighbor(theGraph, e);
     }
-    _K33Search_DeleteEdge(theGraph, context, e);
+    gp_DeleteEdge(theGraph, e);
 
     /* Add the reduction edge, then set its path connectors so the original
        path can be recovered and set the edge type so the essential structure
@@ -1572,7 +1555,7 @@ int _ReduceXYPathToEdge(graphP theGraph, K33SearchContext *context, int u, int x
         e = gp_GetNextEdge(theGraph, e);
         v = gp_GetNeighbor(theGraph, e);
     }
-    _K33Search_DeleteEdge(theGraph, context, e);
+    gp_DeleteEdge(theGraph, e);
 
     e = gp_GetFirstEdge(theGraph, x);
     e = gp_GetNextEdge(theGraph, e);
@@ -1586,7 +1569,7 @@ int _ReduceXYPathToEdge(graphP theGraph, K33SearchContext *context, int u, int x
         e = gp_GetNextEdge(theGraph, e);
         w = gp_GetNeighbor(theGraph, e);
     }
-    _K33Search_DeleteEdge(theGraph, context, e);
+    gp_DeleteEdge(theGraph, e);
 
     /* Now add a single edge to represent the XY-path */
     gp_InsertEdge(theGraph, u, gp_GetFirstEdge(theGraph, u), 0,
@@ -1647,7 +1630,7 @@ int _RestoreReducedPath(graphP theGraph, K33SearchContext *context, int e)
     /* We first delete the edge represented by e and eTwin. We do so before
        restoring the path to ensure we do not exceed the maximum edge capacity. */
 
-    _K33Search_DeleteEdge(theGraph, context, e);
+    gp_DeleteEdge(theGraph, e);
 
     /* Now we add the two edges to reconnect the reduced path represented
        by the edge [e, eTwin].  The edge record in u is added between e0 and e1.
@@ -1732,7 +1715,7 @@ int _RestoreAndOrientReducedPaths(graphP theGraph, K33SearchContext *context)
             /* We first delete the edge represented by e and eTwin. We do so before
                restoring the path to ensure we do not exceed the maximum edge capacity. */
 
-            _K33Search_DeleteEdge(theGraph, context, e);
+            gp_DeleteEdge(theGraph, e);
 
             /* Now we add the two edges to reconnect the reduced path represented
                by the edge [e, eTwin].  The edge record in u is added between e0 and e1.

--- a/c/graphLib/homeomorphSearch/graphK33Search_Extensions.c
+++ b/c/graphLib/homeomorphSearch/graphK33Search_Extensions.c
@@ -40,6 +40,7 @@ int _K33Search_MergeBicomps(graphP theGraph, int v, int RootVertex, int W, int W
 void _K33Search_MergeVertex(graphP theGraph, int W, int WPrevLink, int R);
 int _K33Search_HandleBlockedBicomp(graphP theGraph, int v, int RootVertex, int R);
 int _K33Search_EmbedPostprocess(graphP theGraph, int v, int edgeEmbeddingResult);
+int _K33Search_DeleteEdge(graphP theGraph, int e);
 int _K33Search_CheckEmbeddingIntegrity(graphP theGraph, graphP origGraph);
 int _K33Search_CheckObstructionIntegrity(graphP theGraph, graphP origGraph);
 
@@ -117,6 +118,7 @@ int gp_ExtendWith_K33Search(graphP theGraph)
     context->functions.fpEnsureVertexCapacity = _K33Search_EnsureVertexCapacity;
     context->functions.fpResetGraphStorage = _K33Search_ResetGraphStorage;
     context->functions.fpEnsureEdgeCapacity = _K33Search_EnsureEdgeCapacity;
+    context->functions.fpDeleteEdge = _K33Search_DeleteEdge;
 
     _K33Search_ClearStructures(context);
 
@@ -782,6 +784,28 @@ int _K33Search_EmbedPostprocess(graphP theGraph, int v, int edgeEmbeddingResult)
     }
 
     return NOTOK;
+}
+
+/********************************************************************
+ Edge deletion that occurs during a reduction or restoration of a
+ reduction is augmented by clearing the K_{3,3} search-specific
+ data members.  This augmentation is not needed in the delete edge
+ operations that happen once a K_{3,3} homeomorph has been found and
+ marked for isolation.
+ ********************************************************************/
+
+int _K33Search_DeleteEdge(graphP theGraph, int e)
+{
+    K33SearchContext *context = NULL;
+    gp_FindExtension(theGraph, K33SEARCH_ID, (void *)&context);
+
+    if (context == NULL)
+        return NOTOK;
+
+    _K33Search_InitEdgeRec(context, e);
+    _K33Search_InitEdgeRec(context, gp_GetTwin(theGraph, e));
+
+    return context->functions.fpDeleteEdge(theGraph, e);
 }
 
 /********************************************************************

--- a/c/graphLib/homeomorphSearch/graphK4Search.c
+++ b/c/graphLib/homeomorphSearch/graphK4Search.c
@@ -73,7 +73,6 @@ int _K4_TestPathComponentForAncestor(graphP theGraph, int R, int prevLink, int A
 void _K4_ClearVisitedInPathComponent(graphP theGraph, int R, int prevLink, int A);
 int _K4_DeleteUnmarkedEdgesInPathComponent(graphP theGraph, int R, int prevLink, int A);
 int _K4_DeleteUnmarkedEdgesInBicomp(graphP theGraph, K4SearchContext *context, int BicompRoot);
-int _K4_DeleteEdge(graphP theGraph, K4SearchContext *context, int e);
 
 int _K4_RestoreReducedPath(graphP theGraph, K4SearchContext *context, int e);
 int _K4_RestoreAndOrientReducedPaths(graphP theGraph, K4SearchContext *context);
@@ -1018,7 +1017,7 @@ int _K4_ReducePathComponent(graphP theGraph, K4SearchContext *context, int R, in
  per vertex in the bicomp.
 
  This is the same as _DeleteUnmarkedEdgesInBicomp(), except it calls
- the overloaded _K4_DeleteEdge() rather than gp_DeleteEdge()
+ the overloaded gp_DeleteEdge()
 
  Returns OK on success, NOTOK on implementation failure
  ********************************************************************/
@@ -1041,27 +1040,11 @@ int _K4_DeleteUnmarkedEdgesInBicomp(graphP theGraph, K4SearchContext *context, i
 
             eNext = gp_GetNextEdge(theGraph, e);
             if (!gp_GetEdgeVisited(theGraph, e))
-                _K4_DeleteEdge(theGraph, context, e);
+                gp_DeleteEdge(theGraph, e);
             e = eNext;
         }
     }
     return OK;
-}
-
-/********************************************************************
- Edge deletion that occurs during a reduction or restoration of a
- reduction is augmented by clearing the K_4 search-specific
- data members.  This is augmentation is not needed in the delete edge
- operations that happen once a K_4 homeomorph has been found and
- marked for isolation.
- ********************************************************************/
-
-int _K4_DeleteEdge(graphP theGraph, K4SearchContext *context, int e)
-{
-    _K4Search_InitEdgeRec(context, e);
-    _K4Search_InitEdgeRec(context, gp_GetTwin(theGraph, e));
-
-    return gp_DeleteEdge(theGraph, e);
 }
 
 /****************************************************************************
@@ -1255,7 +1238,7 @@ int _K4_DeleteUnmarkedEdgesInPathComponent(graphP theGraph, int R, int prevLink,
     while (sp_NonEmpty(theGraph->theStack))
     {
         sp_Pop(theGraph->theStack, e);
-        _K4_DeleteEdge(theGraph, context, e);
+        gp_DeleteEdge(theGraph, e);
     }
 
     return OK;
@@ -1321,8 +1304,8 @@ int _K4_ReducePathToEdge(graphP theGraph, K4SearchContext *context, int edgeType
         v_A = gp_GetNeighbor(theGraph, e_A);
 
         // Now delete the two edges that join the path to the bicomp.
-        _K4_DeleteEdge(theGraph, context, e_R);
-        _K4_DeleteEdge(theGraph, context, e_A);
+        gp_DeleteEdge(theGraph, e_R);
+        gp_DeleteEdge(theGraph, e_A);
 
         // Now add a single edge to represent the path
         // We use 1^Rlink, for example, because Rlink was the link from R that indicated e_R,
@@ -1401,7 +1384,7 @@ int _K4_RestoreReducedPath(graphP theGraph, K4SearchContext *context, int e)
 
     // We first delete the edge represented by e and eTwin. We do so before
     // restoring the path to ensure we do not exceed the maximum edge capacity.
-    _K4_DeleteEdge(theGraph, context, e);
+    gp_DeleteEdge(theGraph, e);
 
     // Now we add the two edges to reconnect the reduced path represented
     // by the edge [e, eTwin].  The edge record in u is added between e0 and e1.

--- a/c/graphLib/homeomorphSearch/graphK4Search_Extensions.c
+++ b/c/graphLib/homeomorphSearch/graphK4Search_Extensions.c
@@ -33,6 +33,7 @@ void _K4Search_InitEdgeRec(K4SearchContext *context, int e);
 /* Forward declarations of overloading functions */
 int _K4Search_HandleBlockedBicomp(graphP theGraph, int v, int RootVertex, int R);
 int _K4Search_EmbedPostprocess(graphP theGraph, int v, int edgeEmbeddingResult);
+int _K4Search_DeleteEdge(graphP theGraph, int e);
 int _K4Search_CheckEmbeddingIntegrity(graphP theGraph, graphP origGraph);
 int _K4Search_CheckObstructionIntegrity(graphP theGraph, graphP origGraph);
 
@@ -105,6 +106,7 @@ int gp_ExtendWith_K4Search(graphP theGraph)
     context->functions.fpEnsureVertexCapacity = _K4Search_EnsureVertexCapacity;
     context->functions.fpResetGraphStorage = _K4Search_ResetGraphStorage;
     context->functions.fpEnsureEdgeCapacity = _K4Search_EnsureEdgeCapacity;
+    context->functions.fpDeleteEdge = _K4Search_DeleteEdge;
 
     _K4Search_ClearStructures(context);
 
@@ -522,6 +524,28 @@ int _K4Search_EmbedPostprocess(graphP theGraph, int v, int edgeEmbeddingResult)
     }
 
     return NOTOK;
+}
+
+/********************************************************************
+ Edge deletion that occurs during a reduction or restoration of a
+ reduction is augmented by clearing the K_4 search-specific
+ data members.  This augmentation is not needed in the delete edge
+ operations that happen once a K_4 homeomorph has been found and
+ marked for isolation.
+ ********************************************************************/
+
+int _K4Search_DeleteEdge(graphP theGraph, int e)
+{
+    K4SearchContext *context = NULL;
+    gp_FindExtension(theGraph, K4SEARCH_ID, (void *)&context);
+
+    if (context == NULL)
+        return NOTOK;
+
+    _K4Search_InitEdgeRec(context, e);
+    _K4Search_InitEdgeRec(context, gp_GetTwin(theGraph, e));
+
+    return context->functions.fpDeleteEdge(theGraph, e);
 }
 
 /********************************************************************


### PR DESCRIPTION
﻿## Summary
- add `fpDeleteEdge` to the graph function table and dispatch public `gp_DeleteEdge()` through it
- move K3,3 and K4 edge-delete cleanup into extension overloads that call their saved base delete function
- route K3,3/K4 reduction code through `gp_DeleteEdge()` and update extension-system guidance

Closes #251.

## Testing
- `git diff --check`
- `gcc -O2 -Wall -Wextra -Werror -Wno-unused-parameter -o ./planarity.exe <all planarityApp + graphLib C sources>`
- `./planarity.exe -test ./c/samples/`
- `./planarity.exe -r -p 100000 20`
- `./planarity.exe -r -3 100000 20`
- `./planarity.exe -r -4 100000 20`
- `gcc -O2 -Wall -Wextra -Werror -Wno-unused-parameter -DUSE_0BASEDARRAYS -o ./planarity-0based.exe <all planarityApp + graphLib C sources>`
- `./planarity-0based.exe -r -3 100000 20`
- `./planarity-0based.exe -r -4 100000 20`
