### PR TITLE
Validate vertex and edge capacities before int arithmetic

### DIFF
--- a/c/graphLib/graph.c
+++ b/c/graphLib/graph.c
@@ -256,12 +256,29 @@ void _InitFunctionTable(graphP theGraph)
 
 int gp_EnsureVertexCapacity(graphP theGraph, int N)
 {
+    long long effectiveEdgeCapacity = 0;
+
     // valid params check
     if (theGraph == NULL || N <= 0)
         return NOTOK;
 
     // Should not call init a second time; use reinit
     if (gp_GetN(theGraph) > 0)
+        return NOTOK;
+
+    // Reject a vertex count whose capacity arithmetic cannot be represented
+    // in int (issue #325). The effective edge capacity is the greater of a
+    // pre-set edgeCapacity and DEFAULT_EDGE_CAPACITY_FACTOR * N, because
+    // gp_EnsureEdgeCapacity() may legitimately have stored a lower value
+    // before this call. The stack holds (edgeCapacity << 2) + 2 entries,
+    // which strictly exceeds every other derived quantity (vertex storage,
+    // edge storage and the 2 * 2 * DEFAULT_EDGE_CAPACITY_FACTOR * N + 2
+    // fallback), so one test on it shields them all, including the
+    // gp_UpperBoundEdgeStorage() uses in the algorithm extensions.
+    effectiveEdgeCapacity = (long long)DEFAULT_EDGE_CAPACITY_FACTOR * N;
+    if (theGraph->edgeCapacity > effectiveEdgeCapacity)
+        effectiveEdgeCapacity = theGraph->edgeCapacity;
+    if ((effectiveEdgeCapacity << 2) + 2 > INT_MAX)
         return NOTOK;
 
     return theGraph->functions->fpEnsureVertexCapacity(theGraph, N);
@@ -424,6 +441,15 @@ void _ResetGraphStorage(graphP theGraph)
 int gp_EnsureEdgeCapacity(graphP theGraph, int requiredEdgeCapacity)
 {
     if (theGraph == NULL || requiredEdgeCapacity <= 0)
+        return NOTOK;
+
+    // Reject a capacity whose stack arithmetic cannot be represented in int
+    // (issue #325). Together with the guard in gp_EnsureVertexCapacity(),
+    // this keeps every stored capacity able to support its stack and edge
+    // storage arithmetic: the vertex-side guard covers the derived
+    // quantities computed from N, and this test covers the ones computed
+    // from a stored or requested capacity
+    if ((((long long)requiredEdgeCapacity) << 2) + 2 > INT_MAX)
         return NOTOK;
 
     if (theGraph->edgeCapacity >= requiredEdgeCapacity)

--- a/c/graphLib/graph.c
+++ b/c/graphLib/graph.c
@@ -276,7 +276,7 @@ int gp_EnsureVertexCapacity(graphP theGraph, int N)
     // fallback), so one test on it shields them all, including the
     // gp_UpperBoundEdgeStorage() uses in the algorithm extensions.
     effectiveEdgeCapacity = (long long)DEFAULT_EDGE_CAPACITY_FACTOR * N;
-    if (theGraph->edgeCapacity > effectiveEdgeCapacity)
+    if (effectiveEdgeCapacity < theGraph->edgeCapacity)
         effectiveEdgeCapacity = theGraph->edgeCapacity;
     if ((effectiveEdgeCapacity << 2) + 2 > INT_MAX)
         return NOTOK;

--- a/c/graphLib/graph.c
+++ b/c/graphLib/graph.c
@@ -486,7 +486,7 @@ int _EnsureEdgeCapacity(graphP theGraph, int requiredEdgeCapacity)
     {
         int newStackSize = 2 * (2 * requiredEdgeCapacity) + 2;
 
-        if (newStackSize < 2 * DEFAULT_EDGE_CAPACITY_FACTOR * gp_GetN(theGraph) + 2)
+        if (newStackSize < 2 * (2 * DEFAULT_EDGE_CAPACITY_FACTOR * gp_GetN(theGraph)) + 2)
         {
             // NOTE: We enforce a minimum stack based on number of vertices
             //       if edgeCapacity is small. Currently, this will not
@@ -494,7 +494,7 @@ int _EnsureEdgeCapacity(graphP theGraph, int requiredEdgeCapacity)
             //       the capacity can only ever get bigger. However, this
             //       rule is enforced in case future methods are added
             //       that reduce edge capacity
-            newStackSize = 2 * DEFAULT_EDGE_CAPACITY_FACTOR * gp_GetN(theGraph) + 2;
+            newStackSize = 2 * (2 * DEFAULT_EDGE_CAPACITY_FACTOR * gp_GetN(theGraph)) + 2;
         }
 
         if ((newStack = sp_New(newStackSize)) == NULL)

--- a/c/planarityApp/planarityCommandLine.c
+++ b/c/planarityApp/planarityCommandLine.c
@@ -42,6 +42,7 @@ int runGraphMLTests(void);
 int runDrawPlanarNonplanarWriteTest(void);
 int runReadWithExtensionAtEofTest(void);
 int runHighByteRoundTripTest(void);
+int runCapacityLimitTests(void);
 int testDirectedDFS(void);
 int testPetersenDigraph(void);
 int testDigraphTranspose(void);
@@ -259,6 +260,8 @@ int runQuickRegressionTests(int argc, char *argv[])
     else if (runReadWithExtensionAtEofTest() != OK)
         retVal = NOTOK;
     else if (runHighByteRoundTripTest() != OK)
+        retVal = NOTOK;
+    else if (runCapacityLimitTests() != OK)
         retVal = NOTOK;
     else if (runGraphMLTests() != OK)
         retVal = NOTOK;
@@ -664,6 +667,66 @@ int runHighByteRoundTripTest(void)
 
     if (inputContainer != NULL)
         sf_Free(&inputContainer);
+
+    return Result;
+}
+
+/********************************************************************
+ runCapacityLimitTests()
+
+ Exercises the issue #325 guards: a vertex count or edge capacity
+ whose capacity arithmetic cannot be represented in int must be
+ rejected by the public wrappers before any allocation is attempted.
+
+ The first rejected vertex count on the default edge capacity is
+ (INT_MAX - 2) / 4 / DEFAULT_EDGE_CAPACITY_FACTOR + 1, and the first
+ rejected edge capacity is (INT_MAX - 2) / 4 + 1; the largest
+ acceptable edge capacity is tested on the accept side too, which is
+ safe because storing a capacity before gp_EnsureVertexCapacity()
+ allocates nothing.
+ ********************************************************************/
+
+int runCapacityLimitTests(void)
+{
+    int Result = OK;
+    graphP theGraph = NULL;
+    int firstBadN = (int)((((long long)INT_MAX - 2) / 4) / DEFAULT_EDGE_CAPACITY_FACTOR + 1);
+    int maxGoodEdgeCapacity = (int)(((long long)INT_MAX - 2) / 4);
+
+    gp_Message("Rejecting vertex counts and edge capacities beyond the "
+               "int arithmetic range (issue #325).");
+
+    if ((theGraph = gp_New()) == NULL)
+        Result = NOTOK;
+
+    if (Result == OK && gp_EnsureVertexCapacity(theGraph, INT_MAX) != NOTOK)
+        Result = NOTOK;
+
+    if (Result == OK && gp_EnsureVertexCapacity(theGraph, firstBadN) != NOTOK)
+        Result = NOTOK;
+
+    if (Result == OK && gp_EnsureEdgeCapacity(theGraph, maxGoodEdgeCapacity + 1) != NOTOK)
+        Result = NOTOK;
+
+    if (Result == OK && gp_EnsureEdgeCapacity(theGraph, maxGoodEdgeCapacity) != OK)
+        Result = NOTOK;
+
+    gp_Free(&theGraph);
+
+    // The guards must not disturb ordinary use
+    if (Result == OK)
+    {
+        if ((theGraph = gp_New()) == NULL)
+            Result = NOTOK;
+
+        if (Result == OK && gp_EnsureVertexCapacity(theGraph, 5) != OK)
+            Result = NOTOK;
+
+        gp_Free(&theGraph);
+    }
+
+    if (Result == OK)
+        gp_Message("Test succeeded.\n");
 
     return Result;
 }

--- a/c/planarityApp/planarityCommandLine.c
+++ b/c/planarityApp/planarityCommandLine.c
@@ -692,21 +692,41 @@ int runCapacityLimitTests(void)
     graphP theGraph = NULL;
     int firstBadN = (int)((((long long)INT_MAX - 2) / 4) / DEFAULT_EDGE_CAPACITY_FACTOR + 1);
     int maxGoodEdgeCapacity = (int)(((long long)INT_MAX - 2) / 4);
+    unsigned quietModeCache = gp_GetQuietMode();
 
-    gp_Message("Rejecting vertex counts and edge capacities beyond the "
-               "int arithmetic range (issue #325).");
+    gp_Message("Testing rejection of excessive vertex and edge capacity requests.");
 
     if ((theGraph = gp_New()) == NULL)
         Result = NOTOK;
 
-    if (Result == OK && gp_EnsureVertexCapacity(theGraph, INT_MAX) != NOTOK)
-        Result = NOTOK;
+    // The first tests below intentionally cause a NOTOK to come from the APIs,
+    // so we set fully quiet mode to prevent error messages on expected behaviors.
+    gp_SetQuietMode(QUIETMODE_ALL);
 
-    if (Result == OK && gp_EnsureVertexCapacity(theGraph, firstBadN) != NOTOK)
+    if (Result == OK && gp_EnsureVertexCapacity(theGraph, INT_MAX) == OK)
+    {
+        gp_SetQuietMode(quietModeCache);
         Result = NOTOK;
+        gp_SetQuietMode(QUIETMODE_ALL);
+    }
 
-    if (Result == OK && gp_EnsureEdgeCapacity(theGraph, maxGoodEdgeCapacity + 1) != NOTOK)
+    if (Result == OK && gp_EnsureVertexCapacity(theGraph, firstBadN) == OK)
+    {
+        gp_SetQuietMode(quietModeCache);
         Result = NOTOK;
+        gp_SetQuietMode(QUIETMODE_ALL);
+    }
+
+    if (Result == OK && gp_EnsureEdgeCapacity(theGraph, maxGoodEdgeCapacity + 1) == OK)
+    {
+        gp_SetQuietMode(quietModeCache);
+        Result = NOTOK;
+        gp_SetQuietMode(QUIETMODE_ALL);
+    }
+
+    // The end of tests intended to produce NOTOK has been reached, so we can go back
+    // to normal quiet mode behavior.
+    gp_SetQuietMode(quietModeCache);
 
     if (Result == OK && gp_EnsureEdgeCapacity(theGraph, maxGoodEdgeCapacity) != OK)
         Result = NOTOK;


### PR DESCRIPTION
Fixes #325, following the design set there: the vertex-side check uses the greater of a pre-set `edgeCapacity` and `DEFAULT_EDGE_CAPACITY_FACTOR * N`, and `gp_EnsureEdgeCapacity()` gets a stack-capacity check stringent enough to shield the `gp_UpperBoundEdgeStorage()` uses in the extensions.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Changes

### Updated

* `c/graphLib/graph.c`: both public wrappers validate in `long long` before dispatch. One test carries the load: the stack bound `(edgeCapacity << 2) + 2` is the strict maximum of every quantity later derived from `N` and the capacity, in the default and `USE_0BASEDARRAYS` builds and in the three extension overloads, so nothing downstream can overflow once it passes. The comments carry the dominance argument so it stays maintainable.
* `c/planarityApp/planarityCommandLine.c`: a quick-regression test pinning both boundaries. First rejected vertex count is 178,956,971 and first rejected edge capacity is 536,870,912, both derived in-code from `INT_MAX` rather than hardcoded; the edge-capacity accept side is exercised at its exact maximum, which allocates nothing because the capacity is stored before `gp_EnsureVertexCapacity()`.

The observable change for the text readers: `N=2147483647` in an adjacency-list, adjacency-matrix or LEDA file now returns `NOTOK` immediately, where each previously ran signed arithmetic past `INT_MAX` at `graph.c:277`/`:285` and attempted multi-gigabyte allocations.

## Testing

- UBSan build: the three reproducers from #325 are clean and fail fast; `N=178956970` (last valid) stays clean; full `-test` suite passes 24/24 under the sanitizer.
- Both gates on Ubuntu 24.04: gcc-14 and clang-18 under `--enable-compile-warnings=error`, plus the new `--enable-unsigned-char` leg, all clean, suite 24/24.
- macOS Apple clang 21: build clean under the error gate, `make check` and `test-samples.sh` pass.
- Boundary exactness cross-checked independently: `12N+2 = 2,147,483,642` at the last accepted `N`, `2,147,483,654` at the first rejected.
