### PR TITLE
Let compile-warnings.yml fail on warnings that need -O2, and handle the two chdir returns

### DIFF
--- a/.github/workflows/compile-warnings.yml
+++ b/.github/workflows/compile-warnings.yml
@@ -17,7 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CC: ${{ matrix.compiler }}
-      CFLAGS: -Werror
     strategy:
       fail-fast: false
       matrix:
@@ -30,7 +29,11 @@ jobs:
         run: |
           mkdir -p m4
           autoreconf -if
-          ./configure --enable-compile-warnings CC="$CC" CFLAGS="$CFLAGS"
+          # We deliberately don't set CFLAGS: assigning it replaces autoconf's
+          # default -g -O2, and gcc only emits the fortified warn_unused_result
+          # warnings when optimising, so the job would have nothing to fail on.
+          # -Werror comes from --enable-compile-warnings=error instead.
+          ./configure --enable-compile-warnings=error CC="$CC"
       - name: Build . . .
         run: make -j4
         # We don't run the tests, since in this job we are only checking for

--- a/c/planarityApp/planarityCommandLine.c
+++ b/c/planarityApp/planarityCommandLine.c
@@ -215,7 +215,9 @@ int runQuickRegressionTests(int argc, char *argv[])
                 // Give success result, but Warn if no samples (except no warning if in quiet mode)
                 gp_Message("WARNING: Unable to change to samples directory to "
                            "run tests on samples.");
-                chdir(origDir);
+                if (chdir(origDir) != 0)
+                    gp_Message("WARNING: Unable to restore the original "
+                               "working directory.");
 
                 return OK;
             }
@@ -260,7 +262,9 @@ int runQuickRegressionTests(int argc, char *argv[])
     else
         gp_Message("============\n\nOne or more tests FAILED.");
 
-    chdir(origDir);
+    if (chdir(origDir) != 0)
+        gp_Message("WARNING: Unable to restore the original working directory.");
+
     FlushConsole(stdout);
 
     return retVal;

