### PR TITLE
Name extension callback parameters

### DIFF
--- a/c/graphLib/extensionSystem/graphExtensions.h
+++ b/c/graphLib/extensionSystem/graphExtensions.h
@@ -17,9 +17,9 @@ extern "C"
     int gp_AddExtension(graphP theGraph,
                         int *pModuleID,
                         void *context,
-                        void *(*dupContext)(void *, void *),
-                        int  (*copyData)(void *, void *),
-                        void (*freeContext)(void *),
+                        void *(*dupContext)(void *pContext, void *theGraph),
+                        int  (*copyData)(void *dstContext, void *srcContext),
+                        void (*freeContext)(void *pContext),
                         graphFunctionTableP overloadTable);
 
     int gp_FindExtension(graphP theGraph, int moduleID, void **pContext);

--- a/c/graphLib/extensionSystem/graphExtensions.private.h
+++ b/c/graphLib/extensionSystem/graphExtensions.private.h
@@ -18,9 +18,9 @@ extern "C"
     {
         int moduleID;
         void *context;
-        void *(*dupContext)(void *, void *);
-        int  (*copyData)(void *, void *);
-        void (*freeContext)(void *);
+        void *(*dupContext)(void *pContext, void *theGraph);
+        int  (*copyData)(void *dstContext, void *srcContext);
+        void (*freeContext)(void *pContext);
 
         graphFunctionTableP functions;
 


### PR DESCRIPTION
## Summary
- add parameter names to extension callback function pointer declarations in `graphExtensions.h`
- mirror those names in the private extension struct callback fields

## Validation
- `git diff --check`
- built `planarity.exe` with GCC from the current C sources
- `./planarity.exe -test ./c/samples/`

Refs #188