### PR TITLE
docs: add security reporting policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,9 @@ Contributing can be as simple as asking a question. Please send questions by ema
 
 Contributing can take the form of posting an [issue](https://github.com/graph-algorithms/edge-addition-planarity-suite/issues) containing a feature request or a bug report. You are also welcome to post additional comments on issues to provide your insights or experiences related to the issue, as this will help us to make better decisions when resolving the issue.
 
-**NOTE:** Please do not report any suspected security vulnerabilities as issue. Instead, please email the project lead as above so that we may patch the security vulnerability and notify downstream consumers before it can be exploited.
+**NOTE:** Please do not report suspected security vulnerabilities publicly. Follow the private reporting instructions in the project's [security policy](SECURITY.md) so that we may patch the vulnerability and notify downstream consumers before it can be exploited.
 
 Contributing can also take the form of submitting pull requests that solve or partially solve an existing issue. Please ensure that you are familiar with [this project's license](https://github.com/graph-algorithms/edge-addition-planarity-suite/blob/master/LICENSE.TXT) before you create a pull request to make a contribution. Please also read and follow the instructions in the [Dev Setup Wiki Page](https://github.com/graph-algorithms/edge-addition-planarity-suite/wiki/2.-Dev-Setup) to get started with contributing code.
 
 **NOTE:** If your pull request is merged, then you will be considered as having contributed code. We would very much like for GitHub to add your identity into the Contributors list on [this project's main page](https://github.com/graph-algorithms/edge-addition-planarity-suite). However, this will only happen if you correctly configure your git `user.name` and `user.email` on your development computer. Instructions for this are on [Dev Setup Wiki Page](https://github.com/graph-algorithms/edge-addition-planarity-suite/wiki/2.-Dev-Setup).
-
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Supported Versions
+
+This project does not currently publish a fixed support window. Please report a
+suspected vulnerability even if you observe it in an older release, and include
+the affected release tag or commit so the maintainers can assess it.
+
+## Reporting a Vulnerability
+
+Please do not disclose suspected security vulnerabilities in a public GitHub
+issue, discussion, or pull request. Instead, email the project lead,
+[John M. Boyer](mailto:jboyer@acm.org), and cc
+[John's backup email](mailto:john.boyer.phd@gmail.com).
+
+When possible, include:
+
+- the affected release, commit, platform, and configuration;
+- a description of the vulnerability and its potential impact;
+- steps or a minimal example that reproduce the issue; and
+- any known mitigations or suggested fixes.
+
+Please allow the maintainers time to investigate and coordinate a fix and any
+necessary notification to downstream consumers before public disclosure.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,3 +22,7 @@ When possible, include:
 
 Please allow the maintainers time to investigate and coordinate a fix and any
 necessary notification to downstream consumers before public disclosure.
+
+## Preferred Languages
+
+We prefer reports in **English** since we will otherwise need to use translation tools that may not fully convey intended meanings in your report.


### PR DESCRIPTION
Resolves #303

## Type of change

- This change requires a documentation update

## Changes

### Added

- SECURITY.md: documents private vulnerability reporting, the affected-version information reporters should provide, and responsible-disclosure expectations without promising a fixed support window or response SLA.

### Updated

- CONTRIBUTING.md: directs suspected vulnerability reports to the standard security policy instead of duplicating partial instructions.

## Testing

- Confirmed both mail links match the project lead and backup addresses already documented in CONTRIBUTING.md.
- Confirmed the contributing-guide link resolves to the new root-level policy.
- Confirmed git diff --check passes.

This is a documentation-only change; no runtime behavior is affected.