### PR TITLE
Support incremental embedding initialization

### DIFF
--- a/c/graphLib/graph.c
+++ b/c/graphLib/graph.c
@@ -344,6 +344,7 @@ void _ResetGraphStorage(graphP theGraph)
 
     theGraph->graphFlags &= ~GRAPHFLAGS_DFSNUMBERED;
     theGraph->graphFlags &= ~GRAPHFLAGS_SORTEDBYDFI;
+    theGraph->graphFlags &= ~GRAPHFLAGS_LOWPOINTSCOMPUTED;
     theGraph->graphFlags &= ~GRAPHFLAGS_DIRECTEDEDGEDETECTED;
     _InitVertices(theGraph);
     _InitEdges(theGraph);
@@ -970,6 +971,7 @@ int gp_CopyAdjacencyLists(graphP dstGraph, graphP srcGraph)
 
     dstGraph->graphFlags &= ~GRAPHFLAGS_DFSNUMBERED;
     dstGraph->graphFlags &= ~GRAPHFLAGS_SORTEDBYDFI;
+    dstGraph->graphFlags &= ~GRAPHFLAGS_LOWPOINTSCOMPUTED;
     dstGraph->graphFlags &= ~GRAPHFLAGS_DIRECTEDEDGEDETECTED;
     if (gp_GetGraphFlags(srcGraph) & GRAPHFLAGS_DIRECTEDEDGEDETECTED)
         dstGraph->graphFlags |= GRAPHFLAGS_DIRECTEDEDGEDETECTED;

--- a/c/graphLib/graph.c
+++ b/c/graphLib/graph.c
@@ -53,7 +53,8 @@ void _ClearEdgeVisitedFlags(graphP theGraph);
 int _ClearAllVisitedFlagsInBicomp(graphP theGraph, int BicompRoot);
 int _ClearAllVisitedFlagsInOtherBicomps(graphP theGraph, int BicompRoot);
 void _ClearEdgeVisitedFlagsInUnembeddedEdges(graphP theGraph);
-int _FillVertexVisitedIndexInBicomp(graphP theGraph, int BicompRoot, int FillValue);
+int _FillVertexVisitedIndexes(graphP theGraph, int FillValue);
+int _FillVertexVisitedIndexesInBicomp(graphP theGraph, int BicompRoot, int FillValue);
 int _ClearObstructionMarksInBicomp(graphP theGraph, int BicompRoot);
 
 int _gp_FindEdge(graphP theGraph, int u, int v);
@@ -775,7 +776,27 @@ int _SetAllVisitedFlagsOnPath(graphP theGraph, int u, int v, int w, int x)
 }
 
 /********************************************************************
- _FillVertexVisitedIndexInBicomp()
+ _FillVertexVisitedIndexes()
+
+ Places the FillValue into the visitedIndex of all non-virtual vertices
+ in the graph.
+
+ Returns OK on success, NOTOK on failure.
+ ********************************************************************/
+
+int _FillVertexVisitedIndexes(graphP theGraph, int FillValue)
+{
+    if (theGraph == NULL)
+        return NOTOK;
+
+    for (int v = gp_LowerBoundVertices(theGraph); v < gp_UpperBoundVertices(theGraph); ++v)
+        gp_SetVertexVisitedIndex(theGraph, v, FillValue);
+
+    return OK;
+}
+
+/********************************************************************
+ _FillVertexVisitedIndexesInBicomp()
 
  Places the FillValue into the visitedIndex of the non-virtual vertices
  in the bicomp rooted by BicompRoot.
@@ -787,7 +808,7 @@ int _SetAllVisitedFlagsOnPath(graphP theGraph, int u, int v, int w, int x)
  Returns OK on success, NOTOK on implementation failure.
  ********************************************************************/
 
-int _FillVertexVisitedIndexInBicomp(graphP theGraph, int BicompRoot, int FillValue)
+int _FillVertexVisitedIndexesInBicomp(graphP theGraph, int BicompRoot, int FillValue)
 {
     int v, e;
     int stackBottom = sp_GetCurrentSize(theGraph->theStack);

--- a/c/graphLib/graphDFSUtils.c
+++ b/c/graphLib/graphDFSUtils.c
@@ -326,6 +326,7 @@ int _SortVertices(graphP theGraph)
 
     /* Invert the bit that records the sort order of the graph */
 
+    theGraph->graphFlags &= ~GRAPHFLAGS_LOWPOINTSCOMPUTED;
     theGraph->graphFlags ^= GRAPHFLAGS_SORTEDBYDFI;
 
     _gp_LogLine("graphDFSUtils.c/_SortVertices() end\n");
@@ -468,6 +469,8 @@ int gp_ComputeLowpoints(graphP theGraph)
     }
 
     _gp_LogLine("graphDFSUtils.c/gp_ComputeLowpoints() end\n");
+
+    theGraph->graphFlags |= GRAPHFLAGS_LOWPOINTSCOMPUTED;
 
     return OK;
 }

