### PR TITLE
Enable unused parameter warnings

### DIFF
--- a/.github/workflows/dev-platforms.yml
+++ b/.github/workflows/dev-platforms.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Build using MSVC cl
         run: |
           cl /O2 /nologo /Wall /wd4464 /wd4710 /wd4711 /wd4774 /wd4996 /wd5045 `
-          /wd4068 /wd4100 /wd4820 /external:anglebrackets /external:W0 `
+          /wd4068 /wd4820 /external:anglebrackets /external:W0 `
           /Fe./planarity.exe ./c/planarityApp/**.c ./c/graphLib/**.c `
           ./c/graphLib/extensionSystem/**.c ./c/graphLib/homeomorphSearch/**.c `
           ./c/graphLib/io/**.c ./c/graphLib/lowLevelUtils/**.c `

--- a/c/graphLib/graph.c
+++ b/c/graphLib/graph.c
@@ -705,6 +705,9 @@ int _ClearAllVisitedFlagsOnPath(graphP theGraph, int u, int v, int w, int x)
 {
     int e, eTwin;
 
+    // Suppresses an unused-parameter warning for a parameter we intend to keep
+    (void)w;
+
     // We want to exit u from e, but we get eTwin first here in order to avoid
     // work, in case the degree of u is greater than 2.
     eTwin = _gp_FindEdge(theGraph, v, u);
@@ -746,6 +749,9 @@ int _ClearAllVisitedFlagsOnPath(graphP theGraph, int u, int v, int w, int x)
 int _SetAllVisitedFlagsOnPath(graphP theGraph, int u, int v, int w, int x)
 {
     int e, eTwin;
+
+    // Suppresses an unused-parameter warning for a parameter we intend to keep
+    (void)w;
 
     // We want to exit u from e, but we get eTwin first here in order to avoid
     // work, in case the degree of u is greater than 2.

--- a/c/graphLib/homeomorphSearch/graphK23Search_Extensions.c
+++ b/c/graphLib/homeomorphSearch/graphK23Search_Extensions.c
@@ -118,6 +118,9 @@ void *_K23Search_DupContext(void *pContext, void *theGraph)
     K23SearchContext *context = (K23SearchContext *)pContext;
     K23SearchContext *newContext = (K23SearchContext *)malloc(sizeof(K23SearchContext));
 
+    // Suppresses an unused-parameter warning for a parameter we intend to keep
+    (void)theGraph;
+
     if (newContext != NULL)
     {
         *newContext = *context;
@@ -131,6 +134,11 @@ void *_K23Search_DupContext(void *pContext, void *theGraph)
  ********************************************************************/
 int _K23Search_CopyData(void *dstContext, void *srcContext)
 {
+    // Suppresses an unused-parameter warning for a parameter we intend to keep
+    (void)dstContext;
+    // Suppresses an unused-parameter warning for a parameter we intend to keep
+    (void)srcContext;
+
     return OK;
 }
 

