### PR TITLE
Name planarity app choice strings

### DIFF
--- a/c/planarityApp/planarity.h
+++ b/c/planarityApp/planarity.h
@@ -21,7 +21,11 @@ extern "C"
 #define SUFFIXMAXLENGTH 32
 #define COMMANDSTRINGMAXLENGTH 2
 
+#define MODECHOICECHARS "rsmn"
 #define YESNOCHOICECHARS "yYnN"
+#define RANDOMGRAPHSOUTPUTCHOICECHARS "aAgG"
+#define GRAPHALGORITHMCHOICES "pdo234"
+#define TRANSFORMGRAPHOUTPUTFORMATCHOICES "gam"
 
     char const *GetProjectTitle(void);
     char const *GetAlgorithmFlags(void);

--- a/c/planarityApp/planarityUtils.c
+++ b/c/planarityApp/planarityUtils.c
@@ -45,7 +45,7 @@ int Reconfigure(void)
 
         if (strlen(lineBuff) != 1 ||
             sscanf(lineBuff, " %c", &Mode) != 1 ||
-            !strchr("rsmn", tolower(Mode)))
+            !strchr(MODECHOICECHARS, tolower(Mode)))
             gp_Message("Invalid choice for Mode; please retry.");
         else
         {
@@ -96,7 +96,7 @@ int Reconfigure(void)
 
                 if (strlen(lineBuff) != 1 ||
                     sscanf(lineBuff, " %c", &OrigOutFormat) != 1 ||
-                    !strchr("aAgG", OrigOutFormat))
+                    !strchr(RANDOMGRAPHSOUTPUTCHOICECHARS, OrigOutFormat))
                     gp_Message("Invalid choice; please retry.");
                 else
                 {
@@ -525,7 +525,7 @@ char const *GetAlgorithmSpecifiers(void)
 
 char const *GetAlgorithmChoices(void)
 {
-    return "pdo234";
+    return GRAPHALGORITHMCHOICES;
 }
 
 /****************************************************************************
@@ -719,7 +719,7 @@ char const *GetSupportedOutputChoices(void)
 
 char const *GetSupportedOutputFormats(void)
 {
-    return "gam";
+    return TRANSFORMGRAPHOUTPUTFORMATCHOICES;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
- add named macros for planarity app mode, random graph output, algorithm, and transform output choices
- use those macros in `Reconfigure()` validation and existing helper return values
- preserve existing accepted inputs and avoid behavior changes

Fixes #190

## Testing
- `git diff --check`
- rebuilt `planarity.exe` from current sources with `gcc -O2`
- `./planarity.exe -test ./c/samples/`
- temporary harness verifying the changed choice helpers return the new macros