### PR TITLE
Complete GraphML Writer Part 2

### DIFF
--- a/c/graphLib/io/graphML-writer.c
+++ b/c/graphLib/io/graphML-writer.c
@@ -10,12 +10,14 @@ See the LICENSE.TXT file for licensing information.
 /* Private functions (exported to system) */
 int _WriteGraphMLGraph(graphP theGraph, strOrFileP outputContainer);
 int _WriteGraphMLStartTag(strOrFileP outputContainer);
+int _WriteGraphMLKeysForGraph(graphP theGraph, strOrFileP outputContainer);
 int _WriteGraphMLGraphElement(graphP theGraph, int index, strOrFileP outputContainer);
 int _WriteGraphMLEndTag(strOrFileP outputContainer);
 int _WriteGraphMLGraphStartTag(graphP theGraph, int index, strOrFileP outputContainer);
-int _WriteGraphMLGraphVertices(graphP theGraph, int index, strOrFileP outputContainer);
-int _WriteGraphMLGraphEdges(graphP theGraph, int index, strOrFileP outputContainer);
-int _WriteGraphMLGraphEndTag(graphP theGraph, int index, strOrFileP outputContainer);
+int _WriteGraphMLGraphCustomAttributes(graphP theGraph, strOrFileP outputContainer);
+int _WriteGraphMLGraphVertices(graphP theGraph, strOrFileP outputContainer);
+int _WriteGraphMLGraphEdges(graphP theGraph, strOrFileP outputContainer);
+int _WriteGraphMLGraphEndTag(graphP theGraph, strOrFileP outputContainer);
 
 /********************************************************************
  _WriteGraphMLGraph()
@@ -30,8 +32,32 @@ int _WriteGraphMLGraph(graphP theGraph, strOrFileP outputContainer)
         return NOTOK;
 
     if (_WriteGraphMLStartTag(outputContainer) != OK ||
+        _WriteGraphMLKeysForGraph(theGraph, outputContainer) != OK ||
         _WriteGraphMLGraphElement(theGraph, 1, outputContainer) != OK ||
         _WriteGraphMLEndTag(outputContainer) != OK)
+        return NOTOK;
+
+    return OK;
+}
+
+/********************************************************************
+ _WriteGraphMLKeysForGraph()
+
+ Writes GraphML key declarations for graph-level custom attributes.
+ ********************************************************************/
+int _WriteGraphMLKeysForGraph(graphP theGraph, strOrFileP outputContainer)
+{
+    char const *zeroBasedIOKey =
+        "  <key id=\"graphflags_zerobasedio\" for=\"graph\" "
+        "attr.name=\"graphflags_zerobasedio\" attr.type=\"boolean\">\n"
+        "    <default>false</default>\n"
+        "  </key>\n";
+
+    if (theGraph == NULL || !sf_IsValidStrOrFile(outputContainer))
+        return NOTOK;
+
+    if ((gp_GetGraphFlags(theGraph) & GRAPHFLAGS_ZEROBASEDIO) &&
+        sf_fputs(zeroBasedIOKey, outputContainer) == EOF)
         return NOTOK;
 
     return OK;
@@ -75,9 +101,10 @@ int _WriteGraphMLGraphElement(graphP theGraph, int index, strOrFileP outputConta
         return NOTOK;
 
     if (_WriteGraphMLGraphStartTag(theGraph, index, outputContainer) != OK ||
-        _WriteGraphMLGraphVertices(theGraph, index, outputContainer) != OK ||
-        _WriteGraphMLGraphEdges(theGraph, index, outputContainer) != OK ||
-        _WriteGraphMLGraphEndTag(theGraph, index, outputContainer) != OK)
+        _WriteGraphMLGraphCustomAttributes(theGraph, outputContainer) != OK ||
+        _WriteGraphMLGraphVertices(theGraph, outputContainer) != OK ||
+        _WriteGraphMLGraphEdges(theGraph, outputContainer) != OK ||
+        _WriteGraphMLGraphEndTag(theGraph, outputContainer) != OK)
         return NOTOK;
 
     return OK;
@@ -95,7 +122,33 @@ int _WriteGraphMLGraphStartTag(graphP theGraph, int index, strOrFileP outputCont
 
     if (sf_fputs("  <graph id=\"G", outputContainer) == EOF ||
         sf_WriteInteger(index, outputContainer) != OK ||
-        sf_fputs("\" edgedefault=\"undirected\">\n", outputContainer) == EOF)
+        sf_fputs("\" edgedefault=\"undirected\"\n"
+                 "         parse.nodes=\"",
+                 outputContainer) == EOF ||
+        sf_WriteInteger(gp_GetN(theGraph), outputContainer) != OK ||
+        sf_fputs("\" parse.edges=\"", outputContainer) == EOF ||
+        sf_WriteInteger(gp_GetM(theGraph), outputContainer) != OK ||
+        sf_fputs("\"\n"
+                 "         parse.nodeids=\"canonical\" parse.edgeids=\"canonical\"\n"
+                 "         parse.order=\"nodesfirst\">\n",
+                 outputContainer) == EOF)
+        return NOTOK;
+
+    return OK;
+}
+
+/********************************************************************
+ _WriteGraphMLGraphCustomAttributes()
+
+ Writes graph-level custom attribute values.
+ ********************************************************************/
+int _WriteGraphMLGraphCustomAttributes(graphP theGraph, strOrFileP outputContainer)
+{
+    if (theGraph == NULL || !sf_IsValidStrOrFile(outputContainer))
+        return NOTOK;
+
+    if ((gp_GetGraphFlags(theGraph) & GRAPHFLAGS_ZEROBASEDIO) &&
+        sf_fputs("    <data key=\"graphflags_zerobasedio\">true</data>\n", outputContainer) == EOF)
         return NOTOK;
 
     return OK;
@@ -106,23 +159,20 @@ int _WriteGraphMLGraphStartTag(graphP theGraph, int index, strOrFileP outputCont
 
  Writes one node element for every graph vertex.
  ********************************************************************/
-int _WriteGraphMLGraphVertices(graphP theGraph, int index, strOrFileP outputContainer)
+int _WriteGraphMLGraphVertices(graphP theGraph, strOrFileP outputContainer)
 {
     int v = NIL;
-    int zeroBasedVertexOffset = 0;
-
-    (void)index;
+    int vertexOffset = 0;
 
     if (theGraph == NULL || !sf_IsValidStrOrFile(outputContainer))
         return NOTOK;
 
-    if (gp_GetGraphFlags(theGraph) & GRAPHFLAGS_ZEROBASEDIO)
-        zeroBasedVertexOffset = gp_LowerBoundVertexStorage(theGraph);
+    vertexOffset = gp_LowerBoundVertexStorage(theGraph);
 
     for (v = gp_LowerBoundVertices(theGraph); v < gp_UpperBoundVertices(theGraph); ++v)
     {
         if (sf_fputs("    <node id=\"n", outputContainer) == EOF ||
-            sf_WriteInteger(v - zeroBasedVertexOffset, outputContainer) != OK ||
+            sf_WriteInteger(v - vertexOffset, outputContainer) != OK ||
             sf_fputs("\"/>\n", outputContainer) == EOF)
             return NOTOK;
     }
@@ -135,23 +185,20 @@ int _WriteGraphMLGraphVertices(graphP theGraph, int index, strOrFileP outputCont
 
  Writes one edge element for every in-use edge pair.
  ********************************************************************/
-int _WriteGraphMLGraphEdges(graphP theGraph, int index, strOrFileP outputContainer)
+int _WriteGraphMLGraphEdges(graphP theGraph, strOrFileP outputContainer)
 {
     int e = NIL;
-    int edgeID = 1;
+    int edgeID = 0;
     int sourceEdge = NIL;
     int targetEdge = NIL;
     int sourceVertex = NIL;
     int targetVertex = NIL;
-    int zeroBasedVertexOffset = 0;
-
-    (void)index;
+    int vertexOffset = 0;
 
     if (theGraph == NULL || !sf_IsValidStrOrFile(outputContainer))
         return NOTOK;
 
-    if (gp_GetGraphFlags(theGraph) & GRAPHFLAGS_ZEROBASEDIO)
-        zeroBasedVertexOffset = gp_LowerBoundVertexStorage(theGraph);
+    vertexOffset = gp_LowerBoundVertexStorage(theGraph);
 
     for (e = gp_LowerBoundEdges(theGraph); e < gp_UpperBoundEdges(theGraph); e += 2)
     {
@@ -166,9 +213,15 @@ int _WriteGraphMLGraphEdges(graphP theGraph, int index, strOrFileP outputContain
             sourceEdge = targetEdge;
             targetEdge = e;
         }
+        else if (gp_GetDirection(theGraph, sourceEdge) == 0 &&
+                 gp_GetNeighbor(theGraph, targetEdge) > gp_GetNeighbor(theGraph, sourceEdge))
+        {
+            sourceEdge = targetEdge;
+            targetEdge = e;
+        }
 
-        sourceVertex = gp_GetNeighbor(theGraph, targetEdge) - zeroBasedVertexOffset;
-        targetVertex = gp_GetNeighbor(theGraph, sourceEdge) - zeroBasedVertexOffset;
+        sourceVertex = gp_GetNeighbor(theGraph, targetEdge) - vertexOffset;
+        targetVertex = gp_GetNeighbor(theGraph, sourceEdge) - vertexOffset;
 
         if (sf_fputs("    <edge id=\"e", outputContainer) == EOF ||
             sf_WriteInteger(edgeID, outputContainer) != OK ||
@@ -196,11 +249,9 @@ int _WriteGraphMLGraphEdges(graphP theGraph, int index, strOrFileP outputContain
 
  Writes the graph element end tag.
  ********************************************************************/
-int _WriteGraphMLGraphEndTag(graphP theGraph, int index, strOrFileP outputContainer)
+int _WriteGraphMLGraphEndTag(graphP theGraph, strOrFileP outputContainer)
 {
-    (void)index;
-
-    if (theGraph == NULL)
+    if (theGraph == NULL || !sf_IsValidStrOrFile(outputContainer))
         return NOTOK;
 
     return sf_fputs("  </graph>\n", outputContainer) == EOF ? NOTOK : OK;

--- a/c/planarityApp/planarityCommandLine.c
+++ b/c/planarityApp/planarityCommandLine.c
@@ -40,6 +40,7 @@ int runGraphMLTests(void);
 int runDrawPlanarNonplanarWriteTest(void);
 int testPetersenDigraph(void);
 int testDigraphTranspose(void);
+int runGraphMLWriteTest(char const *inputFileName, char const *expectedOutputFileName);
 int runBasicGraphMLWriteTest(void);
 
 /****************************************************************************
@@ -1714,24 +1715,14 @@ int runDigraphTests(void)
     return retVal;
 }
 
-int runBasicGraphMLWriteTest(void)
+int runGraphMLWriteTest(char const *inputFileName, char const *expectedOutputFileName)
 {
     graphP G = gp_New();
     char *actualOutput = NULL;
-    char const *inputFileName = NULL;
-    char const *expectedOutputFileName = NULL;
     int Result = OK;
 
     if (G == NULL)
         return NOTOK;
-
-#ifdef USE_1BASEDARRAYS
-    inputFileName = "Digraph.transposeTest.txt";
-    expectedOutputFileName = "Digraph.transposeTest.graphml";
-#else
-    inputFileName = "Digraph.transposeTest.0-based.txt";
-    expectedOutputFileName = "Digraph.transposeTest.0-based.graphml";
-#endif
 
     if (gp_Read(G, inputFileName) != OK ||
         gp_WriteToString(G, &actualOutput, WRITE_GRAPHML) != OK ||
@@ -1744,6 +1735,15 @@ int runBasicGraphMLWriteTest(void)
     gp_Free(&G);
 
     return Result;
+}
+
+int runBasicGraphMLWriteTest(void)
+{
+    if (runGraphMLWriteTest("Digraph.transposeTest.txt", "Digraph.transposeTest.graphml") != OK ||
+        runGraphMLWriteTest("Digraph.transposeTest.0-based.txt", "Digraph.transposeTest.0-based.graphml") != OK)
+        return NOTOK;
+
+    return OK;
 }
 
 int runGraphMLTests(void)

--- a/c/samples/Digraph.transposeTest.0-based.graphml
+++ b/c/samples/Digraph.transposeTest.0-based.graphml
@@ -3,7 +3,14 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns
      http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-  <graph id="G1" edgedefault="undirected">
+  <key id="graphflags_zerobasedio" for="graph" attr.name="graphflags_zerobasedio" attr.type="boolean">
+    <default>false</default>
+  </key>
+  <graph id="G1" edgedefault="undirected"
+         parse.nodes="10" parse.edges="15"
+         parse.nodeids="canonical" parse.edgeids="canonical"
+         parse.order="nodesfirst">
+    <data key="graphflags_zerobasedio">true</data>
     <node id="n0"/>
     <node id="n1"/>
     <node id="n2"/>
@@ -14,20 +21,20 @@
     <node id="n7"/>
     <node id="n8"/>
     <node id="n9"/>
-    <edge id="e1" source="n4" target="n0"/>
-    <edge id="e2" source="n1" target="n0" directed="true"/>
-    <edge id="e3" source="n2" target="n1" directed="true"/>
-    <edge id="e4" source="n2" target="n7" directed="true"/>
-    <edge id="e5" source="n3" target="n2" directed="true"/>
-    <edge id="e6" source="n4" target="n3" directed="true"/>
-    <edge id="e7" source="n5" target="n0" directed="true"/>
-    <edge id="e8" source="n5" target="n8" directed="true"/>
-    <edge id="e9" source="n6" target="n1" directed="true"/>
-    <edge id="e10" source="n6" target="n9" directed="true"/>
-    <edge id="e11" source="n7" target="n5" directed="true"/>
-    <edge id="e12" source="n8" target="n6" directed="true"/>
-    <edge id="e13" source="n8" target="n3" directed="true"/>
-    <edge id="e14" source="n9" target="n7" directed="true"/>
-    <edge id="e15" source="n9" target="n4" directed="true"/>
+    <edge id="e0" source="n0" target="n4"/>
+    <edge id="e1" source="n1" target="n0" directed="true"/>
+    <edge id="e2" source="n2" target="n1" directed="true"/>
+    <edge id="e3" source="n2" target="n7" directed="true"/>
+    <edge id="e4" source="n3" target="n2" directed="true"/>
+    <edge id="e5" source="n4" target="n3" directed="true"/>
+    <edge id="e6" source="n5" target="n0" directed="true"/>
+    <edge id="e7" source="n5" target="n8" directed="true"/>
+    <edge id="e8" source="n6" target="n1" directed="true"/>
+    <edge id="e9" source="n6" target="n9" directed="true"/>
+    <edge id="e10" source="n7" target="n5" directed="true"/>
+    <edge id="e11" source="n8" target="n6" directed="true"/>
+    <edge id="e12" source="n8" target="n3" directed="true"/>
+    <edge id="e13" source="n9" target="n7" directed="true"/>
+    <edge id="e14" source="n9" target="n4" directed="true"/>
   </graph>
 </graphml>

--- a/c/samples/Digraph.transposeTest.graphml
+++ b/c/samples/Digraph.transposeTest.graphml
@@ -3,7 +3,11 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns
      http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-  <graph id="G1" edgedefault="undirected">
+  <graph id="G1" edgedefault="undirected"
+         parse.nodes="10" parse.edges="15"
+         parse.nodeids="canonical" parse.edgeids="canonical"
+         parse.order="nodesfirst">
+    <node id="n0"/>
     <node id="n1"/>
     <node id="n2"/>
     <node id="n3"/>
@@ -13,21 +17,20 @@
     <node id="n7"/>
     <node id="n8"/>
     <node id="n9"/>
-    <node id="n10"/>
-    <edge id="e1" source="n5" target="n1"/>
+    <edge id="e0" source="n0" target="n4"/>
+    <edge id="e1" source="n1" target="n0" directed="true"/>
     <edge id="e2" source="n2" target="n1" directed="true"/>
-    <edge id="e3" source="n3" target="n2" directed="true"/>
-    <edge id="e4" source="n3" target="n8" directed="true"/>
+    <edge id="e3" source="n2" target="n7" directed="true"/>
+    <edge id="e4" source="n3" target="n2" directed="true"/>
     <edge id="e5" source="n4" target="n3" directed="true"/>
-    <edge id="e6" source="n5" target="n4" directed="true"/>
-    <edge id="e7" source="n6" target="n1" directed="true"/>
-    <edge id="e8" source="n6" target="n9" directed="true"/>
-    <edge id="e9" source="n7" target="n2" directed="true"/>
-    <edge id="e10" source="n7" target="n10" directed="true"/>
+    <edge id="e6" source="n5" target="n0" directed="true"/>
+    <edge id="e7" source="n5" target="n8" directed="true"/>
+    <edge id="e8" source="n6" target="n1" directed="true"/>
+    <edge id="e9" source="n6" target="n9" directed="true"/>
+    <edge id="e10" source="n7" target="n5" directed="true"/>
     <edge id="e11" source="n8" target="n6" directed="true"/>
-    <edge id="e12" source="n9" target="n7" directed="true"/>
-    <edge id="e13" source="n9" target="n4" directed="true"/>
-    <edge id="e14" source="n10" target="n8" directed="true"/>
-    <edge id="e15" source="n10" target="n5" directed="true"/>
+    <edge id="e12" source="n8" target="n3" directed="true"/>
+    <edge id="e13" source="n9" target="n7" directed="true"/>
+    <edge id="e14" source="n9" target="n4" directed="true"/>
   </graph>
 </graphml>


### PR DESCRIPTION
Resolves #300

## Type of change

- New feature (non-breaking change which adds functionality)

## Changes

### Added

- `c/samples/Digraph.transposeTest.0-based.graphml`: expected GraphML output that records the zero-based I/O graph flag.

### Updated

- `c/graphLib/io/graphML-writer.c`: removes unused index parameters, emits canonical node/edge IDs, orients undirected edges from the lower-numbered vertex, adds GraphML parse metadata, and serializes the zero-based I/O flag as graph key/data elements.
- `c/planarityApp/planarityCommandLine.c`: exercises both one-based and zero-based GraphML inputs with shared test logic.
- `c/samples/Digraph.transposeTest.graphml`: updates the canonical expected output.

### Removed

- The compile-time branch that tested only one GraphML input/storage mode.

## Testing

- Default build: `make check` — 1/1 test passed.
- Clean zero-based build: `./configure CPPFLAGS=-DUSE_0BASEDARRAYS && make check` — 1/1 test passed.
- `xmllint --noout c/samples/Digraph.transposeTest.graphml c/samples/Digraph.transposeTest.0-based.graphml`
- `git diff --check`