--- a/c/graphLib/graphDFSUtils.h
+++ b/c/graphLib/graphDFSUtils.h
@@ -30,10 +30,13 @@ extern "C"
         GRAPHFLAGS_SORTEDBYDFI records whether the graph is in original vertex order
                 or sorted by depth first index. Successive calls to the
                 gp_SortVertices() utility method below toggle this bit.
+        GRAPHFLAGS_LOWPOINTSCOMPUTED records whether lowpoint calculations have
+                been performed on the graph.
 */
 #define GRAPHFLAGS_EXTENDEDWITH_DFSUTILS 256
 #define GRAPHFLAGS_DFSNUMBERED 512
 #define GRAPHFLAGS_SORTEDBYDFI 1024
+#define GRAPHFLAGS_LOWPOINTSCOMPUTED 2048
 
         // DFS-related utility methods that create a DFS tree, sort vertices and
         // compute least ancestor and lowpoint values

--- a/c/graphLib/homeomorphSearch/graphK33Search.c
+++ b/c/graphLib/homeomorphSearch/graphK33Search.c
@@ -13,7 +13,7 @@ See the LICENSE.TXT file for licensing information.
 extern int _ClearAllVisitedFlagsInBicomp(graphP theGraph, int BicompRoot);
 extern int _ClearAllVisitedFlagsInOtherBicomps(graphP theGraph, int BicompRoot);
 extern void _ClearEdgeVisitedFlagsInUnembeddedEdges(graphP theGraph);
-extern int _FillVertexVisitedIndexInBicomp(graphP theGraph, int BicompRoot, int FillValue);
+extern int _FillVertexVisitedIndexesInBicomp(graphP theGraph, int BicompRoot, int FillValue);
 
 // extern int  _GetBicompSize(graphP theGraph, int BicompRoot);
 extern int _HideInternalEdges(graphP theGraph, int vertex);