--- a/c/graphLib/homeomorphSearch/graphK33Search.c
+++ b/c/graphLib/homeomorphSearch/graphK33Search.c
@@ -1428,6 +1428,9 @@ int _K33Search_DeleteUnmarkedEdgesInBicomp(graphP theGraph, K33SearchContext *co
     int V, e, eNext;
     int stackBottom = sp_GetCurrentSize(theGraph->theStack);
 
+    // Suppresses an unused-parameter warning for a parameter we intend to keep
+    (void)context;
+
     sp_Push(theGraph->theStack, BicompRoot);
     while (sp_GetCurrentSize(theGraph->theStack) > stackBottom)
     {

--- a/c/graphLib/homeomorphSearch/graphK4Search.c
+++ b/c/graphLib/homeomorphSearch/graphK4Search.c
@@ -1027,6 +1027,9 @@ int _K4_DeleteUnmarkedEdgesInBicomp(graphP theGraph, K4SearchContext *context, i
     int V, e, eNext;
     int stackBottom = sp_GetCurrentSize(theGraph->theStack);
 
+    // Suppresses an unused-parameter warning for a parameter we intend to keep
+    (void)context;
+
     sp_Push(theGraph->theStack, BicompRoot);
     while (sp_GetCurrentSize(theGraph->theStack) > stackBottom)
     {

--- a/c/graphLib/io/graphIO.c
+++ b/c/graphLib/io/graphIO.c
@@ -597,6 +597,11 @@ int _ReadGraph(graphP theGraph, strOrFileP *pInputContainer)
 
 int _ReadPostprocess(graphP theGraph, char *extraData)
 {
+    // Suppresses an unused-parameter warning for a parameter we intend to keep
+    (void)theGraph;
+    // Suppresses an unused-parameter warning for a parameter we intend to keep
+    (void)extraData;
+
     return OK;
 }
 
@@ -1077,5 +1082,10 @@ int _WriteGraph(graphP theGraph, strOrFileP *pOutputContainer, int Mode)
 
 int _WritePostprocess(graphP theGraph, char **pExtraData)
 {
+    // Suppresses an unused-parameter warning for a parameter we intend to keep
+    (void)theGraph;
+    // Suppresses an unused-parameter warning for a parameter we intend to keep
+    (void)pExtraData;
+
     return OK;
 }

--- a/c/graphLib/io/graphML-writer.c
+++ b/c/graphLib/io/graphML-writer.c
@@ -111,6 +111,7 @@ int _WriteGraphMLGraphVertices(graphP theGraph, int index, strOrFileP outputCont
     int v = NIL;
     int zeroBasedVertexOffset = 0;
 
+    // Suppresses an unused-parameter warning for a parameter we intend to keep
     (void)index;
 
     if (theGraph == NULL || !sf_IsValidStrOrFile(outputContainer))
@@ -145,6 +146,7 @@ int _WriteGraphMLGraphEdges(graphP theGraph, int index, strOrFileP outputContain
     int targetVertex = NIL;
     int zeroBasedVertexOffset = 0;
 
+    // Suppresses an unused-parameter warning for a parameter we intend to keep
     (void)index;
 
     if (theGraph == NULL || !sf_IsValidStrOrFile(outputContainer))
@@ -198,6 +200,7 @@ int _WriteGraphMLGraphEdges(graphP theGraph, int index, strOrFileP outputContain
  ********************************************************************/
 int _WriteGraphMLGraphEndTag(graphP theGraph, int index, strOrFileP outputContainer)
 {
+    // Suppresses an unused-parameter warning for a parameter we intend to keep
     (void)index;
 
     if (theGraph == NULL)

--- a/c/graphLib/planarityRelated/graphDrawPlanar.c
+++ b/c/graphLib/planarityRelated/graphDrawPlanar.c
@@ -646,6 +646,13 @@ void _CollectDrawingData(DrawPlanarContext *context, int RootVertex, int W, int 
     graphP theEmbedding = context->theGraph;
     int K, Parent, BicompRoot, DFSChild, direction, descendant;
 
+    // Suppresses an unused-parameter warning for a parameter we intend to keep
+    (void)RootVertex;
+    // Suppresses an unused-parameter warning for a parameter we intend to keep
+    (void)W;
+    // Suppresses an unused-parameter warning for a parameter we intend to keep
+    (void)WPrevLink;
+
     _gp_LogLine("\ngraphDrawPlanar.c/_CollectDrawingData() start");
     _gp_LogLine(_gp_MakeLogStr3("_CollectDrawingData(RootVertex=%d, W=%d, W_in=%d)",
                                 RootVertex, W, WPrevLink));

--- a/c/graphLib/planarityRelated/graphEmbed.c
+++ b/c/graphLib/planarityRelated/graphEmbed.c
@@ -935,6 +935,15 @@ int _MergeBicomps(graphP theGraph, int v, int RootVertex, int W, int WPrevLink)
 {
     int R, Rout, Z, ZPrevLink, e, extFaceVertex;
 
+    // Suppresses an unused-parameter warning for a parameter we intend to keep
+    (void)v;
+    // Suppresses an unused-parameter warning for a parameter we intend to keep
+    (void)RootVertex;
+    // Suppresses an unused-parameter warning for a parameter we intend to keep
+    (void)W;
+    // Suppresses an unused-parameter warning for a parameter we intend to keep
+    (void)WPrevLink;
+
     while (sp_NonEmpty(theGraph->theStack))
     {
         sp_Pop2(theGraph->theStack, R, Rout);
@@ -1516,7 +1525,12 @@ void _AdvanceFwdEdgeList(graphP theGraph, int v, int child, int nextChild)
 
 int _HandleInactiveVertex(graphP theGraph, int BicompRoot, int *pW, int *pWPrevLink)
 {
-    int X = gp_GetExtFaceVertex(theGraph, *pW, 1 ^ *pWPrevLink);
+    int X;
+
+    // Suppresses an unused-parameter warning for a parameter we intend to keep
+    (void)BicompRoot;
+
+    X = gp_GetExtFaceVertex(theGraph, *pW, 1 ^ *pWPrevLink);
     *pWPrevLink = gp_GetExtFaceVertex(theGraph, X, 0) == *pW ? 0 : 1;
     *pW = X;
 
@@ -1551,6 +1565,9 @@ int _HandleInactiveVertex(graphP theGraph, int BicompRoot, int *pW, int *pWPrevL
 int _EmbedPostprocess(graphP theGraph, int v, int edgeEmbeddingResult)
 {
     int RetVal = edgeEmbeddingResult;
+
+    // Suppresses an unused-parameter warning for a parameter we intend to keep
+    (void)v;
 
     // If an embedding was found, then post-process the embedding structure give
     // a consistent orientation to all vertices then eliminate virtual vertices
@@ -1697,6 +1714,9 @@ int _JoinBicomps(graphP theGraph)
 int _OrientExternalFacePath(graphP theGraph, int u, int v, int w, int x)
 {
     int e_u, e_v, e_ulink, e_vlink;
+
+    // Suppresses an unused-parameter warning for a parameter we intend to keep
+    (void)w;
 
     // Get the edge record in u that indicates v; uses the "get twin" method
     // to ensure the cost is dominated by the degree of v (which is 2), not u

--- a/c/planarityApp/planarityUtils.c
+++ b/c/planarityApp/planarityUtils.c
@@ -1013,6 +1013,9 @@ void WriteAlgorithmResults(graphP theGraph, int Result, char command, platform_t
     char algorithmResults[MAXLINE + 1];
     char *target = algorithmResults;
 
+    // Suppresses an unused-parameter warning for a parameter we intend to keep
+    (void)theGraph;
+
     memset(algorithmResults, '\0', MAXLINE + 1);
 
     target += sprintf(target, "The graph ");

--- a/devEnvSetupAndDefaults/.vscode/tasks.json
+++ b/devEnvSetupAndDefaults/.vscode/tasks.json
@@ -39,9 +39,7 @@
                 "-Wnested-externs",
                 "-Wno-error=suggest-attribute=format",
                 "-Wno-error=missing-field-initializers",
-                "-Wno-error=unused-parameter",
                 "-Wno-missing-field-initializers",
-                "-Wno-unused-parameter",
                 "-Wnull-dereference",
                 "-Wold-style-definition",
                 "-Wpacked",
@@ -118,9 +116,7 @@
                 "-Wnested-externs",
                 "-Wno-error=suggest-attribute=format",
                 "-Wno-error=missing-field-initializers",
-                "-Wno-error=unused-parameter",
                 "-Wno-missing-field-initializers",
-                "-Wno-unused-parameter",
                 "-Wnull-dereference",
                 "-Wold-style-definition",
                 "-Wpacked",
@@ -193,9 +189,7 @@
                 "-Wmissing-prototypes",
                 "-Wnested-externs",
                 "-Wno-error=missing-field-initializers",
-                "-Wno-error=unused-parameter",
                 "-Wno-missing-field-initializers",
-                "-Wno-unused-parameter",
                 "-Wnull-dereference",
                 "-Wold-style-definition",
                 "-Wpacked",
@@ -269,9 +263,7 @@
                 "-Wmissing-prototypes",
                 "-Wnested-externs",
                 "-Wno-error=missing-field-initializers",
-                "-Wno-error=unused-parameter",
                 "-Wno-missing-field-initializers",
-                "-Wno-unused-parameter",
                 "-Wnull-dereference",
                 "-Wold-style-definition",
                 "-Wpacked",
@@ -343,9 +335,7 @@
                 "-Wmissing-prototypes",
                 "-Wnested-externs",
                 "-Wno-error=missing-field-initializers",
-                "-Wno-error=unused-parameter",
                 "-Wno-missing-field-initializers",
-                "-Wno-unused-parameter",
                 "-Wnull-dereference",
                 "-Wold-style-definition",
                 "-Wpacked",
@@ -403,7 +393,6 @@
                 "/wd4996", // Ignore safety warnings about sprintf, scanf, strcpy, strcat, fopen, etc.
                 "/wd5045", // Ignore Spectre mitigation warning
                 "/wd4068", // Ignore warnings about unrecognized pragmas (like the ones that suppress format-nonliteral warnings)
-                "/wd4100", // Ignore warnings about unused parameters (because they may be used by future function overloads or may help with programming consistency)
                 "/wd4820", // Ignore warnings from antediluvian compiler about padding, e.g., for normal use of bool type
                 "/external:anglebrackets",
                 "/external:W0", // Ignore warnings thrown by external headers
@@ -447,7 +436,6 @@
                 "/wd4996", // Ignore safety warnings about sprintf, scanf, strcpy, strcat, fopen, etc.
                 "/wd5045", // Ignore Spectre mitigation warning
                 "/wd4068", // Ignore warnings about unrecognized pragmas (like the ones that suppress format-nonliteral warnings)
-                "/wd4100", // Ignore warnings about unused parameters (because they may be used by future function overloads or may help with programming consistency)
                 "/wd4820", // Ignore warnings from antediluvian compiler about padding, e.g., for normal use of bool type
                 "/external:anglebrackets",
                 "/external:W0", // Ignore warnings thrown by external headers
@@ -487,7 +475,6 @@
                 "/wd4996", // Ignore safety warnings about sprintf, scanf, strcpy, strcat, fopen, etc.
                 "/wd5045", // Ignore Spectre mitigation warning
                 "/wd4068", // Ignore warnings about unrecognized pragmas (like the ones that suppress format-nonliteral warnings)
-                "/wd4100", // Ignore warnings about unused parameters (because they may be used by future function overloads or may help with programming consistency)
                 "/wd4820", // Ignore warnings from antediluvian compiler about padding, e.g., for normal use of bool type
                 "/external:anglebrackets",
                 "/external:W0", // Ignore warnings thrown by external headers
@@ -542,9 +529,7 @@
                 "-Wmissing-prototypes",
                 "-Wnested-externs",
                 "-Wno-error=missing-field-initializers",
-                "-Wno-error=unused-parameter",
                 "-Wno-missing-field-initializers",
-                "-Wno-unused-parameter",
                 "-Wnull-dereference",
                 "-Wold-style-definition",
                 "-Wpacked",
@@ -616,9 +601,7 @@
                 "-Wmissing-prototypes",
                 "-Wnested-externs",
                 "-Wno-error=missing-field-initializers",
-                "-Wno-error=unused-parameter",
                 "-Wno-missing-field-initializers",
-                "-Wno-unused-parameter",
                 "-Wnull-dereference",
                 "-Wold-style-definition",
                 "-Wpacked",
@@ -686,9 +669,7 @@
                 "-Wmissing-prototypes",
                 "-Wnested-externs",
                 "-Wno-error=missing-field-initializers",
-                "-Wno-error=unused-parameter",
                 "-Wno-missing-field-initializers",
-                "-Wno-unused-parameter",
                 "-Wnull-dereference",
                 "-Wold-style-definition",
                 "-Wpacked",

--- a/m4/ax_compiler_flags_cflags.m4
+++ b/m4/ax_compiler_flags_cflags.m4
@@ -94,7 +94,7 @@ AC_DEFUN([AX_COMPILER_FLAGS_CFLAGS],[
             -Wpointer-arith dnl
             -Wmissing-declarations dnl
             -Wredundant-decls dnl
-            -Wno-unused-parameter dnl
+            -Wunused-parameter dnl
             -Wno-missing-field-initializers dnl
             -Wformat=2 dnl
             -Wcast-align dnl


### PR DESCRIPTION
Resolves #299

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Changes

### Updated

* `devEnvSetupAndDefaults/.vscode/tasks.json` removes every GCC/Clang and MSVC unused-parameter warning suppression from the development build tasks.
* `m4/ax_compiler_flags_cflags.m4` enables `-Wunused-parameter` in the Autotools warning set used by `compile-warnings.yml`; `Makefile.am` already applies that generated `WARNING_CFLAGS` value to all targets.
* `.github/workflows/dev-platforms.yml` removes `/wd4100` from the MSVC build so the Windows CI job verifies the same policy.
* The affected graph library, extension, GraphML, and application callback implementations explicitly consume intentionally retained parameters with `(void)param;`. Every such line, including the three pre-existing GraphML markers, now has the requested explanatory comment.

The warning-flag investigation found that `compile-warnings.yml` selects the compiler and passes `-Werror`, `configure.ac` enables the checked warning set through `AX_COMPILER_FLAGS_CFLAGS`, and `Makefile.am` applies the resulting `WARNING_CFLAGS`. The VS Code tasks also contain compiler-specific warnings beyond that portable, feature-probed set; aligning all of those is separable from this unused-parameter fix.

## Testing

- Apple Clang 17, default 1-based storage: `autoreconf -if && ./configure --enable-compile-warnings CC=clang CFLAGS=-Werror && make -j4 && ./test-samples.sh`
- Apple Clang 17, 0-based storage: `./configure --enable-compile-warnings CC=clang CFLAGS="-Werror -DUSE_0BASEDARRAYS" && make -j4 && ./test-samples.sh`
- Independent syntax scan of every C translation unit with `-Wall -Wextra -Wunused-parameter`; no unused-parameter diagnostics remain.
- MSVC `/Wall` coverage is provided by the updated `dev-platforms.yml` job because MSVC is not available in the local macOS environment.

<details><summary>Validation result</summary>

```text
WARNING_CFLAGS includes -Wunused-parameter and no unused-parameter suppressor.
Default build: All tests have succeeded.
0-based build: All tests have succeeded.
```

</details>
