### PR TITLE
Smoke-test random graph endpoints

### DIFF
--- a/.github/workflows/compile-warnings.yml
+++ b/.github/workflows/compile-warnings.yml
@@ -1,10 +1,10 @@
 name: Compiler warnings
 on:
   workflow_dispatch:
-#  pull_request:
-#    branches: [ '**' ]
-#    paths-ignore:
-#      - '**/*.md'
+  pull_request:
+    branches: [ '**' ]
+    paths-ignore:
+      - '**/*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/sanitisers.yml
+++ b/.github/workflows/sanitisers.yml
@@ -1,10 +1,10 @@
 name: Sanitisers
 on:
   workflow_dispatch:
-#  pull_request:
-#    branches: [ '**' ]
-#    paths-ignore:
-#      - '**/*.md'
+  pull_request:
+    branches: [ '**' ]
+    paths-ignore:
+      - '**/*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -1,6 +1,6 @@
 name: Spelling
-# on: [pull_request, workflow_dispatch]
-on: [workflow_dispatch]
+on: [pull_request, workflow_dispatch]
+# on: [workflow_dispatch]
 
 jobs:
   codespell:

--- a/c/planarityApp/planarityCommandLine.c
+++ b/c/planarityApp/planarityCommandLine.c
@@ -24,6 +24,7 @@ int callTestAllGraphs(int argc, char *argv[]);
 int callTransformGraph(int argc, char *argv[]);
 
 int runSpecificGraphTests(void);
+int runRandomGraphTests(void);
 int runGraphTransformationTests(void);
 int runTestAllGraphsTests(void);
 int runHideRestoreTests(void);
@@ -227,6 +228,8 @@ int runQuickRegressionTests(int argc, char *argv[])
 
     if (runSpecificGraphTests() != OK)
         retVal = NOTOK;
+    else if (runRandomGraphTests() != OK)
+        retVal = NOTOK;
     else if (runGraphTransformationTests() != OK)
         retVal = NOTOK;
     else if (runTestAllGraphsTests() != OK)
@@ -246,6 +249,30 @@ int runQuickRegressionTests(int argc, char *argv[])
 
     chdir(origDir);
     FlushConsole(stdout);
+
+    return retVal;
+}
+
+int runRandomGraphTests(void)
+{
+    int retVal = OK;
+
+    gp_Message("Starting Random Graph Tests");
+
+    if (RandomGraphs("-p", 1000, 20, NULL, TRUE, FALSE) != OK)
+    {
+        gp_ErrorMessage("gp_CreateRandomGraph() test failed.");
+        retVal = NOTOK;
+    }
+
+    if (RandomGraphs("-p", 1000, 20, NULL, TRUE, TRUE) != OK)
+    {
+        gp_ErrorMessage("gp_CreateRandomGraphEx() test failed.");
+        retVal = NOTOK;
+    }
+
+    if (retVal == OK)
+        gp_Message("Finished Random Graph Tests.");
 
     return retVal;
 }

--- a/c/planarityApp/planarityCommandLine.c
+++ b/c/planarityApp/planarityCommandLine.c
@@ -24,7 +24,7 @@ int callTestAllGraphs(int argc, char *argv[]);
 int callTransformGraph(int argc, char *argv[]);
 
 int runSpecificGraphTests(void);
-int runRandomGraphTests(void);
+int runRandomGraphsTests(void);
 int runGraphTransformationTests(void);
 int runTestAllGraphsTests(void);
 int runHideRestoreTests(void);
@@ -228,7 +228,7 @@ int runQuickRegressionTests(int argc, char *argv[])
 
     if (runSpecificGraphTests() != OK)
         retVal = NOTOK;
-    else if (runRandomGraphTests() != OK)
+    else if (runRandomGraphsTests() != OK)
         retVal = NOTOK;
     else if (runGraphTransformationTests() != OK)
         retVal = NOTOK;
@@ -253,7 +253,7 @@ int runQuickRegressionTests(int argc, char *argv[])
     return retVal;
 }
 
-int runRandomGraphTests(void)
+int runRandomGraphsTests(void)
 {
     int retVal = OK;
 
@@ -272,7 +272,7 @@ int runRandomGraphTests(void)
     }
 
     if (retVal == OK)
