### PR TITLE
Add --enable-unsigned-char and an unsigned-char CI leg

### DIFF
--- a/.github/workflows/compile-warnings.yml
+++ b/.github/workflows/compile-warnings.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   tests:
-    name: ${{ matrix.compiler }}
+    name: ${{ matrix.compiler }}${{ matrix.unsigned-char == 'yes' && ' (unsigned char)' || '' }}
     timeout-minutes: 60
     runs-on: ubuntu-latest
     env:
@@ -21,6 +21,13 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [clang-18, gcc-14]
+        unsigned-char: [no]
+        include:
+          # One leg emulates unsigned-plain-char ABIs (Linux AArch64, ARM,
+          # PowerPC, s390x) so char-signedness bugs like issue #319 surface
+          # on the x86-64 runner
+          - compiler: gcc-14
+            unsigned-char: yes
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Compiler information . . .
@@ -33,7 +40,9 @@ jobs:
           # default -g -O2, and gcc only emits the fortified warn_unused_result
           # warnings when optimising, so the job would have nothing to fail on.
           # -Werror comes from --enable-compile-warnings=error instead.
-          ./configure --enable-compile-warnings=error CC="$CC"
+          ./configure --enable-compile-warnings=error \
+            ${{ matrix.unsigned-char == 'yes' && '--enable-unsigned-char' || '' }} \
+            CC="$CC"
       - name: Build . . .
         run: make -j4
         # We don't run the tests, since in this job we are only checking for

--- a/configure.ac
+++ b/configure.ac
@@ -59,6 +59,23 @@ AS_IF([test "x$enable_compile_warnings" != "xno"],
        -pedantic dnl])
    AC_SUBST([WARNING_CFLAGS])])
 
+# Build with -funsigned-char so that CI can exercise unsigned-plain-char
+# behavior (e.g. the Linux ABIs for AArch64, ARM, PowerPC, s390x) on any
+# host. Off by default; no build is affected unless the switch is given.
+# See issue #319.
+
+AC_ARG_ENABLE([unsigned-char],
+    [AS_HELP_STRING([--enable-unsigned-char],
+        [build with -funsigned-char, to test unsigned-plain-char ABIs on any host])],
+    [enable_unsigned_char=yes],
+    [enable_unsigned_char=no])
+AC_MSG_CHECKING([whether to build with -funsigned-char])
+AC_MSG_RESULT([$enable_unsigned_char])
+
+AS_IF([test "x$enable_unsigned_char" = "xyes"],
+  [AX_APPEND_COMPILE_FLAGS([-funsigned-char], [WARNING_CFLAGS])
+   AC_SUBST([WARNING_CFLAGS])])
+
 AC_CONFIG_FILES([
   Makefile
   c/samples/Makefile


### PR DESCRIPTION
The CI follow-up agreed in #319, now that the int conversion (#320) is in.

## Type of change

- Build system / CI change (non-breaking; no library code touched)

## Changes

### Updated

* `configure.ac` gains `--enable-unsigned-char`, which appends `-funsigned-char` to `WARNING_CFLAGS` via `AX_APPEND_COMPILE_FLAGS`. Riding the existing `AM_CFLAGS = $(WARNING_CFLAGS)` plumbing means the workflow needs no `CFLAGS` assignment, so the autoconf default `-g -O2` stays intact, which was the concern raised in #319 after #322. Off by default: no build is affected unless the switch is given.
* `compile-warnings.yml` gains one matrix leg, gcc-14 with the switch, named `gcc-14 (unsigned char)`. Char-signedness regressions of the #319 class now surface on the x86-64 runner on every pull request.

## Testing

- With the switch: `WARNING_CFLAGS` contains `-funsigned-char`; full build under `--enable-compile-warnings=error` is clean; `make check` and `test-samples.sh` pass, including the two #320 regression tests, on Apple clang 21 and on gcc-14/Ubuntu 24.04.
- Without the switch: `WARNING_CFLAGS` does not contain the flag, byte-identical to master behavior.
- Control from the #320 work: the pre-#320 tree fails exactly this configuration, so the leg is known to be able to fail.