@@ -207,7 +207,7 @@ int _SearchForK33InBicomp(graphP theGraph, K33SearchContext *context, int v, int
     /* Set visitedIndex values in the bicomp to the initialized state so the planarity
         algorithm can properly do the Walkup procedure in future steps */
 
-    if (_FillVertexVisitedIndexInBicomp(theGraph, IC->r, gp_GetN(theGraph)) != OK)
+    if (_FillVertexVisitedIndexesInBicomp(theGraph, IC->r, gp_GetN(theGraph)) != OK)
         return NOTOK;
 
     /* We now intend to ignore the pertinence of W (conceptually eliminating

--- a/c/graphLib/io/graphIO.c
+++ b/c/graphLib/io/graphIO.c
@@ -177,7 +177,7 @@ int _ReadAdjList(graphP theGraph, strOrFileP inputContainer)
         if (v == gp_LowerBoundVertexStorage(theGraph))
         {
             // Infer whether the input file is zero-based or one-based from
-            // the first vertex label, then convert file labels to storage indices.
+            // the first vertex label, then convert file labels to storage indexes.
             // A zero-based file terminates adjacency lists with any negative
             // value; a one-based file terminates them with any value below 1.
             zeroBased = indexValue == 0;

--- a/c/graphLib/lowLevelUtils/appconst.h
+++ b/c/graphLib/lowLevelUtils/appconst.h
@@ -79,7 +79,7 @@ extern int debugNOTOK(void);
 #undef USE_1BASEDARRAYS
 #endif
 
-/* Array indices are used as pointers, and NIL means bad pointer */
+/* Array indexes are used as pointers, and NIL means bad pointer */
 #ifdef USE_1BASEDARRAYS
 // This definition is used with 1-based array indexing
 #define NIL 0

--- a/c/graphLib/planarityRelated/graphEmbed.c
+++ b/c/graphLib/planarityRelated/graphEmbed.c
@@ -36,6 +36,8 @@ extern int _gp_FindEdge(graphP theGraph, int u, int v);
 
 int _gp_EmbedFlagsValid(graphP theGraph, int embedFlags);
 int _EmbeddingInitialize(graphP theGraph);
+int _EmbeddingInitialize_Full(graphP theGraph);
+int _EmbeddingInitialize_Incremental(graphP theGraph);
 
 void _EmbedBackEdgeToDescendant(graphP theGraph, int RootSide, int RootVertex, int W, int WPrevLink);
 
@@ -249,6 +251,212 @@ int _gp_EmbedFlagsValid(graphP theGraph, int embedFlags)
 /********************************************************************
  _EmbeddingInitialize()
 
+ Routes to the full initialization path when no DFS state is present,
+ otherwise uses the incremental path to honor DFS utility work already
+ performed by the caller.
+ ********************************************************************/
+int _EmbeddingInitialize(graphP theGraph)
+{
+    unsigned graphFlags;
+
+    if (theGraph == NULL)
+        return NOTOK;
+
+    graphFlags = gp_GetGraphFlags(theGraph);
+
+    if (!(graphFlags & (GRAPHFLAGS_DFSNUMBERED |
+                        GRAPHFLAGS_SORTEDBYDFI |
+                        GRAPHFLAGS_LOWPOINTSCOMPUTED)))
+    {
+        return _EmbeddingInitialize_Full(theGraph);
+    }
+
+    return _EmbeddingInitialize_Incremental(theGraph);
+}
+
+/********************************************************************
+ _EmbeddingInitialize_Incremental()
+
+ Uses previously computed DFS, sort, and/or lowpoint data to perform
+ only the embedding initialization steps still required by gp_Embed().
+ ********************************************************************/
+int _EmbeddingInitialize_Incremental(graphP theGraph)
+{
+    stackP theStack;
+    unsigned graphFlags;
+    int graphAlreadySorted;
+    int v, R, uparent, u, uneighbor, e, f, eTwin, ePrev, eNext;
+    int child;
+
+    _gp_LogLine("graphEmbed.c/_EmbeddingInitialize_Incremental() start\n");
+
+    graphFlags = gp_GetGraphFlags(theGraph);
+
+    if ((graphFlags & GRAPHFLAGS_SORTEDBYDFI) &&
+        !(graphFlags & GRAPHFLAGS_DFSNUMBERED))
+    {
+        gp_ErrorMessage("Invalid graph flags: SORTEDBYDFI requires DFSNUMBERED.");
+        return NOTOK;
+    }
+
+    if ((graphFlags & GRAPHFLAGS_LOWPOINTSCOMPUTED) &&
+        ((graphFlags & (GRAPHFLAGS_DFSNUMBERED | GRAPHFLAGS_SORTEDBYDFI)) !=
+         (GRAPHFLAGS_DFSNUMBERED | GRAPHFLAGS_SORTEDBYDFI)))
+    {
+        gp_ErrorMessage("Invalid graph flags: LOWPOINTSCOMPUTED requires DFSNUMBERED and SORTEDBYDFI.");
+        return NOTOK;
+    }
+
+    if (!(graphFlags & GRAPHFLAGS_DFSNUMBERED))
+    {
+        if (gp_DepthFirstSearch(theGraph) != OK)
+            return NOTOK;
+        graphFlags = gp_GetGraphFlags(theGraph);
+    }
+
+    graphAlreadySorted = (graphFlags & GRAPHFLAGS_SORTEDBYDFI) != 0;
+    theStack = theGraph->theStack;
+
+    if (sp_GetCapacity(theStack) < 2 * 2 * gp_GetM(theGraph) + 2)
+        return NOTOK;
+
+    sp_ClearStack(theStack);
+    _ClearVertexVisitedFlags(theGraph, FALSE);
+
+    for (v = gp_LowerBoundVertices(theGraph); v < gp_UpperBoundVertices(theGraph); ++v)
+    {
+        if (gp_IsVertex(theGraph, gp_GetVertexParent(theGraph, v)))
+            continue;
+
+        sp_Push2(theStack, NIL, NIL);
+        while (sp_NonEmpty(theStack))
+        {
+            sp_Pop2(theStack, uparent, e);
+            u = gp_IsNotVertex(theGraph, uparent) ? v : gp_GetNeighbor(theGraph, e);
+
+            if (!gp_GetVisited(theGraph, u))
+            {
+                gp_SetVisited(theGraph, u);
+
+                if (gp_IsEdge(theGraph, e))
+                {
+                    if (gp_GetEdgeType(theGraph, e) != EDGE_TYPE_CHILD)
+                        return NOTOK;
+
+                    child = graphAlreadySorted ? u : gp_GetIndex(theGraph, u);
+
+                    gp_SetVertexSortedDFSChildList(theGraph, uparent,
+                                                   gp_AppendDFSChild(theGraph, uparent, child));
+
+                    R = gp_GetBicompRootFromDFSChild(theGraph, child);
+                    gp_SetFirstEdge(theGraph, R, e);
+                    gp_SetLastEdge(theGraph, R, e);
+                }
+
+                e = gp_GetFirstEdge(theGraph, u);
+                while (gp_IsEdge(theGraph, e))
+                {
+                    if (gp_GetEdgeType(theGraph, e) == EDGE_TYPE_CHILD)
+                    {
+                        if (!gp_GetVisited(theGraph, gp_GetNeighbor(theGraph, e)))
+                            sp_Push2(theStack, u, e);
+                    }
+                    else if (gp_GetEdgeType(theGraph, e) == EDGE_TYPE_BACK)
+                    {
+                        eTwin = gp_GetTwin(theGraph, e);
+                        uneighbor = gp_GetNeighbor(theGraph, e);
+                        ePrev = gp_GetPrevEdge(theGraph, eTwin);
+                        eNext = gp_GetNextEdge(theGraph, eTwin);
+
+                        if (gp_IsEdge(theGraph, ePrev))
+                            gp_SetNextEdge(theGraph, ePrev, eNext);
+                        else
+                            gp_SetFirstEdge(theGraph, uneighbor, eNext);
+                        if (gp_IsEdge(theGraph, eNext))
+                            gp_SetPrevEdge(theGraph, eNext, ePrev);
+                        else
+                            gp_SetLastEdge(theGraph, uneighbor, ePrev);
+
+                        if (gp_IsEdge(theGraph, f = gp_GetVertexFwdEdgeList(theGraph, uneighbor)))
+                        {
+                            ePrev = gp_GetPrevEdge(theGraph, f);
+                            gp_SetPrevEdge(theGraph, eTwin, ePrev);
+                            gp_SetNextEdge(theGraph, eTwin, f);
+                            gp_SetPrevEdge(theGraph, f, eTwin);
+                            gp_SetNextEdge(theGraph, ePrev, eTwin);
+                        }
+                        else
+                        {
+                            gp_SetVertexFwdEdgeList(theGraph, uneighbor, eTwin);
+                            gp_SetPrevEdge(theGraph, eTwin, eTwin);
+                            gp_SetNextEdge(theGraph, eTwin, eTwin);
+                        }
+                    }
+
+                    e = gp_GetNextEdge(theGraph, e);
+                }
+            }
+        }
+    }
+
+    if (!graphAlreadySorted)
+    {
+        if (gp_SortVertices(theGraph) != OK)
+            return NOTOK;
+        graphFlags = gp_GetGraphFlags(theGraph);
+    }
+
+    if (!(graphFlags & GRAPHFLAGS_LOWPOINTSCOMPUTED))
+    {
+        if (gp_ComputeLowpoints(theGraph) != OK)
+            return NOTOK;
+    }
+
+    for (v = gp_UpperBoundVertices(theGraph) - 1; v >= gp_LowerBoundVertices(theGraph); --v)
+    {
+        gp_SetVertexVisitedInfo(theGraph, v, gp_GetN(theGraph));
+
+        child = gp_GetVertexSortedDFSChildList(theGraph, v);
+        gp_SetVertexFuturePertinentChild(theGraph, v, child);
+
+        if (_gp_IsDFSTreeRoot(theGraph, v))
+        {
+            gp_SetFirstEdge(theGraph, v, NIL);
+            gp_SetLastEdge(theGraph, v, NIL);
+        }
+        else
+        {
+            R = gp_GetBicompRootFromDFSChild(theGraph, v);
+
+            e = gp_GetFirstEdge(theGraph, R);
+            gp_SetPrevEdge(theGraph, e, NIL);
+            gp_SetNextEdge(theGraph, e, NIL);
+
+            eTwin = gp_GetTwin(theGraph, e);
+            gp_SetNeighbor(theGraph, eTwin, R);
+
+            gp_SetFirstEdge(theGraph, v, eTwin);
+            gp_SetLastEdge(theGraph, v, eTwin);
+            gp_SetPrevEdge(theGraph, eTwin, NIL);
+            gp_SetNextEdge(theGraph, eTwin, NIL);
+
+            gp_SetExtFaceVertex(theGraph, R, 0, v);
+            gp_SetExtFaceVertex(theGraph, R, 1, v);
+            gp_SetExtFaceVertex(theGraph, v, 0, R);
+            gp_SetExtFaceVertex(theGraph, v, 1, R);
+        }
+    }
+
+    theGraph->graphFlags |= GRAPHFLAGS_LOWPOINTSCOMPUTED;
+
+    _gp_LogLine("graphEmbed.c/_EmbeddingInitialize_Incremental() end\n");
+
+    return OK;
+}
+
+/********************************************************************
+ _EmbeddingInitialize_Full()
+
  This method performs the following tasks:
  (1) Assign depth first index (DFI) and DFS parentvalues to vertices
  (2) Assign DFS edge types
@@ -264,13 +472,13 @@ int _gp_EmbedFlagsValid(graphP theGraph, int embedFlags)
  are assigned and then the DFS tree edges stored in virtual vertices
  during the DFS are used to create the DFS tree embedding.
  ********************************************************************/
-int _EmbeddingInitialize(graphP theGraph)
+int _EmbeddingInitialize_Full(graphP theGraph)
 {
     stackP theStack;
     int DFI, v, R, uparent, u, uneighbor, e, f, eTwin, ePrev, eNext;
     int leastValue, child;
 
-    _gp_LogLine("graphEmbed.c/_EmbeddingInitialize() start\n");
+    _gp_LogLine("graphEmbed.c/_EmbeddingInitialize_Full() start\n");
 
     theStack = theGraph->theStack;
 
@@ -460,7 +668,9 @@ int _EmbeddingInitialize(graphP theGraph)
         }
     }
 
