### PR TITLE
Name remaining function declaration parameters

### DIFF
--- a/c/graphLib/extensionSystem/graphFunctionTable.h
+++ b/c/graphLib/extensionSystem/graphFunctionTable.h
@@ -24,37 +24,37 @@ extern "C"
         // These function pointers allow extension modules to overload some of
         // the behaviors of protected functions.  Only advanced applications
         // will overload these functions
-        int (*fpEmbeddingInitialize)(graphP);
-        void (*fpEmbedBackEdgeToDescendant)(graphP, int, int, int, int);
-        void (*fpWalkUp)(graphP, int, int);
-        int (*fpWalkDown)(graphP, int, int);
-        int (*fpMergeBicomps)(graphP, int, int, int, int);
-        void (*fpMergeVertex)(graphP, int, int, int);
-        int (*fpHandleInactiveVertex)(graphP, int, int *, int *);
-        int (*fpHandleBlockedBicomp)(graphP, int, int, int);
-        int (*fpEmbedPostprocess)(graphP, int, int);
-        int (*fpMarkDFSPath)(graphP, int, int);
+        int (*fpEmbeddingInitialize)(graphP theGraph);
+        void (*fpEmbedBackEdgeToDescendant)(graphP theGraph, int RootSide, int RootVertex, int W, int WPrevLink);
+        void (*fpWalkUp)(graphP theGraph, int v, int e);
+        int (*fpWalkDown)(graphP theGraph, int v, int RootVertex);
+        int (*fpMergeBicomps)(graphP theGraph, int v, int RootVertex, int W, int WPrevLink);
+        void (*fpMergeVertex)(graphP theGraph, int W, int WPrevLink, int R);
+        int (*fpHandleInactiveVertex)(graphP theGraph, int BicompRoot, int *pW, int *pWPrevLink);
+        int (*fpHandleBlockedBicomp)(graphP theGraph, int v, int RootVertex, int R);
+        int (*fpEmbedPostprocess)(graphP theGraph, int v, int edgeEmbeddingResult);
+        int (*fpMarkDFSPath)(graphP theGraph, int ancestor, int descendant);
 
-        int (*fpCheckEmbeddingIntegrity)(graphP, graphP);
-        int (*fpCheckObstructionIntegrity)(graphP, graphP);
+        int (*fpCheckEmbeddingIntegrity)(graphP theGraph, graphP origGraph);
+        int (*fpCheckObstructionIntegrity)(graphP theGraph, graphP origGraph);
 
         // These function pointers allow extension modules to overload some
         // of the behaviors of gp_* function in the public API
-        int (*fpEnsureVertexCapacity)(graphP, int);
-        void (*fpResetGraphStorage)(graphP);
-        int (*fpEnsureEdgeCapacity)(graphP, int);
-        int (*fpSortVertices)(graphP);
+        int (*fpEnsureVertexCapacity)(graphP theGraph, int N);
+        void (*fpResetGraphStorage)(graphP theGraph);
+        int (*fpEnsureEdgeCapacity)(graphP theGraph, int requiredEdgeCapacity);
+        int (*fpSortVertices)(graphP theGraph);
 
-        int (*fpReadPostprocess)(graphP, char *);
-        int (*fpWritePostprocess)(graphP, char **);
+        int (*fpReadPostprocess)(graphP theGraph, char *extraData);
+        int (*fpWritePostprocess)(graphP theGraph, char **pExtraData);
 
-        int (*fpDeleteEdge)(graphP, int);
-        void (*fpHideEdge)(graphP, int);
-        void (*fpRestoreEdge)(graphP, int);
-        int (*fpHideVertex)(graphP, int);
-        int (*fpRestoreVertex)(graphP);
-        int (*fpContractEdge)(graphP, int);
-        int (*fpIdentifyVertices)(graphP, int, int, int);
+        int (*fpDeleteEdge)(graphP theGraph, int e);
+        void (*fpHideEdge)(graphP theGraph, int e);
+        void (*fpRestoreEdge)(graphP theGraph, int e);
+        int (*fpHideVertex)(graphP theGraph, int vertex);
+        int (*fpRestoreVertex)(graphP theGraph);
+        int (*fpContractEdge)(graphP theGraph, int e);
+        int (*fpIdentifyVertices)(graphP theGraph, int u, int v, int eBefore);
     };
 
     typedef struct graphFunctionTableStruct graphFunctionTableStruct;