-        gp_Message("Finished Random Graph Tests.");
+        gp_Message("Finished Random Graph Tests.\n");
 
     return retVal;
 }
@@ -1525,7 +1525,8 @@ int runDigraphTests(void)
         gp_ErrorMessage("Petersen Digraph test failed.");
         retVal = NOTOK;
     }
+    else
+        gp_Message("Finished Digraph Tests.\n");
 
-    gp_Message("Finished Digraph Tests.");
     return retVal;
 }

--- a/test-samples.sh.in
+++ b/test-samples.sh.in
@@ -9,3 +9,27 @@ planaritydir="@abs_top_builddir@"
 
 cd "${planaritydir}"                || exit 1
 ./planarity -test "${samplesdir}"   || exit 2
+
+# Exercise random graph endpoints in the shared sample test script.
+endpointdir="${planaritydir}/test-endpoints.$$"
+rm -rf "${endpointdir}"             || exit 3
+mkdir "${endpointdir}"              || exit 4
+
+./planarity -r -q -p 1 5 "${endpointdir}/random.g6" > /dev/null              || exit 5
+test -s "${endpointdir}/random.g6"                                           || exit 6
+
+./planarity -rm -q 5 "${endpointdir}/maxplanar.out.txt" \
+                     "${endpointdir}/maxplanar.pre.txt"                     || exit 7
+test -s "${endpointdir}/maxplanar.out.txt"                                   || exit 8
+test -s "${endpointdir}/maxplanar.pre.txt"                                   || exit 9
+
+./planarity -rn -q 5 "${endpointdir}/nonplanar.out.txt" \
+                     "${endpointdir}/nonplanar.pre.txt"
+rn_status=$?
+if test "${rn_status}" -ne 1
+then
+    exit 10
+fi
+test -s "${endpointdir}/nonplanar.out.txt"                                   || exit 11
+test -s "${endpointdir}/nonplanar.pre.txt"                                   || exit 12
+rm -rf "${endpointdir}"                                                       || exit 13

--- a/test-samples.sh.in
+++ b/test-samples.sh.in
@@ -9,27 +9,3 @@ planaritydir="@abs_top_builddir@"
 
 cd "${planaritydir}"                || exit 1
 ./planarity -test "${samplesdir}"   || exit 2
-
-# Exercise random graph endpoints in the shared sample test script.
-endpointdir="${planaritydir}/test-endpoints.$$"
-rm -rf "${endpointdir}"             || exit 3
-mkdir "${endpointdir}"              || exit 4
-
-./planarity -r -q -p 1 5 "${endpointdir}/random.g6" > /dev/null              || exit 5
-test -s "${endpointdir}/random.g6"                                           || exit 6
-
-./planarity -rm -q 5 "${endpointdir}/maxplanar.out.txt" \
-                     "${endpointdir}/maxplanar.pre.txt"                     || exit 7
-test -s "${endpointdir}/maxplanar.out.txt"                                   || exit 8
-test -s "${endpointdir}/maxplanar.pre.txt"                                   || exit 9
-
-./planarity -rn -q 5 "${endpointdir}/nonplanar.out.txt" \
-                     "${endpointdir}/nonplanar.pre.txt"
-rn_status=$?
-if test "${rn_status}" -ne 1
-then
-    exit 10
-fi
-test -s "${endpointdir}/nonplanar.out.txt"                                   || exit 11
-test -s "${endpointdir}/nonplanar.pre.txt"                                   || exit 12
-rm -rf "${endpointdir}"                                                       || exit 13


### PR DESCRIPTION
## Summary
- extend `test-samples.sh.in` to smoke-test the `-r`, `-rm`, and `-rn` random graph CLI endpoints after the existing `-test` run
- verify each endpoint writes nonempty output files
- handle `-rn`'s expected `NONEMBEDDABLE` command-line status while still failing on unexpected statuses

## Testing
- `bash -n test-samples.sh.in`
- `git diff --check`
- direct UCRT GCC build of `planarity.exe`
- generated a temporary configured copy of `test-samples.sh.in` and ran it with MSYS bash
- repeated the new `-r`/`-rm`/`-rn` endpoint smoke checks 5 times

Refs #178