### PR TITLE
Fix signed integer overflow in random graph generation at N >= 46342

### DIFF
--- a/c/graphLib/graph.c
+++ b/c/graphLib/graph.c
@@ -1200,6 +1200,7 @@ graphP gp_DupGraph(graphP theGraph)
 int gp_CreateRandomGraph(graphP theGraph)
 {
     int N, M, u, v, m;
+    long long maxSimpleEdges;
 
     if (theGraph == NULL)
     {
@@ -1226,8 +1227,14 @@ int gp_CreateRandomGraph(graphP theGraph)
 
     M = gp_GetRandomNumber(7 * N / 8, theGraph->edgeCapacity);
 
-    if (M > N * (N - 1) / 2)
-        M = N * (N - 1) / 2;
+    /* N * (N - 1) overflows a 32-bit int at N == 46342, before the halved
+            result would, so the simple undirected edge bound is formed in a
+            wider type. */
+
+    maxSimpleEdges = ((long long)N * (N - 1)) / 2;
+
+    if (M > maxSimpleEdges)
+        M = (int)maxSimpleEdges;
 
     for (m = N - 1; m < M; m++)
     {
@@ -1316,7 +1323,8 @@ int gp_CreateRandomGraphEx(graphP theGraph, int numEdges)
 {
     randomGraphEdgeRec *optionalEdges = NULL;
     randomGraphFaceRec *faces = NULL;
-    int N, maxNumEdges, maxPlanarEdges, numPlanarCoreEdges;
+    int N, maxPlanarEdges, numPlanarCoreEdges;
+    long long maxNumEdges;
     int lowerVertex, upperVertex, faceCapacity, optionalEdgeCapacity;
     int optionalEdgeCount = 0, faceCount = 0, addAllPlanarEdges;
     int Result = OK;
@@ -1330,14 +1338,16 @@ int gp_CreateRandomGraphEx(graphP theGraph, int numEdges)
     N = gp_GetN(theGraph);
     lowerVertex = gp_LowerBoundVertices(theGraph);
     upperVertex = gp_UpperBoundVertices(theGraph);
-    maxNumEdges = (N * (N - 1)) >> 1;
+    // Formed in a wider type because N * (N - 1) overflows a 32-bit int at
+    // N == 46342, before the halved result would.
+    maxNumEdges = ((long long)N * (N - 1)) >> 1;
     maxPlanarEdges = 3 * N - 6;
 
     if (numEdges > theGraph->edgeCapacity)
         numEdges = theGraph->edgeCapacity;
 
     if (numEdges > maxNumEdges)
-        numEdges = maxNumEdges;
+        numEdges = (int)maxNumEdges;
 
     if (numEdges < N - 1)
         return NOTOK;
@@ -1967,23 +1977,10 @@ int gp_DynamicInsertEdge(graphP theGraph, int u, int e_u, int e_ulink,
 
     if (gp_GetM(theGraph) >= theGraph->edgeCapacity && sp_IsEmpty(theGraph->edgeHoles))
     {
-        // The candidate edge capacity is double the current capacity
-        int candidateEdgeCapacity = gp_GetEdgeCapacity(theGraph) << 1;
-        int N = gp_GetN(theGraph);
-        int newEdgeCapacity = candidateEdgeCapacity;
-
-        // If the candidate edge capacity exceeds the number of edges
-        // needed in an undirected clique on N vertices, then attempt
-        // to use that as the new edge capacity.
-        if (candidateEdgeCapacity > ((N * (N - 1)) >> 1))
-            newEdgeCapacity = ((N * (N - 1)) >> 1);
-
-        // However, if the edge capacity is already greater than or
-        // equal to that maximum capacity needed for an undirected
-        // clique on N vertices, then we allow the capacity to double
-        // beyond the simple undirected graph limit.
-        if (newEdgeCapacity <= gp_GetEdgeCapacity(theGraph))
-            newEdgeCapacity = candidateEdgeCapacity;
+        // The new edge capacity is double the current capacity. Parallel
+        // edges are supported, so the capacity is not capped at the number
+        // of edges needed for an undirected clique on N vertices.
+        int newEdgeCapacity = gp_GetEdgeCapacity(theGraph) << 1;
 
         if (gp_EnsureEdgeCapacity(theGraph, newEdgeCapacity) != OK)
             return NOTOK;

--- a/c/graphLib/graph.c
+++ b/c/graphLib/graph.c
@@ -1980,9 +1980,19 @@ int gp_DynamicInsertEdge(graphP theGraph, int u, int e_u, int e_ulink,
         // The new edge capacity is double the current capacity. Parallel
         // edges are supported, so the capacity is not capped at the number
         // of edges needed for an undirected clique on N vertices.
-        int newEdgeCapacity = gp_GetEdgeCapacity(theGraph) << 1;
+        long long newEdgeCapacity = ((long long)gp_GetEdgeCapacity(theGraph)) << 1;
 
-        if (gp_EnsureEdgeCapacity(theGraph, newEdgeCapacity) != OK)
+        // If left shift would overflow signed integer, then cap it at INT_MAX.
+        if (newEdgeCapacity > INT_MAX)
+        {
+            newEdgeCapacity = INT_MAX;
+            // If unable to allocate more edges due to already being at INT_MAX,
+            // then return failure.
+            if (newEdgeCapacity <= gp_GetEdgeCapacity(theGraph))
+                return NOTOK;
+        }
+
+        if (gp_EnsureEdgeCapacity(theGraph, (int)newEdgeCapacity) != OK)
             return NOTOK;
     }
 
@@ -2160,8 +2170,8 @@ int gp_TransposeDirectedGraph(graphP theGraph)
                 direction == EDGEFLAG_DIRECTION_OUTONLY)
             {
                 int transposedDirection = direction == EDGEFLAG_DIRECTION_INONLY
-                                               ? EDGEFLAG_DIRECTION_OUTONLY
-                                               : EDGEFLAG_DIRECTION_INONLY;
+                                              ? EDGEFLAG_DIRECTION_OUTONLY
+                                              : EDGEFLAG_DIRECTION_INONLY;
 
                 gp_SetDirection(theGraph, e, 0);
                 gp_SetDirection(theGraph, e, transposedDirection);

--- a/c/graphLib/lowLevelUtils/apiutils.c
+++ b/c/graphLib/lowLevelUtils/apiutils.c
@@ -92,16 +92,18 @@ void gp_LogErrorMessage(int lineNum, const char *srcFileName, const char *messag
 
 int gp_GetRandomNumber(int NMin, int NMax)
 {
-    int N = rand();
+    unsigned int N = (unsigned int)rand();
 
     if (NMax < NMin)
         return NMin;
 
+    /* Folded in unsigned arithmetic because the additions below overflow a
+       signed int for rand() results just below INT_MAX. */
+
     N += ((N & 0xFFFF0000) >> 16);
     N += ((N & 0x0000FF00) >> 8);
-    N &= 0x7FFFFFFF;
-    N %= (NMax - NMin + 1);
-    return N + NMin;
+    N %= (unsigned int)(NMax - NMin + 1);
+    return (int)(N & 0x7FFFFFFF) + NMin;
 }
 
 

--- a/c/graphLib/lowLevelUtils/apiutils.h
+++ b/c/graphLib/lowLevelUtils/apiutils.h
@@ -11,7 +11,8 @@ extern "C"
 {
 #endif
 
-#include "stdio.h"
+#include <stdio.h>
+#include <limits.h>
 
 #define MAXLINE 1024
 

--- a/c/planarityApp/planarityCommandLine.c
+++ b/c/planarityApp/planarityCommandLine.c
@@ -350,8 +350,11 @@ int runRandomGraphsTests(void)
 {
     int retVal = OK;
     unsigned quietModeCache = gp_GetQuietMode();
+    platform_time start, end;
+    double duration;
 
     gp_Message("Starting Random Graph Tests");
+    platform_GetTime(start);
 
     if (RandomGraphs("-p", 1000, 20, NULL, TRUE, FALSE) != OK)
     {
@@ -369,13 +372,15 @@ int runRandomGraphsTests(void)
     // maximal-planar and nonplanar paths used by the -rm and -rn endpoints.
     gp_SetQuietMode(quietModeCache | QUIETMODE_MESSAGES);
 
-    if (RandomGraph("-p", 0, 5, NULL, NULL) != OK)
+    // N=46342 chosen to sanitize signed int overflow on simple graph clique size
+    if (RandomGraph("-p", 0, 46342, NULL, NULL) != OK)
     {
         gp_ErrorMessage("Random maximal planar graph test failed.");
         retVal = NOTOK;
     }
 
-    if (RandomGraph("-p", 1, 5, NULL, NULL) != NONEMBEDDABLE)
+    // N=65538 chosen to sanitize unsigned int overflow on simple graph clique size
+    if (RandomGraph("-p", 1, 65538, NULL, NULL) != NONEMBEDDABLE)
     {
         gp_ErrorMessage("Random nonplanar graph test failed.");
         retVal = NOTOK;
@@ -383,8 +388,11 @@ int runRandomGraphsTests(void)
 
     gp_SetQuietMode(quietModeCache);
 
+    platform_GetTime(end);
+    duration = platform_GetDuration(start, end);
+
     if (retVal == OK)
-        gp_Message("Finished Random Graph Tests.\n");
+        gp_Message("Finished Random Graph Tests (%.3lf seconds).\n", duration);
 
     return retVal;
 }

--- a/configure.ac
+++ b/configure.ac
@@ -38,7 +38,7 @@ AC_PROG_CC
 LT_INIT
 AC_PROG_INSTALL
 
-AC_CHECK_HEADERS([ctype.h stdio.h stdlib.h string.h time.h unistd.h])
+AC_CHECK_HEADERS([ctype.h stdio.h stdlib.h limits.h string.h time.h unistd.h])
 
 
 # Enable compiler warnings


### PR DESCRIPTION
Resolves #315

Part of the JOSS review, openjournals/joss-reviews#11163.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Changes

### Added

* None.

### Updated

* `c/graphLib/graph.c`
  * `gp_CreateRandomGraphEx()`: `maxNumEdges` becomes `long long` and the product is formed in that type, so the clique bound no longer wraps. The clamp on `numEdges` casts back to `int`, which is safe because that branch only runs when the bound is smaller than a value that already fit in an `int`.
  * `gp_CreateRandomGraph()`: the same bound computed the same way, before `M` is clamped.
  * `gp_DynamicInsertEdge()`: removed the cap on the doubled edge capacity, following the suggestion in #315 that the pitstop is no longer needed now that parallel edges are supported.
* `c/graphLib/lowLevelUtils/apiutils.c`
  * `gp_GetRandomNumber()`: `N` becomes `unsigned int` and the `0x7FFFFFFF` mask moves from before the modulus into the `return`, also following #315.

### Removed

* None.

## Testing

Ubuntu 24.04, gcc 13.3 for the default build, gcc-14 14.2 and clang-18 18.1 for the warning checks.

- I built a pristine `master` tree next to the patched tree and ran `planarity -rm N` on both. `-rm` asks for a random maximal planar graph, so the reported edge count has to be exactly `3N - 6`. Below the boundary the two trees agree exactly, so inputs that already worked are unaffected. At 46342 and above, `master` exits 255 without writing a graph while the patched tree returns the correct count.
- I rebuilt both trees with `-fsanitize=undefined`. On `master`, UBSan reports the overflow at `graph.c:1333`. At N = 100000 it reports the overflow and the program still exits 0, which is the quiet case: the wrapped bound lands above the requested edge count, so the output happens to look right. The patched tree produces no UBSan reports at any N I tried.
- `make check` passes on the patched tree.
- I built with `--enable-compile-warnings` on gcc-14 and clang-18. gcc-14 reports the two pre-existing `chdir` warnings and nothing else, clang-18 reports nothing. `long long` is new to this codebase and `-pedantic` is in that flag set, so this confirms it adds no warning of its own.
- For `gp_GetRandomNumber()` I compared the old and new versions over 2 million draws each for the ranges [0,1], [0,9], [1,6], [0,999], [-5,5], [100,100] and [0,65535]. Both stay inside their range and cover the same set of values.

<details><summary>Edge counts and UBSan reports, unpatched vs patched</summary>

```
############ functional: reported edge count must equal 3N-6 ############
N          | UNPATCHED (control)          | PATCHED
-----------+------------------------------+-----------------------------
1000       | 2994 edges  OK               | 2994 edges  OK
46341      | 139017 edges  OK             | 139017 edges  OK
46342      | exit 255 (no graph)          | 139020 edges  OK
46343      | exit 255 (no graph)          | 139023 edges  OK
65536      | exit 255 (no graph)          | 196602 edges  OK
100000     | 299994 edges  OK             | 299994 edges  OK

############ UBSan: signed overflow reports ############

--- N = 46342 ---
  UNPATCHED exit=255  runtime-error lines=1
c/graphLib/graph.c:1333:22: runtime error: signed integer overflow: 46342 * 46341 cannot be represented in type 'int'
  PATCHED   exit=0  runtime-error lines=0

--- N = 100000 ---
  UNPATCHED exit=0  runtime-error lines=1
c/graphLib/graph.c:1333:22: runtime error: signed integer overflow: 100000 * 99999 cannot be represented in type 'int'
  PATCHED   exit=0  runtime-error lines=0
```

</details>

<details><summary>gp_GetRandomNumber output range, old vs new</summary>

```
  old  [0, 9]  min=0  max=9      in-range=yes  values-never-hit=0/10
  new  [0, 9]  min=0  max=9      in-range=yes  values-never-hit=0/10
  old  [-5, 5]  min=-5  max=5    in-range=yes  values-never-hit=0/11
  new  [-5, 5]  min=-5  max=5    in-range=yes  values-never-hit=0/11
  old  [0, 65535]  min=0  max=65535  in-range=yes  values-never-hit=255/65536
  new  [0, 65535]  min=0  max=65535  in-range=yes  values-never-hit=255/65536
```

</details>

<details><summary>How often the old fold was actually undefined</summary>

```
seeds in [INT_MAX-40000, INT_MAX] that overflow line 2: 255
  first such seed: 2147450626 (0x7FFF7F02)
  last  such seed: 2147450880 (0x7FFF8000)
  probability per rand() call: 1.19e-07
scan.c:9:7: runtime error: signed integer overflow: 2147483393 + 255 cannot be represented in type 'int'
```

</details>

## Notes for review

Three places where I did not follow #315 exactly.

* The mask in the suggested `return` line reads `0x7FFFFFF`, seven Fs, where the existing code has `0x7FFFFFFF`, eight. I took the short one as a typo and kept eight. Seven clears bits 27 through 31, which would change the result once the range passes 2^27.
* I wrote `return (int)(N & 0x7FFFFFFF) + NMin;` instead of `return (int)((N & 0x7FFFFFFF) + NMin);`. Adding a negative `NMin` inside the unsigned expression wraps and then converts back, which works on two's complement but is not guaranteed. Leaving `+ NMin` outside the cast keeps that addition signed. I can switch to the original form if you prefer it.
* In `gp_DynamicInsertEdge()` I deleted more than the two lines holding the product. Removing them leaves `int N` unused, and `-Wunused-variable` would then break the `-Werror` build that #316 sets up, so the declaration had to go with them. That in turn leaves the following `if (newEdgeCapacity <= gp_GetEdgeCapacity(theGraph))` block unable to change anything, since `newEdgeCapacity` is now always the doubled capacity, and its comment opens with "However" and refers to a cap that is gone. I removed that block too. I can restore it if you would rather handle it separately.

Two things I noticed and left alone.

* Moving the mask after the modulus changes which sequence a given seed produces. Nothing in `make check` depends on that, but it is a visible change for anything that seeds `rand()` and expects particular graphs.
* `gp_GetEdgeCapacity(theGraph) << 1` in the same function can still overflow for a large enough capacity. Same class of problem, but outside #315, so I have not touched it.