-    _gp_LogLine("graphEmbed.c/_EmbeddingInitialize() end\n");
+    theGraph->graphFlags |= GRAPHFLAGS_LOWPOINTSCOMPUTED;
+
+    _gp_LogLine("graphEmbed.c/_EmbeddingInitialize_Full() end\n");
 
     return OK;
 }

--- a/c/graphLib/planarityRelated/graphEmbed.c
+++ b/c/graphLib/planarityRelated/graphEmbed.c
@@ -319,6 +319,13 @@ int _EmbeddingInitialize_Incremental(graphP theGraph)
         graphFlags = gp_GetGraphFlags(theGraph);
     }
 
+    if (!(graphFlags & GRAPHFLAGS_LOWPOINTSCOMPUTED))
+    {
+        if (gp_ComputeLowpoints(theGraph) != OK)
+            return NOTOK;
+        graphFlags = gp_GetGraphFlags(theGraph);
+    }
+
     theStack = theGraph->theStack;
 
     if (sp_GetCapacity(theStack) < 2 * 2 * gp_GetM(theGraph) + 2)
@@ -401,12 +408,6 @@ int _EmbeddingInitialize_Incremental(graphP theGraph)
         }
     }
 
-    if (!(graphFlags & GRAPHFLAGS_LOWPOINTSCOMPUTED))
-    {
-        if (gp_ComputeLowpoints(theGraph) != OK)
-            return NOTOK;
-    }
-
     for (v = gp_UpperBoundVertices(theGraph) - 1; v >= gp_LowerBoundVertices(theGraph); --v)
     {
         gp_SetVertexVisitedIndex(theGraph, v, gp_GetN(theGraph));
@@ -441,8 +442,6 @@ int _EmbeddingInitialize_Incremental(graphP theGraph)
             gp_SetExtFaceVertex(theGraph, v, 1, R);
         }
     }
