### PR TITLE
Name low-level utility header parameters

### DIFF
--- a/c/graphLib/io/strbuf.h
+++ b/c/graphLib/io/strbuf.h
@@ -23,12 +23,12 @@ extern "C"
 
         typedef strBuf *strBufP;
 
-        strBufP sb_New(int);
-        void sb_Free(strBufP *);
+        strBufP sb_New(int capacity);
+        void sb_Free(strBufP *pStrBuf);
 
-        void sb_ClearBuf(strBufP);
-        int sb_Copy(strBufP, strBufP);
-        strBufP sb_Duplicate(strBufP);
+        void sb_ClearBuf(strBufP theStrBuf);
+        int sb_Copy(strBufP strBufDst, strBufP strBufSrc);
+        strBufP sb_Duplicate(strBufP theStrBuf);
 
 #define sb_GetFullString(theStrBuf) (theStrBuf->buf)
 #define sb_GetSize(theStrBuf) (theStrBuf->size)
@@ -42,17 +42,17 @@ extern "C"
                 theStrBuf->readPos = theReadPos; \
         }
 
-        void sb_ReadSkipWhitespace(strBufP);
-        void sb_ReadSkipInteger(strBufP);
+        void sb_ReadSkipWhitespace(strBufP theStrBuf);
+        void sb_ReadSkipInteger(strBufP theStrBuf);
 #define sb_ReadSkipChar(theStrBuf)    \
         {                             \
                 theStrBuf->readPos++; \
         }
 
-        int sb_ConcatString(strBufP, char const *);
-        int sb_ConcatChar(strBufP, char);
+        int sb_ConcatString(strBufP theStrBuf, char const *s);
+        int sb_ConcatChar(strBufP theStrBuf, char ch);
 
-        char *sb_TakeString(strBufP);
+        char *sb_TakeString(strBufP theStrBuf);
 
 #ifndef SPEED_MACROS
 // Optimized SPEED_MACROS versions of larger methods are not used in this module

--- a/c/graphLib/lowLevelUtils/apiutils.private.h
+++ b/c/graphLib/lowLevelUtils/apiutils.private.h
@@ -35,11 +35,11 @@ extern "C"
 #define _gp_MakeLogStr4 _MakeLogStr4
 #define _gp_MakeLogStr5 _MakeLogStr5
 
-    char *_MakeLogStr1(const char *format, int);
-    char *_MakeLogStr2(const char *format, int, int);
-    char *_MakeLogStr3(const char *format, int, int, int);
-    char *_MakeLogStr4(const char *format, int, int, int, int);
-    char *_MakeLogStr5(const char *format, int, int, int, int, int);
+    char *_MakeLogStr1(const char *format, int one);
+    char *_MakeLogStr2(const char *format, int one, int two);
+    char *_MakeLogStr3(const char *format, int one, int two, int three);
+    char *_MakeLogStr4(const char *format, int one, int two, int three, int four);
+    char *_MakeLogStr5(const char *format, int one, int two, int three, int four, int five);
 
 #else
 #define _gp_LogLine(Line)

--- a/c/graphLib/lowLevelUtils/stack.h
+++ b/c/graphLib/lowLevelUtils/stack.h
@@ -24,10 +24,10 @@ extern "C"
         typedef struct stackStruct stackStruct;
         typedef stackStruct *stackP;
 
-        stackP sp_New(int);
-        void sp_Free(stackP *);
+        stackP sp_New(int capacity);
+        void sp_Free(stackP *pStack);
 
-        int sp_Copy(stackP, stackP);
+        int sp_Copy(stackP stackDst, stackP stackSrc);
 
         int sp_CopyContent(stackP stackDst, stackP stackSrc);
         stackP sp_Duplicate(stackP theStack);
@@ -36,12 +36,12 @@ extern "C"
 
 #ifndef SPEED_MACROS
 
-        int sp_ClearStack(stackP);
+        int sp_ClearStack(stackP theStack);
         int sp_GetCurrentSize(stackP theStack);
         int sp_SetCurrentSize(stackP theStack, int top);
 
-        int sp_IsEmpty(stackP);
-        int sp_NonEmpty(stackP);
+        int sp_IsEmpty(stackP theStack);
+        int sp_NonEmpty(stackP theStack);
 
 #define sp_Push(theStack, a)                       \
         {                                          \
@@ -54,8 +54,8 @@ extern "C"
                         return NOTOK;                    \
         }
 
-        int sp__Push(stackP, int);
-        int sp__Push2(stackP, int, int);
+        int sp__Push(stackP theStack, int a);
+        int sp__Push2(stackP theStack, int a, int b);
 
 #define sp_Pop(theStack, a)                        \
         {                                          \
@@ -84,16 +84,16 @@ extern "C"
                         return NOTOK;                 \
         }
 
-        int sp__Pop(stackP, int *);
+        int sp__Pop(stackP theStack, int *pA);
         int sp__Pop_Discard(stackP theStack);
 
-        int sp__Pop2(stackP, int *, int *);
+        int sp__Pop2(stackP theStack, int *pA, int *pB);
         int sp__Pop2_Discard1(stackP theStack, int *pA);
         int sp__Pop2_Discard(stackP theStack);
 
-        int sp_Top(stackP);
-        int sp_Get(stackP, int);
-        int sp_Set(stackP, int, int);
+        int sp_Top(stackP theStack);
+        int sp_Get(stackP theStack, int pos);
+        int sp_Set(stackP theStack, int pos, int val);
 
 #else
 


### PR DESCRIPTION
## Summary
- add parameter names to `strbuf.h` declarations to match the implementation definitions
- add parameter names to `stack.h` declarations to match the implementation definitions
- add parameter names to private logging string helper declarations

Refs #188

This intentionally avoids `graphFunctionTable.h` because it overlaps an open PR/claim for #251 and its function-pointer fields are a separate conflict surface.

## Testing
- `git diff --check`
- rebuilt `planarity.exe` from current sources with `gcc -O2`
- `./planarity.exe -test ./c/samples/`