--- a/configure.ac
+++ b/configure.ac
@@ -44,14 +44,17 @@ AC_CHECK_HEADERS([ctype.h stdio.h stdlib.h string.h time.h unistd.h])
 # Enable compiler warnings
 
 AC_ARG_ENABLE([compile-warnings],
-    [AS_HELP_STRING([--enable-compile-warnings], [enable compiler warnings])],
-    [enable_compile_warnings=yes],
+    [AS_HELP_STRING([--enable-compile-warnings@<:@=no|yes|error@:>@],
+        [enable compiler warnings; "error" also makes them fatal])],
+    [AS_CASE([$enableval],
+        [no|yes|error], [enable_compile_warnings=$enableval],
+        [AC_MSG_ERROR([invalid value "$enableval" for --enable-compile-warnings; use no, yes or error])])],
     [enable_compile_warnings=no])
 AC_MSG_CHECKING([whether enable compiler warnings])
 AC_MSG_RESULT([$enable_compile_warnings])
 
 AS_IF([test "x$enable_compile_warnings" != "xno"],
-  [ax_enable_compile_warnings=yes
+  [ax_enable_compile_warnings=$enable_compile_warnings
    AX_COMPILER_FLAGS_CFLAGS([WARNING_CFLAGS], [], [ dnl
        -pedantic dnl])
    AC_SUBST([WARNING_CFLAGS])])


### PR DESCRIPTION
Resolves #316

Part of the JOSS review, openjournals/joss-reviews#11163.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Changes

### Added

* None.

### Updated

* `configure.ac`: `--enable-compile-warnings` now takes `no`, `yes` or `error` and passes the value through to `ax_enable_compile_warnings`. It was hardcoding `yes`, so the `error` branch already sitting in `m4/ax_compiler_flags_cflags.m4` could never run. A value other than those three now stops configure instead of being quietly read as `yes`.
* `.github/workflows/compile-warnings.yml`: configures with `--enable-compile-warnings=error` and no longer assigns `CFLAGS`. Assigning it replaced autoconf's default `-g -O2`, and gcc does not emit the fortified `warn_unused_result` warnings without optimisation, so the job had nothing to fail on. I added a comment recording why `CFLAGS` is left unset.
* `c/planarityApp/planarityCommandLine.c`: the two `chdir(origDir)` calls that restore the working directory now check the return value and warn if it fails. These are the warnings the job was hiding.

### Removed

* None.

## Testing

Ubuntu 24.04, with gcc-14 14.2 and clang-18 18.1 to match the workflow matrix.

- On current `master`, configured exactly as the workflow does, the build emits no warnings and passes. The `-Werror` from `CFLAGS` is on the command line, but assigning `CFLAGS` also dropped autoconf's default `-g -O2`, so gcc never emits the `chdir` warnings and `-Werror` has nothing to act on. That is the state #316 describes.
- With the `configure.ac` and workflow changes in place but the `chdir` calls untouched, the build fails on both of them. The gate now does what it was written to do.
- With all three changes, the same configuration builds clean and `make check` passes.
- A plain `--enable-compile-warnings` build still leaves `-Werror` out of `WARNING_CFLAGS` and still succeeds, so local warning builds behave as before.
- `--enable-compile-warnings=bogus` stops configure with a readable message, and `--disable-compile-warnings` still works.
- clang-18 builds clean under `=error` whether or not the `chdir` calls are handled, because it does not emit that warning at all. Only the gcc leg of the matrix catches this one.
- `./configure --help` renders the option as `--enable-compile-warnings[=no|yes|error]`.

<details><summary>Six configurations, before and after</summary>

```
########## gcc-14 ##########
  A. master as-is (CFLAGS=-Werror, no -O2)        -Werror=no  warnings=0  build PASSES
     expected: PASSES - this is the bug: warnings exist but cannot fail the job
  B. fixed gate, chdir NOT fixed                  -Werror=yes warnings=0  build FAILS
     expected: FAILS - the gate now has teeth
c/planarityApp/planarityCommandLine.c:218:17: error: ignoring return value of 'chdir' declared with attribute 'warn_unused_result' [-Werror=unused-result]
c/planarityApp/planarityCommandLine.c:263:5: error: ignoring return value of 'chdir' declared with attribute 'warn_unused_result' [-Werror=unused-result]
  C. fixed gate, chdir fixed                      -Werror=yes warnings=0  build PASSES
  D. plain --enable-compile-warnings, chdir fixed  -Werror=no  warnings=0  build PASSES

########## clang-18 ##########
  E. fixed gate, chdir fixed                      -Werror=yes warnings=0  build PASSES
  F. fixed gate, chdir NOT fixed                  -Werror=yes warnings=0  build PASSES
     expected: PASSES - clang does not emit the chdir warning at all

########## argument validation ##########
  bogus value rejected: invalid value "bogus" for --enable-compile-warnings; use no, yes or error
  --disable-compile-warnings still works

########## the fixed tree still passes its tests ##########
  make check exit: 0
PASS: test-samples.sh
```

</details>

## Notes for review

You suggested adding `-Werror` to the `AX_APPEND_COMPILE_FLAGS` list in `m4/ax_compiler_flags_cflags.m4`, and I went another way, so this part is worth a look before you decide.

That file already appends `-Werror` when `ax_enable_compile_warnings` is `error`, in the `AS_IF` near the end. `configure.ac` was setting the variable to `yes` unconditionally, which left the branch dead. Passing the value through revives it and needs no edit to the vendored macro. It also keeps a plain `--enable-compile-warnings` build non-fatal, which seems friendlier for local work. The macro's comment at that spot notes `-Werror` has to go in with `AX_APPEND_FLAG` rather than `AX_APPEND_COMPILE_FLAGS` because there is nothing to probe for, so putting it in the probed list would work against that reasoning. If you would still rather have it in the flag list, I can redo it that way.

One loose end: the dev setup wiki page might deserve a line about `=error`, but I did not want to assume. The change is backward compatible, so `--enable-compile-warnings` in any existing instructions keeps working unchanged.