-
-    theGraph->graphFlags |= GRAPHFLAGS_LOWPOINTSCOMPUTED;
 
     _gp_LogLine("graphEmbed.c/_EmbeddingInitialize_Incremental() end\n");
 

--- a/c/graphLib/planarityRelated/graphEmbed.c
+++ b/c/graphLib/planarityRelated/graphEmbed.c
@@ -284,9 +284,7 @@ int _EmbeddingInitialize_Incremental(graphP theGraph)
 {
     stackP theStack;
     unsigned graphFlags;
-    int graphAlreadySorted;
-    int v, R, uparent, u, uneighbor, e, f, eTwin, ePrev, eNext;
-    int child;
+    int v, R, uparent, u, uneighbor, e, f, eTwin, ePrev, eNext, child;
 
     _gp_LogLine("graphEmbed.c/_EmbeddingInitialize_Incremental() start\n");
 
@@ -314,7 +312,13 @@ int _EmbeddingInitialize_Incremental(graphP theGraph)
         graphFlags = gp_GetGraphFlags(theGraph);
     }
 
-    graphAlreadySorted = (graphFlags & GRAPHFLAGS_SORTEDBYDFI) != 0;
+    if (!(graphFlags & GRAPHFLAGS_SORTEDBYDFI))
+    {
+        if (gp_SortVertices(theGraph) != OK)
+            return NOTOK;
+        graphFlags = gp_GetGraphFlags(theGraph);
+    }
+
     theStack = theGraph->theStack;
 
     if (sp_GetCapacity(theStack) < 2 * 2 * gp_GetM(theGraph) + 2)
@@ -343,12 +347,10 @@ int _EmbeddingInitialize_Incremental(graphP theGraph)
                     if (gp_GetEdgeType(theGraph, e) != EDGE_TYPE_CHILD)
                         return NOTOK;
 
-                    child = graphAlreadySorted ? u : gp_GetIndex(theGraph, u);
-
                     gp_SetVertexSortedDFSChildList(theGraph, uparent,
-                                                   gp_AppendDFSChild(theGraph, uparent, child));
+                                                   gp_AppendDFSChild(theGraph, uparent, u));
 
-                    R = gp_GetBicompRootFromDFSChild(theGraph, child);
+                    R = gp_GetBicompRootFromDFSChild(theGraph, u);
                     gp_SetFirstEdge(theGraph, R, e);
                     gp_SetLastEdge(theGraph, R, e);
                 }
@@ -397,13 +399,6 @@ int _EmbeddingInitialize_Incremental(graphP theGraph)
                 }
             }
         }
-    }
-
-    if (!graphAlreadySorted)
-    {
-        if (gp_SortVertices(theGraph) != OK)
-            return NOTOK;
-        graphFlags = gp_GetGraphFlags(theGraph);
     }
 
     if (!(graphFlags & GRAPHFLAGS_LOWPOINTSCOMPUTED))

--- a/c/graphLib/planarityRelated/graphEmbed.c
+++ b/c/graphLib/planarityRelated/graphEmbed.c
@@ -24,6 +24,7 @@ See the LICENSE.TXT file for licensing information.
 /* Imported functions */
 
 extern void _ClearVertexVisitedFlags(graphP theGraph, int);
+extern int _FillVertexVisitedIndexes(graphP theGraph, int FillValue);
 
 extern int _IsolateKuratowskiSubgraph(graphP theGraph, int v, int R);
 extern int _IsolateOuterplanarObstruction(graphP theGraph, int v, int R);
@@ -326,6 +327,15 @@ int _EmbeddingInitialize_Incremental(graphP theGraph)
         graphFlags = gp_GetGraphFlags(theGraph);
     }
 
