### PR TITLE
Test single random graph endpoints

### DIFF
--- a/c/planarityApp/planarityCommandLine.c
+++ b/c/planarityApp/planarityCommandLine.c
@@ -345,6 +345,7 @@ int runAddInsertEdgeTests(void)
 int runRandomGraphsTests(void)
 {
     int retVal = OK;
+    unsigned quietModeCache = gp_GetQuietMode();
 
     gp_Message("Starting Random Graph Tests");
 
@@ -359,6 +360,24 @@ int runRandomGraphsTests(void)
         gp_ErrorMessage("gp_CreateRandomGraphEx() test failed.");
         retVal = NOTOK;
     }
+
+    // Suppress RandomGraph()'s interactive save prompts while exercising the
+    // maximal-planar and nonplanar paths used by the -rm and -rn endpoints.
+    gp_SetQuietMode(quietModeCache | QUIETMODE_MESSAGES);
+
+    if (RandomGraph("-p", 0, 5, NULL, NULL) != OK)
+    {
+        gp_ErrorMessage("Random maximal planar graph test failed.");
+        retVal = NOTOK;
+    }
+
+    if (RandomGraph("-p", 1, 5, NULL, NULL) != NONEMBEDDABLE)
+    {
+        gp_ErrorMessage("Random nonplanar graph test failed.");
+        retVal = NOTOK;
+    }
+
+    gp_SetQuietMode(quietModeCache);
 
     if (retVal == OK)
         gp_Message("Finished Random Graph Tests.\n");


### PR DESCRIPTION
## Summary

- exercise the single-graph generator used by the `-rm` and `-rn` command-line endpoints from the quick regression suite
- use five vertices so the maximal-planar case is expected to return `OK` and the one-extra-edge case is deterministically `NONEMBEDDABLE`
- temporarily suppress interactive save prompts and restore the caller's quiet-mode setting afterward
- avoid creating output files in the source samples directory during out-of-tree or `distcheck` runs

This fills the endpoint gap identified while reviewing whether #178 is ready to close. It complements the existing `RandomGraphs()` checks rather than restoring the older shell-level temporary-file tests.

## Validation

- Clang build with `-Wall -Wextra -Werror -g -O1` and full `./test-samples.sh`
- 20 additional consecutive full regression runs
- AddressSanitizer build and full regression
- UndefinedBehaviorSanitizer build and full regression
- `USE_0BASEDARRAYS` warning-as-error build and full regression
- `git diff --check`

Refs #178
