### PR TITLE
Align AX_APPEND_COMPILE_FLAGS with the tasks.json warning set

### DIFF
--- a/m4/ax_compiler_flags_cflags.m4
+++ b/m4/ax_compiler_flags_cflags.m4
@@ -86,6 +86,21 @@ AC_DEFUN([AX_COMPILER_FLAGS_CFLAGS],[
         fi
 
         # "yes" flags
+        #
+        # This list is kept in step with the compiler flags in
+        # devEnvSetupAndDefaults/.vscode/tasks.json. Compiler-specific spellings
+        # are safe to list together because AX_APPEND_COMPILE_FLAGS probes each
+        # flag and drops the ones the active compiler does not accept, e.g.
+        # -Wdiscarded-qualifiers is gcc and
+        # -Wincompatible-pointer-types-discards-qualifiers is its clang analogue.
+        #
+        # Deliberately not mirrored from tasks.json:
+        #   -Wno-deprecated-declarations  a suppression, not a warning; the
+        #     editor tasks quiet it for local builds, and adding it here would
+        #     weaken the gate that compile-warnings.yml exists to enforce.
+        #   -fsanitize=address, -fdiagnostics-color, -fcolor-diagnostics,
+        #     -fansi-escape-codes  not warning flags; sanitisers have their own
+        #     workflow and colour is an editor concern.
         AX_APPEND_COMPILE_FLAGS([ dnl
             -Wall dnl
             -Wextra dnl
@@ -121,6 +136,11 @@ AC_DEFUN([AX_COMPILER_FLAGS_CFLAGS],[
             -Wrestrict dnl
             -Wnull-dereference dnl
             -Wdouble-promotion dnl
+            -Wunused-result dnl
+            -Wignored-qualifiers dnl
+            -Wdiscarded-qualifiers dnl
+            -Wdeprecated-non-prototype dnl
+            -Wincompatible-pointer-types-discards-qualifiers dnl
             $4 dnl
             $5 dnl
             $6 dnl


### PR DESCRIPTION
Part of #310 (second item in the warnings group).

## Type of change

- Build system change (non-breaking; no library or application code touched)

## Changes

### Updated

* `m4/ax_compiler_flags_cflags.m4` adds the five warning flags that the VS Code tasks enable and the Autotools set omitted: `-Wunused-result`, `-Wignored-qualifiers`, `-Wdiscarded-qualifiers`, `-Wdeprecated-non-prototype` and `-Wincompatible-pointer-types-discards-qualifiers`. The gcc-only and clang-only spellings sit in the same list because `AX_APPEND_COMPILE_FLAGS` probes every flag and drops what the active compiler rejects; the probe result is in the testing section below.
* The same file records why the remaining `tasks.json` entries are deliberately not mirrored, per the first bullet of #310: `-Wno-deprecated-declarations` is a suppression rather than a warning and would weaken the gate `compile-warnings.yml` exists to enforce, and `-fsanitize=address`, `-fdiagnostics-color=always`, `-fcolor-diagnostics` and `-fansi-escape-codes` are not warning flags.

After this the two lists differ only by those documented entries. This is the follow-up #307 set aside as separable.

## Testing

Each configuration is a clean `make distclean && autoreconf -if && ./configure --enable-compile-warnings CC=<cc> CFLAGS=-Werror && make -j4`.

- Apple clang 21, macOS arm64: build clean, `make check` 1/1 pass.
- gcc 14 and clang 18 on Ubuntu 24.04 x86_64, matching the `compile-warnings.yml` matrix: both build clean, `./test-samples.sh` OK in both.
- Control on unpatched `master` in the same containers, so a clean result is attributable to the change rather than to the environment.

Two failures the added flags did **not** cause, both checked against unpatched `master` in the same container before attributing them:

- `-O2 -Werror` fails on `chdir` return values at `c/planarityApp/planarityCommandLine.c:218` and `:263`. Unpatched `master` fails identically. That is #316.
- `-funsigned-char -Werror` fails at `c/graphLib/io/graphIO.c:560`. Unpatched `master` fails identically. Filed separately.

<details><summary>Probed flag sets</summary>

```text
gcc-14   : -Wunused-result -Wignored-qualifiers -Wdiscarded-qualifiers
clang-18 : -Wunused-result -Wignored-qualifiers -Wdeprecated-non-prototype -Wincompatible-pointer-types-discards-qualifiers
```

</details>