--- a/c/graphLib/graphDFSUtils.c
+++ b/c/graphLib/graphDFSUtils.c
@@ -20,7 +20,7 @@ int _DepthFirstSearchDirected(graphP theGraph);
 int _SortVertices(graphP theGraph);
 
 // Imported methods
-extern void _ClearVertexVisitedFlags(graphP theGraph, int);
+extern void _ClearVertexVisitedFlags(graphP theGraph, int includeVirtualVertices);
 extern int _FillVertexVisitedIndexes(graphP theGraph, int FillValue);
 
 /********************************************************************

--- a/c/graphLib/homeomorphSearch/graphK23Search.c
+++ b/c/graphLib/homeomorphSearch/graphK23Search.c
@@ -9,7 +9,7 @@ See the LICENSE.TXT file for licensing information.
 
 /* Imported functions */
 
-extern void _ClearAllVisitedFlagsInGraph(graphP);
+extern void _ClearAllVisitedFlagsInGraph(graphP theGraph);
 
 extern int _GetNeighborOnExtFace(graphP theGraph, int curVertex, int *pPrevLink);
 extern int _OrientVerticesInBicomp(graphP theGraph, int BicompRoot, int PreserveSigns);

--- a/c/graphLib/homeomorphSearch/graphK23Search_Extensions.c
+++ b/c/graphLib/homeomorphSearch/graphK23Search_Extensions.c
@@ -29,8 +29,8 @@ int _K23Search_CheckObstructionIntegrity(graphP theGraph, graphP origGraph);
 /* Forward declarations of functions used by the extension system */
 
 void *_K23Search_DupContext(void *pContext, void *theGraph);
-int _K23Search_CopyData(void *, void *);
-void _K23Search_FreeContext(void *);
+int _K23Search_CopyData(void *dstContext, void *srcContext);
+void _K23Search_FreeContext(void *pContext);
 
 /****************************************************************************
  * K23SEARCH_ID - the variable used to hold the integer identifier for this

--- a/c/graphLib/homeomorphSearch/graphK33Search_Extensions.c
+++ b/c/graphLib/homeomorphSearch/graphK33Search_Extensions.c
@@ -52,7 +52,7 @@ int _K33Search_EnsureEdgeCapacity(graphP theGraph, int requiredEdgeCapacity);
 
 void *_K33Search_DupContext(void *pContext, void *theGraph);
 int _K33Search_CopyData(void *dstContext, void *srcContext);
-void _K33Search_FreeContext(void *);
+void _K33Search_FreeContext(void *pContext);
 
 /****************************************************************************
  * K33SEARCH_ID - the variable used to hold the integer identifier for this

--- a/c/graphLib/homeomorphSearch/graphK4Search.c
+++ b/c/graphLib/homeomorphSearch/graphK4Search.c
@@ -10,7 +10,7 @@ See the LICENSE.TXT file for licensing information.
 /* Imported functions */
 
 extern void _InitIsolatorContext(graphP theGraph);
-extern void _ClearAllVisitedFlagsInGraph(graphP);
+extern void _ClearAllVisitedFlagsInGraph(graphP theGraph);
 extern int _ClearAllVisitedFlagsInBicomp(graphP theGraph, int BicompRoot);
 // extern int  _ClearAllVisitedFlagsInOtherBicomps(graphP theGraph, int BicompRoot);
 // extern void _ClearEdgeVisitedFlagsInUnembeddedEdges(graphP theGraph);

--- a/c/graphLib/homeomorphSearch/graphK4Search_Extensions.c
+++ b/c/graphLib/homeomorphSearch/graphK4Search_Extensions.c
@@ -45,7 +45,7 @@ int _K4Search_EnsureEdgeCapacity(graphP theGraph, int requiredEdgeCapacity);
 
 void *_K4Search_DupContext(void *pContext, void *theGraph);
 int _K4Search_CopyData(void *dstContext, void *srcContext);
-void _K4Search_FreeContext(void *);
+void _K4Search_FreeContext(void *pContext);
 
 /****************************************************************************
  * K4SEARCH_ID - the variable used to hold the integer identifier for this

--- a/c/graphLib/io/g6-api-utilities.c
+++ b/c/graphLib/io/g6-api-utilities.c
@@ -25,7 +25,7 @@ int _g6_ValidateOrderOfEncodedGraph(char *graphBuff, int order);
 int _g6_ValidateGraphEncoding(char *graphBuff, const int order, const size_t numChars);
 
 /* Private functions */