+    // The planarity embedder uses the visitedIndex like a flag, except that equality
+    // means 'set' and greater than means 'clear'. So, the 'flag' is implicitly
+    // cleared when the main embedding loop decrements v to process the next lower
+    // numbered vertex (because then all the visitedIndex values are greater than v).
+    // This call starts all 'flags' as clear since gp_UpperBoundVertices() returns
+    // a value one greater than the highest numbered vertex.
+    if (_FillVertexVisitedIndexes(theGraph, gp_UpperBoundVertices(theGraph)) != OK)
+        return NOTOK;
+
     theStack = theGraph->theStack;
 
     if (sp_GetCapacity(theStack) < 2 * 2 * gp_GetM(theGraph) + 2)
@@ -410,8 +420,6 @@ int _EmbeddingInitialize_Incremental(graphP theGraph)
 
     for (v = gp_UpperBoundVertices(theGraph) - 1; v >= gp_LowerBoundVertices(theGraph); --v)
     {
-        gp_SetVertexVisitedIndex(theGraph, v, gp_GetN(theGraph));
-
         child = gp_GetVertexSortedDFSChildList(theGraph, v);
         gp_SetVertexFuturePertinentChild(theGraph, v, child);
 
@@ -612,7 +620,7 @@ int _EmbeddingInitialize_Full(graphP theGraph)
     for (v = gp_UpperBoundVertices(theGraph) - 1; v >= gp_LowerBoundVertices(theGraph); --v)
     {
         // (7) Initialize for pertinence management
-        gp_SetVertexVisitedIndex(theGraph, v, gp_GetN(theGraph));
+        gp_SetVertexVisitedIndex(theGraph, v, gp_UpperBoundVertices(theGraph));
 
         // (7) Initialize for future pertinence management
         child = gp_GetVertexSortedDFSChildList(theGraph, v);

--- a/c/graphLib/planarityRelated/graphEmbed.c
+++ b/c/graphLib/planarityRelated/graphEmbed.c
@@ -285,7 +285,7 @@ int _EmbeddingInitialize_Incremental(graphP theGraph)
 {
     stackP theStack;
     unsigned graphFlags;
-    int v, R, uparent, u, uneighbor, e, f, eTwin, ePrev, eNext, child;
+    int v, R, uparent, u, uneighbor, e, f, eTwin, ePrev, eNext;
 
     _gp_LogLine("graphEmbed.c/_EmbeddingInitialize_Incremental() start\n");
 
@@ -306,6 +306,10 @@ int _EmbeddingInitialize_Incremental(graphP theGraph)
         return NOTOK;
     }
 
+    // Start with the standard initializations to perform depth-first search,
+    // sorting vertices (in linear time) by their depth-first indexes, and
+    // computing least ancestor and lowpoint values for the vertices, if they
+    // have not already been done before calling gp_Embed()
     if (!(graphFlags & GRAPHFLAGS_DFSNUMBERED))
     {
         if (gp_DepthFirstSearch(theGraph) != OK)
@@ -336,6 +340,12 @@ int _EmbeddingInitialize_Incremental(graphP theGraph)
     if (_FillVertexVisitedIndexes(theGraph, gp_UpperBoundVertices(theGraph)) != OK)
         return NOTOK;
 
+    // Use the stack and visited flags to traverse the previously created DFS tree to
+    // do initializations that build up the sorted DFS child lists of each vertex, to
+    // associate each tree edge with the bicomp root associated with the child endpoint,
+    // and to remove the back edges from being embedded in the graph and instead put
+    // their forward edge records in the forward edge lists of the ancestor endpoints
+    // (so back edges from a vertex to its descendants can be easily processed).
     theStack = theGraph->theStack;
 
     if (sp_GetCapacity(theStack) < 2 * 2 * gp_GetM(theGraph) + 2)
@@ -361,32 +371,44 @@ int _EmbeddingInitialize_Incremental(graphP theGraph)
 
                 if (gp_IsEdge(theGraph, e))
                 {
+                    // If we are visiting a previously unvisited vertex via an existing edge,
+                    // then of course we are arriving via a DFS tree edge from its parent.
                     if (gp_GetEdgeType(theGraph, e) != EDGE_TYPE_CHILD)
                         return NOTOK;
 
+                    // Build up the sorted DFS child lists of each vertex (by appending
+                    // the vertex being visited to the sorted DFS child list of its parent)
                     gp_SetVertexSortedDFSChildList(theGraph, uparent,
                                                    gp_AppendDFSChild(theGraph, uparent, u));
 
+                    // Associate each tree edge with the bicomp root associated with the child endpoint
                     R = gp_GetBicompRootFromDFSChild(theGraph, u);
                     gp_SetFirstEdge(theGraph, R, e);
                     gp_SetLastEdge(theGraph, R, e);
                 }
 
+                // Iterate the adjacency list of vertex u
                 e = gp_GetFirstEdge(theGraph, u);
                 while (gp_IsEdge(theGraph, e))
                 {
                     if (gp_GetEdgeType(theGraph, e) == EDGE_TYPE_CHILD)
                     {
+                        // If the edge record points to an unvisited DFS child, then
+                        // that is a new vertex to add to the navigation stack
                         if (!gp_GetVisited(theGraph, gp_GetNeighbor(theGraph, e)))
                             sp_Push2(theStack, u, e);
                     }
                     else if (gp_GetEdgeType(theGraph, e) == EDGE_TYPE_BACK)
                     {
+                        // For each back edge record, we get the associated forward
+                        // edge record (into eTwin) and info about it.
                         eTwin = gp_GetTwin(theGraph, e);
                         uneighbor = gp_GetNeighbor(theGraph, e);
                         ePrev = gp_GetPrevEdge(theGraph, eTwin);
                         eNext = gp_GetNextEdge(theGraph, eTwin);
 
+                        // The forward edge record is then removed from the adjacency list
+                        // of the ancestor (uneighbor), and...
                         if (gp_IsEdge(theGraph, ePrev))
                             gp_SetNextEdge(theGraph, ePrev, eNext);
                         else
@@ -396,6 +418,7 @@ int _EmbeddingInitialize_Incremental(graphP theGraph)
                         else
                             gp_SetLastEdge(theGraph, uneighbor, ePrev);
 
+                        // ... placed into the forward edge list of the ancestor (uneighbor)
                         if (gp_IsEdge(theGraph, f = gp_GetVertexFwdEdgeList(theGraph, uneighbor)))
                         {
                             ePrev = gp_GetPrevEdge(theGraph, f);
@@ -418,32 +441,71 @@ int _EmbeddingInitialize_Incremental(graphP theGraph)
         }
     }
 
-    for (v = gp_UpperBoundVertices(theGraph) - 1; v >= gp_LowerBoundVertices(theGraph); --v)
-    {
-        child = gp_GetVertexSortedDFSChildList(theGraph, v);
-        gp_SetVertexFuturePertinentChild(theGraph, v, child);
+    // Initialize the future pertinent child of each vertex to just be the first
+    // element of the sorted DFS child list. Initially, the embedding comprises
+    // only DFS tree edges embedded as singleton bicomps, so every DFS child is
+    // separated from its DFS parent(in a separate bicomp from its parent). In the
+    // first articulation of the edge addition planarity algorithm, the knowledge
+    // of future pertinent children was managed by a "separated DFS child list" that
+    // was sorted by lowpoint. In the current implementation, this has been
+    // relaxed. We start out with any separated DFS child, but then just before
+    // the future pertinent child must be used in a vertex step v, it is updated to
+    // be the first child that has any lowpoint less than v (it doesn't have to be
+    // the lowest, so we don't need a separated DFS child list strictly sorted by
+    // lowpoint). See the invocations of gp_UpdateVertexFuturePertinentChild().
+    for (v = gp_LowerBoundVertices(theGraph); v < gp_UpperBoundVertices(theGraph); ++v)
+        gp_SetVertexFuturePertinentChild(theGraph, v, gp_GetVertexSortedDFSChildList(theGraph, v));
 
+    // A second pass through the vertices to set up the embedding of all
+    // DFS tree edges as singleton comps
+    for (v = gp_LowerBoundVertices(theGraph); v < gp_UpperBoundVertices(theGraph); ++v)
+    {
         if (_gp_IsDFSTreeRoot(theGraph, v))
         {
+            // Each DFS tree root vertex is not going to be in a singleton bicomp
+            // with its DFS parent because it has no parent, so it will initially
+            // have no adjacency list entries (rather than having an adjacency list
+            // entry for a tree edge to its parent, as in the else clause).
             gp_SetFirstEdge(theGraph, v, NIL);
             gp_SetLastEdge(theGraph, v, NIL);
         }
         else
         {
+            // For each vertex v that is not a DFS tree root, v will be joining
+            // a virtual vertex R representing its DFS parent in an embedding of
+            // a singleton biconnected component containing only the DFS tree edge
+            // between v and the virtual vertex R representing v's DFS parent.
+            // In the preceding initialization for-loop, the DFS tree edge was
+            // already linked to R, so we obtain R now...
             R = gp_GetBicompRootFromDFSChild(theGraph, v);
 
+            // ... and then ensure that the DFS tree edge record is alone in the
+            // adjacency list of R...
             e = gp_GetFirstEdge(theGraph, R);
             gp_SetPrevEdge(theGraph, e, NIL);
             gp_SetNextEdge(theGraph, e, NIL);
 
+            // ... then we get the twin edge record that will be going into
+            // v's adjacency list, and we reset its neighbor from indicating
+            // v's DFS parent to indicating R (because R is the virtual vertex
+            // representing v's parent in the bicomp that will contain v).
             eTwin = gp_GetTwin(theGraph, e);
             gp_SetNeighbor(theGraph, eTwin, R);
 
+            // Now we place that twin edge record into v's adjacency list as
+            // its only adjacency.
             gp_SetFirstEdge(theGraph, v, eTwin);
             gp_SetLastEdge(theGraph, v, eTwin);
             gp_SetPrevEdge(theGraph, eTwin, NIL);
             gp_SetNextEdge(theGraph, eTwin, NIL);
 
+            // And finally we initialize the auxiliary data structure that
+            // optimizes knowledge and management of the vertices on the
+            // external face of the bicomp rooted by R. At this initial stage,
+            // the external face contains only R and v. The links are arranged
+            // so that one can navigate around the external face from R to v a
+            // and back to R in either a clockwise or counterclockwise direction
+            // by consistently following either 0 links or 1 links.
             gp_SetExtFaceVertex(theGraph, R, 0, v);
             gp_SetExtFaceVertex(theGraph, R, 1, v);
             gp_SetExtFaceVertex(theGraph, v, 0, R);
@@ -473,6 +535,9 @@ int _EmbeddingInitialize_Incremental(graphP theGraph)
  Afterward, the vertices are sorted by their DFIs, the lowpoint values
  are assigned and then the DFS tree edges stored in virtual vertices
  during the DFS are used to create the DFS tree embedding.
+
+ This performs the same function as _EmbeddingInitialize_Incremental()
+ but has optimized total gp_Embed() execution by about 12%.
  ********************************************************************/
 int _EmbeddingInitialize_Full(graphP theGraph)
 {
@@ -931,7 +996,9 @@ int _MergeBicomps(graphP theGraph, int v, int RootVertex, int W, int WPrevLink)
         gp_DeleteVertexPertinentRoot(theGraph, Z, R);
 
         // If the merge will place the current future pertinence child into the same bicomp as Z,
-        // then we advance to the next child (or NIL) because future pertinence is
+        // then we advance to the next child (or NIL) because future pertinence is based on
+        // back edge connections from vertices in other bicomps (i.e., DFS subtrees rooted by
+        // other DFS children of Z that have not yet been merged into the bicomp with Z).
         if (gp_GetDFSChildFromBicompRoot(theGraph, R) == gp_GetVertexFuturePertinentChild(theGraph, Z))
         {
             gp_SetVertexFuturePertinentChild(theGraph, Z,

--- a/c/graphLib/planarityRelated/graphEmbed.c
+++ b/c/graphLib/planarityRelated/graphEmbed.c
@@ -414,7 +414,7 @@ int _EmbeddingInitialize_Incremental(graphP theGraph)
 
     for (v = gp_UpperBoundVertices(theGraph) - 1; v >= gp_LowerBoundVertices(theGraph); --v)
     {
-        gp_SetVertexVisitedInfo(theGraph, v, gp_GetN(theGraph));
+        gp_SetVertexVisitedIndex(theGraph, v, gp_GetN(theGraph));
 
         child = gp_GetVertexSortedDFSChildList(theGraph, v);
         gp_SetVertexFuturePertinentChild(theGraph, v, child);

--- a/c/planarityApp/planarityRandomGraphs.c
+++ b/c/planarityApp/planarityRandomGraphs.c
@@ -187,6 +187,24 @@ int RandomGraphs(char const *const commandString, int NumGraphs, int SizeOfGraph
                 return Result;
             }
 
+            if ((Result = gp_DepthFirstSearch(theGraph)) != OK)
+            {
+                gp_ErrorMessage("Unable to depth first search graph number %d before embedding.", K);
+                break;
+            }
+
+            if ((Result = gp_SortVertices(theGraph)) != OK)
+            {
+                gp_ErrorMessage("Unable to sort graph number %d before embedding.", K);
+                break;
+            }
+
+            if ((Result = gp_ComputeLowpoints(theGraph)) != OK)
+            {
+                gp_ErrorMessage("Unable to compute lowpoints for graph number %d before embedding.", K);
+                break;
+            }
+
             Result = gp_Embed(theGraph, embedFlags);
 
             if (gp_TestEmbedResultIntegrity(theGraph, origGraph, Result) != Result)


### PR DESCRIPTION
## Summary
- add `GRAPHFLAGS_LOWPOINTSCOMPUTED` and maintain it across lowpoint computation, vertex sorting, graph reset, and adjacency-list copy
- split embedding initialization into full and incremental paths so callers can precompute DFS, sort, and lowpoints before `gp_Embed()`
- precompute DFS, sort, and lowpoints in random graph runs before embedding to exercise the incremental initialization path

Fixes #240

## Testing
- `git diff --check`
- rebuilt `planarity.exe` from current sources with `gcc -O2`
- `./planarity.exe -test ./c/samples/`
- `./planarity.exe -r -p 100000 20`
- `./planarity.exe -r -o 100000 20`
- `./planarity.exe -r -2 100000 20`
- `./planarity.exe -r -3 100000 20`
- `./planarity.exe -r -4 100000 20`
- rebuilt `planarity-0based.exe` with `gcc -O2 -DUSE_0BASEDARRAYS`
- `./planarity-0based.exe -r -p 100000 20`
- `./planarity-0based.exe -r -3 100000 20`
- `./planarity-0based.exe -r -4 100000 20`
- temporary harness for invalid embedding flag combinations
- temporary harness for embedding initialization modes: none, DFS-only, DFS+sort, DFS+sort+lowpoints over 10,000 random graphs, default and `USE_0BASEDARRAYS`