### PR TITLE
Return int from sf_getc and sf_ungetc so EOF survives unsigned char

### DIFF
--- a/c/graphLib/io/g6-read-iterator.c
+++ b/c/graphLib/io/g6-read-iterator.c
@@ -249,7 +249,7 @@ int _g6_InitReaderWithStrOrFile(G6ReadIteratorP theG6ReadIterator, strOrFileP *p
 
 int _g6_InitReader(G6ReadIteratorP theG6ReadIterator)
 {
-    char charConfirmation = EOF;
+    int charConfirmation = EOF;
     int firstChar = '\0';
     int lineNum = 1;
     int order = NIL;
@@ -262,7 +262,7 @@ int _g6_InitReader(G6ReadIteratorP theG6ReadIterator)
     }
     else
     {
-        charConfirmation = sf_ungetc((char)firstChar, inputContainer);
+        charConfirmation = sf_ungetc(firstChar, inputContainer);
 
         if (charConfirmation != firstChar)
         {
@@ -283,7 +283,7 @@ int _g6_InitReader(G6ReadIteratorP theG6ReadIterator)
     }
 
     firstChar = sf_getc(inputContainer);
-    charConfirmation = sf_ungetc((char)firstChar, inputContainer);
+    charConfirmation = sf_ungetc(firstChar, inputContainer);
 
     if (charConfirmation != firstChar)
     {
@@ -430,7 +430,7 @@ int _g6_DetermineOrderFromInput(strOrFileP inputContainer, int *order)
             return NOTOK;
         }
 
-        sf_ungetc((char)graphChar, inputContainer);
+        sf_ungetc(graphChar, inputContainer);
 
         for (int i = 2; i >= 0; i--)
         {

--- a/c/graphLib/io/graphIO.c
+++ b/c/graphLib/io/graphIO.c
@@ -556,7 +556,7 @@ int _ReadGraph(graphP theGraph, strOrFileP *pInputContainer)
     // was OK.
     if (extraDataAllowed)
     {
-        char charAfterGraphRead = EOF;
+        int charAfterGraphRead = EOF;
         if ((charAfterGraphRead = sf_getc((*pInputContainer))) != EOF)
         {
             if (sf_ungetc(charAfterGraphRead, (*pInputContainer)) != charAfterGraphRead)

--- a/c/graphLib/io/strOrFile.c
+++ b/c/graphLib/io/strOrFile.c
@@ -279,11 +279,17 @@ int sf_IsValidStrOrFile(strOrFileP theStrOrFile)
  If the ungetBuf is empty, then we'll read from pFile using getc() OR
  from theStrBuf by fetching the character at theStrPos and incrementing
  theStrPos.
+
+ Like getc() in stdio, returns the character as an unsigned char
+ converted to int, or EOF. The int return type is what keeps EOF
+ distinguishable from the byte 0xFF on builds where plain char is
+ unsigned, e.g. the Linux ABIs for AArch64, ARM, PowerPC and s390x,
+ where (char)EOF == 255 (issue #319).
  ********************************************************************/
 
-char sf_getc(strOrFileP theStrOrFile)
+int sf_getc(strOrFileP theStrOrFile)
 {
-    char theChar = EOF;
+    int theChar = EOF;
 
     if (!sf_IsValidStrOrFile(theStrOrFile) ||
         theStrOrFile->containerType != INPUT_CONTAINER)
@@ -302,14 +308,16 @@ char sf_getc(strOrFileP theStrOrFile)
         // so we cut to the underlying debug method to stop its warnings
         sp__Pop(theStrOrFile->ungetBuf, &(currChar));
 #endif
-        theChar = (char)currChar;
+        theChar = currChar;
     }
     else if (theStrOrFile->pFile != NULL)
-        theChar = (char)getc(theStrOrFile->pFile);
+        theChar = getc(theStrOrFile->pFile);
     else if (theStrOrFile->theStrBuf != NULL && sb_GetUnreadCharCount(theStrOrFile->theStrBuf) > 0)
     {
+        // N.B. Convert through unsigned char so that a literal 0xFF byte in
+        // the string buffer does not sign-extend to EOF on signed-char platforms
         theChar = sb_GetReadString(theStrOrFile->theStrBuf) != NULL
-                      ? sb_GetReadString(theStrOrFile->theStrBuf)[0]
+                      ? (unsigned char)sb_GetReadString(theStrOrFile->theStrBuf)[0]
                       : EOF;
         if (theChar != EOF)
             sb_ReadSkipChar(theStrOrFile->theStrBuf);
@@ -345,7 +353,7 @@ int sf_ReadSkipChar(strOrFileP theStrOrFile)
 
 int sf_ReadSkipWhitespace(strOrFileP theStrOrFile)
 {
-    char currChar = EOF;
+    int currChar = EOF;
 
     if (!sf_IsValidStrOrFile(theStrOrFile) ||
         theStrOrFile->containerType != INPUT_CONTAINER)
@@ -405,7 +413,7 @@ int sf_ReadInteger(int *intToRead, strOrFileP theStrOrFile)
     int exitCode = OK;
 
     int intCandidate = 0, intCandidateIndex = 0;
-    char currChar = '\0', nextChar = '\0';
+    int currChar = '\0', nextChar = '\0';
     int startedReadingInt = FALSE, isNegative = FALSE;
     char intCandidateStr[MAXCHARSFOR32BITINT + 1];
     memset(intCandidateStr, '\0', (MAXCHARSFOR32BITINT + 1) * sizeof(char));
@@ -552,17 +560,23 @@ int sf_ReadSkipLineRemainder(strOrFileP theStrOrFile)
  where it contains a strBufP, we unget to the ungetBuf; this ungetBuf
  is consumed first when we sf_getc(), sf_fgets(), etc.
 
- Like ungetc() in stdio, on success theChar is returned. On failure,
- EOF is returned.
+ Like ungetc() in stdio, on success the pushed byte is returned as
+ (unsigned char)theChar converted to int. On failure, EOF is
+ returned. Takes and returns int for the same reason as sf_getc():
+ EOF must stay distinguishable from the byte 0xFF.
  ********************************************************************/
 
-char sf_ungetc(char theChar, strOrFileP theStrOrFile)
+int sf_ungetc(int theChar, strOrFileP theStrOrFile)
 {
     if (theChar == EOF ||
         !sf_IsValidStrOrFile(theStrOrFile) ||
         theStrOrFile->containerType != INPUT_CONTAINER ||
         sp_GetCurrentSize(theStrOrFile->ungetBuf) >= sp_GetCapacity(theStrOrFile->ungetBuf))
-        return EOF; // Acceptable downcast, allowing char rather than int return type
+        return EOF;
+
+    // N.B. Store the byte value as an unsigned char would deliver it, so a
+    // pushed-back byte reads back from sf_getc() exactly as it was read
+    theChar = (unsigned char)theChar;
 
 #ifndef DEBUG
     sp_Push(theStrOrFile->ungetBuf, theChar);
@@ -593,7 +607,9 @@ int sf_ungets(char *strToUnget, strOrFileP theStrOrFile)
         return NOTOK;
 
     for (int i = (strlen(strToUnget) - 1); i >= 0; i--)
-        sp_Push(theStrOrFile->ungetBuf, strToUnget[i]);
+        // N.B. Convert through unsigned char so a 0xFF byte does not enter the
+        // unget buffer as EOF on signed-char platforms
+        sp_Push(theStrOrFile->ungetBuf, (unsigned char)strToUnget[i]);
 
     return OK;
 }
@@ -630,7 +646,7 @@ char *sf_fgets(char *str, int count, strOrFileP theStrOrFile)
         int numCharsInUngetBuf = sp_GetCurrentSize(theStrOrFile->ungetBuf);
         if (numCharsInUngetBuf > 0)
         {
-            char currChar = '\0';
+            int currChar = '\0';
             int encounteredNewline = FALSE;
 
             charsToReadFromUngetBuf = (count > numCharsInUngetBuf) ? numCharsInUngetBuf : count;
@@ -639,7 +655,7 @@ char *sf_fgets(char *str, int count, strOrFileP theStrOrFile)
                 currChar = sf_getc(theStrOrFile);
                 if (currChar == EOF)
                     return NULL;
-                str[i] = currChar;
+                str[i] = (char)currChar;
                 str[i + 1] = '\0';
                 // N.B. fgets() includes the \n in the string returned, and
                 // no further characters shall be read

--- a/c/graphLib/io/strOrFile.h
+++ b/c/graphLib/io/strOrFile.h
@@ -39,7 +39,7 @@ extern "C"
 
     int sf_IsValidStrOrFile(strOrFileP theStrOrFile);
 
-    char sf_getc(strOrFileP theStrOrFile);
+    int sf_getc(strOrFileP theStrOrFile);
     int sf_ReadSkipChar(strOrFileP theStrOrFile);
     int sf_ReadSkipWhitespace(strOrFileP theStrOrFile);
     int sf_ReadSingleDigit(int *digitToRead, strOrFileP theStrOrFile);
@@ -47,7 +47,7 @@ extern "C"
     int sf_ReadSkipInteger(strOrFileP theStrOrFile);
     int sf_ReadSkipLineRemainder(strOrFileP theStrOrFile);
 
-    char sf_ungetc(char theChar, strOrFileP theStrOrFile);
+    int sf_ungetc(int theChar, strOrFileP theStrOrFile);
     int sf_ungets(char *contentsToUnget, strOrFileP theStrOrFile);
 
     char *sf_fgets(char *str, int count, strOrFileP theStrOrFile);

--- a/c/planarityApp/planarityCommandLine.c
+++ b/c/planarityApp/planarityCommandLine.c
@@ -5,6 +5,7 @@ See the LICENSE.TXT file for licensing information.
 */
 
 #include "planarity.h"
+#include "../graphLib/io/strOrFile.h"
 
 #if defined(_MSC_VER) && !defined(__llvm__) && !defined(__INTEL_COMPILER)
 // MSVC under Windows doesn't have unistd.h, but does define functions like getcwd and chdir
@@ -39,6 +40,8 @@ int runIdentifyContractTest(graphP theGraph);
 int runDigraphTests(void);
 int runGraphMLTests(void);
 int runDrawPlanarNonplanarWriteTest(void);
+int runReadWithExtensionAtEofTest(void);
+int runHighByteRoundTripTest(void);
 int testDirectedDFS(void);
 int testPetersenDigraph(void);
 int testDigraphTranspose(void);
@@ -252,6 +255,10 @@ int runQuickRegressionTests(int argc, char *argv[])
     else if (runDigraphTests() != OK)
         retVal = NOTOK;
     else if (runGraphMLTests() != OK)
+        retVal = NOTOK;
+    else if (runReadWithExtensionAtEofTest() != OK)
+        retVal = NOTOK;
+    else if (runHighByteRoundTripTest() != OK)
         retVal = NOTOK;
 
     // All done.
@@ -555,6 +562,100 @@ int runDrawPlanarNonplanarWriteTest(void)
     gp_Free(&theGraph);
 
     return Result == NONEMBEDDABLE ? OK : Result;
+}
+
+/********************************************************************
+ runReadWithExtensionAtEofTest()
+
+ Reads a graph with an extension attached before gp_Read(), which
+ exercises the end-of-input handling in _ReadGraph(): the extra-data
+ check must see a true EOF rather than a fabricated byte.
+
+ Before the sf_getc()/sf_ungetc() int conversion (issue #319), on
+ platforms where plain char is unsigned, (char)EOF == 255, so this
+ read handed a spurious 0xFF extra-data byte to the extension's
+ post-processor and failed on a valid input file.
+ ********************************************************************/
+
+int runReadWithExtensionAtEofTest(void)
+{
+    int Result = OK;
+    graphP theGraph = NULL;
+
+    gp_Message("Reading a graph with an extension attached, to exercise "
+               "the end-of-input path (issue #319).");
+
+    if ((theGraph = gp_New()) == NULL)
+        Result = NOTOK;
+
+    if (Result == OK && gp_ExtendWith_DrawPlanar(theGraph) != OK)
+        Result = NOTOK;
+
+    if (Result == OK && gp_Read(theGraph, "maxPlanar5.txt") != OK)
+        Result = NOTOK;
+
+    if (Result == OK)
+        gp_Message("Test succeeded.\n");
+
+    gp_Free(&theGraph);
+
+    return Result;
+}
+
+/********************************************************************
+ runHighByteRoundTripTest()
+
+ Reads the byte 0xFF from a string container directly and through the
+ unget buffer, and confirms it is never mistaken for EOF.
+
+ Before the sf_getc()/sf_ungetc() int conversion (issue #319), on
+ platforms where plain char is signed, a literal 0xFF byte fetched
+ from the string container sign-extended to EOF, and the same
+ happened to bytes round-tripped through the unget buffer.
+ ********************************************************************/
+
+int runHighByteRoundTripTest(void)
+{
+    int Result = OK;
+    int currChar = EOF;
+    char const highByteStr[] = {'a', (char)0xFF, 'b', '\0'};
+    strOrFileP inputContainer = NULL;
+
+    gp_Message("Reading a 0xFF byte directly and through the unget buffer "
+               "(issue #319).");
+
+    if ((inputContainer = sf_NewInputContainer(highByteStr, NULL)) == NULL)
+        Result = NOTOK;
+
+    if (Result == OK && sf_getc(inputContainer) != 'a')
+        Result = NOTOK;
+
+    if (Result == OK)
+    {
+        currChar = sf_getc(inputContainer);
+        if (currChar != 0xFF)
+            Result = NOTOK;
+    }
+
+    if (Result == OK && sf_ungetc(currChar, inputContainer) != 0xFF)
+        Result = NOTOK;
+
+    if (Result == OK && sf_getc(inputContainer) != 0xFF)
+        Result = NOTOK;
+
+    if (Result == OK && sf_getc(inputContainer) != 'b')
+        Result = NOTOK;
+
+    if (Result == OK && sf_getc(inputContainer) != EOF)
+        Result = NOTOK;
+
+    if (Result == OK)
+        gp_Message("Test succeeded.\n");
+
+    if (inputContainer != NULL)
+        sf_Free(&inputContainer);
+
+    return Result;
 }
 
 int runGraphTransformationTests(void)

--- a/c/planarityApp/planarityCommandLine.c
+++ b/c/planarityApp/planarityCommandLine.c
@@ -256,11 +256,11 @@ int runQuickRegressionTests(int argc, char *argv[])
         retVal = NOTOK;
     else if (runDigraphTests() != OK)
         retVal = NOTOK;
-    else if (runGraphMLTests() != OK)
-        retVal = NOTOK;
     else if (runReadWithExtensionAtEofTest() != OK)
         retVal = NOTOK;
     else if (runHighByteRoundTripTest() != OK)
+        retVal = NOTOK;
+    else if (runGraphMLTests() != OK)
         retVal = NOTOK;
 
     // All done.
@@ -594,8 +594,7 @@ int runReadWithExtensionAtEofTest(void)
     int Result = OK;
     graphP theGraph = NULL;
 
-    gp_Message("Reading a graph with an extension attached, to exercise "
-               "the end-of-input path (issue #319).");
+    gp_Message("Test EOF Handling (for platforms that have char unsigned).");
 
     if ((theGraph = gp_New()) == NULL)
         Result = NOTOK;
@@ -633,8 +632,7 @@ int runHighByteRoundTripTest(void)
     char const highByteStr[] = {'a', (char)0xFF, 'b', '\0'};
     strOrFileP inputContainer = NULL;
 
-    gp_Message("Reading a 0xFF byte directly and through the unget buffer "
-               "(issue #319).");
+    gp_Message("Test Support of 0xFF Byte.");
 
     if ((inputContainer = sf_NewInputContainer(highByteStr, NULL)) == NULL)
         Result = NOTOK;


### PR DESCRIPTION
Fixes #319. Follows the plan agreed there: full int conversion rather than the `(char)EOF` casts.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Changes

### Updated

* `c/graphLib/io/strOrFile.h`, `strOrFile.c`: `sf_getc()` and `sf_ungetc()` now take and return `int`, following the stdio `getc()`/`ungetc()` contract, so EOF stays distinguishable from the byte 0xFF on builds where plain `char` is unsigned (the Linux ABIs for AArch64, ARM, PowerPC, s390x). All EOF-sensitive temporaries in `strOrFile.c` are `int` now.
* The conversion also closes the same defect in the opposite direction: a literal 0xFF byte from the string container sign-extended to EOF on signed-char builds, and bytes round-tripped through the unget buffer did the same. Both paths now normalize through `unsigned char`.
* `c/graphLib/io/g6-read-iterator.c`, `graphIO.c`: callers updated; the `(char)` casts at `sf_ungetc()` call sites are gone.
* `c/planarityApp/planarityCommandLine.c`: two quick-regression tests. `runReadWithExtensionAtEofTest()` reads a valid adjacency-list file with DrawPlanar attached, which is the #319 reproducer. `runHighByteRoundTripTest()` feeds the byte 0xFF through the string container and the unget buffer directly; this one bites on today's signed-char CI, not only on unsigned-char builds.

## Testing

- Positive control for both tests: `master`'s `graphLib` built against this branch's tests fails the suite (exit 255, the 0xFF round-trip test) on plain x86-64, and fails the extension-at-EOF test under `-funsigned-char`; with the patched `graphLib` the full suite passes 23/23 in both configurations.
- The #319 reproducer flips from `NOTOK` to `OK` on native linux/arm64 (Ubuntu 24.04 container) and on x86-64 with `-funsigned-char`; both checked against unpatched `master` in the same containers.
- CI-faithful matrix: gcc-14 and clang-18, `--enable-compile-warnings CFLAGS=-Werror`, Ubuntu 24.04: both build clean. Apple clang 21 on macOS arm64: build clean, `make check` and `test-samples.sh` pass.

The `--enable-unsigned-char` configure switch discussed in #319 is left for the CI follow-up, so this MR stays the mechanical type conversion plus its tests.