-size_t _g6_GetMaxEdgeCount(int);
+size_t _g6_GetMaxEdgeCount(int order);
 
 size_t _g6_GetMaxEdgeCount(int order)
 {

--- a/c/graphLib/planarityRelated/graphDrawPlanar_Extensions.c
+++ b/c/graphLib/planarityRelated/graphDrawPlanar_Extensions.c
@@ -12,7 +12,7 @@ See the LICENSE.TXT file for licensing information.
 
 #include <stdlib.h>
 
-extern void _ClearVertexVisitedFlags(graphP theGraph, int);
+extern void _ClearVertexVisitedFlags(graphP theGraph, int includeVirtualVertices);
 
 extern void _CollectDrawingData(DrawPlanarContext *context, int RootVertex, int W, int WPrevLink);
 extern int _BreakTie(DrawPlanarContext *context, int BicompRoot, int W, int WPrevLink);
@@ -53,7 +53,7 @@ int _DrawPlanar_WritePostprocess(graphP theGraph, char **pExtraData);
 
 void *_DrawPlanar_DupContext(void *pContext, void *theGraph);
 int _DrawPlanar_CopyData(void *dstContext, void *srcContext);
-void _DrawPlanar_FreeContext(void *);
+void _DrawPlanar_FreeContext(void *pContext);
 
 /****************************************************************************
  * DRAWPLANAR_ID - the variable used to hold the integer identifier for this

--- a/c/graphLib/planarityRelated/graphEmbed.c
+++ b/c/graphLib/planarityRelated/graphEmbed.c
@@ -23,7 +23,7 @@ See the LICENSE.TXT file for licensing information.
 
 /* Imported functions */
 
-extern void _ClearVertexVisitedFlags(graphP theGraph, int);
+extern void _ClearVertexVisitedFlags(graphP theGraph, int includeVirtualVertices);
 extern int _FillVertexVisitedIndexes(graphP theGraph, int FillValue);
 
 extern int _IsolateKuratowskiSubgraph(graphP theGraph, int v, int R);

--- a/c/graphLib/planarityRelated/graphIsolator.c
+++ b/c/graphLib/planarityRelated/graphIsolator.c
@@ -12,7 +12,7 @@ See the LICENSE.TXT file for licensing information.
 
 /* Imported functions */
 
-extern void _ClearAllVisitedFlagsInGraph(graphP);
+extern void _ClearAllVisitedFlagsInGraph(graphP theGraph);
 
 extern int _GetNeighborOnExtFace(graphP theGraph, int curVertex, int *pPrevLink);
 extern int _JoinBicomps(graphP theGraph);

--- a/c/graphLib/planarityRelated/graphOuterplanarObstruction.c
+++ b/c/graphLib/planarityRelated/graphOuterplanarObstruction.c
@@ -9,7 +9,7 @@ See the LICENSE.TXT file for licensing information.
 
 /* Imported functions */
 
-extern void _ClearAllVisitedFlagsInGraph(graphP);
+extern void _ClearAllVisitedFlagsInGraph(graphP theGraph);
 
 extern int _JoinBicomps(graphP theGraph);
 

--- a/c/graphLib/planarityRelated/graphTests.c
+++ b/c/graphLib/planarityRelated/graphTests.c
@@ -13,7 +13,7 @@ See the LICENSE.TXT file for licensing information.
 #include "graphPlanarity.h"
 #include "graphPlanarity.private.h"
 
-extern void _ClearVertexVisitedFlags(graphP theGraph, int);
+extern void _ClearVertexVisitedFlags(graphP theGraph, int includeVirtualVertices);
 
 /* Private function declarations (some exported to system) */
 


### PR DESCRIPTION
## Summary

Closes #188.

Add names to all 25 graph function-table callback signatures and to the 14 remaining unnamed parameters in C forward declarations. The follow-up covers the six source files identified in review; a repository-wide audit found and corrected the same pattern in six additional source files.

This remains a names-only change: parameter types, order, return types, and behavior are unchanged.

## Validation

- Checked each callback signature and forward declaration against its corresponding implementation.
- Audited tracked C headers and source forward declarations for remaining unnamed parameters.
- `make -j2 check` — passed; all sample tests succeeded.
- `./configure --enable-compile-warnings CC=clang CFLAGS=-Werror && make -j2` — passed with the full project warning set.
- `make -j2 check` under the strict warning configuration — passed.
- Header syntax checks with C11 and C++17, using `-Wall -Wextra -Werror -pedantic` — passed.
- `git diff --check` — passed.