### PR TITLE
Fix LEDA reader unreachable-code warning

### DIFF
--- a/c/graphLib/io/graphIO.c
+++ b/c/graphLib/io/graphIO.c
@@ -359,7 +359,7 @@ int _ReadLEDAGraph(graphP theGraph, strOrFileP inputContainer)
 
     int graphType = 0;
     int N = 0, M = 0, u = NIL, v = NIL;
-    int zeroBasedOffset = (gp_LowerBoundVertexStorage(theGraph) == 0) ? 1 : 0;
+    int zeroBasedOffset = (gp_LowerBoundVertexStorage(theGraph) == ( 0 )) ? ( 1 ) : ( 0 );
     char Line[MAXLINE + 1];
 
     memset(Line, '\0', (MAXLINE + 1));


### PR DESCRIPTION
Resolves #304

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Changes

### Updated

- `c/graphLib/io/graphIO.c`: explicitly parenthesize the compile-time constant operands in `_ReadLEDAGraph()` so Clang treats the intentionally constant conditional as acknowledged rather than reporting unreachable code.

## Testing

- Built with Apple Clang 17 using `-Werror -Wunreachable-code` in the default one-based array configuration.
- Built with the same flags and `-DUSE_0BASEDARRAYS`.
- Ran `./test-samples.sh` for both builds; both completed with `All tests have succeeded.`
- Confirmed `git diff --check` passes.

The builds retain the repository's existing `-Wno-error=unused-parameter` exception so unrelated pre-existing unused-parameter diagnostics do not mask the targeted unreachable-code check.
