### PR TITLE
Issue323 address msvc warnings

### DIFF
--- a/.github/workflows/compile-warnings.yml
+++ b/.github/workflows/compile-warnings.yml
@@ -45,5 +45,39 @@ jobs:
             CC="$CC"
       - name: Build . . .
         run: make -j4
-        # We don't run the tests, since in this job we are only checking for
-        # compiler warnings
+        # This job is run on every PR, so we ensure that for at least these warning-free
+        # compiles, the build program also works
+      - name: Run the tests . . .
+        run: ./test-samples.sh
+
+  msvc:
+    name: Windows MSVC cl
+    timeout-minutes: 60
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x64, x86, x86_amd64, amd64_x86]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup MSVC Developer Command Prompt
+        uses: TheMrMilchmann/setup-msvc-dev@368ef7d1ee4d1171b31d4a7f67f4d954f903f5a9 # v4.1.0
+        with:
+          arch: ${{ matrix.arch }}
+        # NOTE: Using defaults for sdk (use default Windows SDK), toolset (use
+        # default compiler toolset), uwp (not building for Windows Store, so no
+        # need for Universal Windows Platform support), nor spectre (not using
+        # VS tools with spectre mitigations) Also, not setting vs-path so we
+        # always use the latest
+      - name: Build using MSVC cl
+        run: |
+          cl /O2 /nologo /Wall /wd4464 /wd4710 /wd4711 /wd4774 /wd4996 /wd5045 `
+          /wd4068 /wd4820 /WX /external:anglebrackets /external:W0 `
+          /Fe./planarity.exe ./c/planarityApp/**.c ./c/graphLib/**.c `
+          ./c/graphLib/extensionSystem/**.c ./c/graphLib/homeomorphSearch/**.c `
+          ./c/graphLib/io/**.c ./c/graphLib/lowLevelUtils/**.c `
+          ./c/graphLib/planarityRelated/**.c
+        # This job is run on every PR, so we ensure that for at least these warning-free
+        # compiles, the build program also works
+      - name: Run the tests...
+        run: ./planarity.exe -test ./c/samples/

--- a/c/graphLib/io/g6-read-iterator.c
+++ b/c/graphLib/io/g6-read-iterator.c
@@ -356,6 +356,7 @@ int _g6_InitReader(G6ReadIteratorP theG6ReadIterator)
 
 int _g6_ValidateHeader(strOrFileP inputContainer)
 {
+    int intChar = 0;
     char const *g6Header = ">>graph6<<";
     char const *sparse6Header = ">>sparse6<";
     char const *digraph6Header = ">>digraph6";
@@ -371,7 +372,13 @@ int _g6_ValidateHeader(strOrFileP inputContainer)
 
     for (int i = 0; i < 10; i++)
     {
-        headerCandidateChars[i] = sf_getc(inputContainer);
+        intChar = sf_getc(inputContainer);
+        if (intChar == EOF)
+        {
+            gp_ErrorMessage("Truncated >>graph6<< header.");
+            return NOTOK;
+        }
+        headerCandidateChars[i] = (char)intChar;
     }
 
     headerCandidateChars[10] = '\0';

--- a/c/graphLib/io/g6-read-iterator.c
+++ b/c/graphLib/io/g6-read-iterator.c
@@ -32,7 +32,7 @@ int _g6_ValidateHeader(strOrFileP inputContainer);
 int _g6_ValidateFirstChar(char c, const int lineNum);
 int _g6_DetermineOrderFromInput(strOrFileP inputContainer, int *order);
 
-int _g6_DecodeGraph(char *graphBuff, const int order, const int numChars, graphP theGraph);
+int _g6_DecodeGraph(char *graphBuff, const int order, const size_t numChars, graphP theGraph);
 
 int _g6_ReadGraphFromFile(graphP theGraph, char *pathToG6File);
 int _g6_ReadGraphFromString(graphP theGraph, char *g6EncodedString);
@@ -475,7 +475,7 @@ int g6_ReadGraph(G6ReadIteratorP theG6ReadIterator)
     graphP currGraph = NULL;
     const int order = theG6ReadIterator == NULL ? 0 : theG6ReadIterator->order;
     const int numCharsForOrder = theG6ReadIterator == NULL ? 0 : theG6ReadIterator->numCharsForOrder;
-    const int numCharsForGraphEncoding = theG6ReadIterator == NULL ? 0 : theG6ReadIterator->numCharsForGraphEncoding;
+    const size_t numCharsForGraphEncoding = theG6ReadIterator == NULL ? 0 : theG6ReadIterator->numCharsForGraphEncoding;
     const int currGraphBuffSize = theG6ReadIterator == NULL ? 0 : theG6ReadIterator->currGraphBuffSize;
 
     if (!_g6_IsReaderInitialized(theG6ReadIterator, TRUE))
@@ -503,10 +503,9 @@ int g6_ReadGraph(G6ReadIteratorP theG6ReadIterator)
         // If the line was too long, then we would have placed the null terminator at the final
         // index (where it already was; see strcpn docs), and the length of the string will be
         // longer than the line should have been, i.e. orderOffset + numCharsForGraphRepr
-        if ((int)strlen(currGraphBuff) != (((lineNum == 1) ? 0 : numCharsForOrder) + numCharsForGraphEncoding))
+        if (strlen(currGraphBuff) != (((lineNum == 1) ? 0 : numCharsForOrder) + numCharsForGraphEncoding))
         {
-            gp_ErrorMessage("Invalid line length read on line %d",
-                            lineNum);
+            gp_ErrorMessage("Invalid line length read on line %d", lineNum);
             return NOTOK;
         }
 
@@ -514,8 +513,7 @@ int g6_ReadGraph(G6ReadIteratorP theG6ReadIterator)
         {
             if (_g6_ValidateOrderOfEncodedGraph(currGraphBuff, order) != OK)
             {
-                gp_ErrorMessage("Order of graph on line %d is incorrect.",
-                                lineNum);
+                gp_ErrorMessage("Order of graph on line %d is incorrect.", lineNum);
                 return NOTOK;
             }
         }
@@ -564,7 +562,7 @@ int g6_ReadGraph(G6ReadIteratorP theG6ReadIterator)
 // the final byte, we determine how many padding zeroes to expect, and exclude them
 // from being processed. We index into the adjacency matrix by row and column, which
 // are incremented such that row ranges from 0 to one less than the column index.
-int _g6_DecodeGraph(char *graphBuff, const int order, const int numChars, graphP theGraph)
+int _g6_DecodeGraph(char *graphBuff, const int order, const size_t numChars, graphP theGraph)
 {
     int numPaddingZeroes = _g6_GetExpectedNumPaddingZeroes(order, numChars);
 
@@ -580,7 +578,13 @@ int _g6_DecodeGraph(char *graphBuff, const int order, const int numChars, graphP
         return NOTOK;
     }
 
-    for (int i = 0; i < numChars; i++)
+    if (numChars > INT_MAX)
+    {
+        gp_ErrorMessage("Unsupported number of characters to decode.");
+        return NOTOK;
+    }
+
+    for (int i = 0; i < (int)numChars; i++)
     {
         currByte = graphBuff[i] - 63;
         // j corresponds to the number of places one must bitshift the byte by
@@ -589,7 +593,7 @@ int _g6_DecodeGraph(char *graphBuff, const int order, const int numChars, graphP
         {
             // If we are on the final byte, we know that the final
             // numPaddingZeroes bits can be ignored, so we break out of the loop
-            if ((i == numChars) && j == numPaddingZeroes - 1)
+            if ((i == (int)numChars) && j == numPaddingZeroes - 1)
                 break;
 
             if (row == col)

--- a/c/graphLib/io/g6-read-iterator.c
+++ b/c/graphLib/io/g6-read-iterator.c
@@ -476,11 +476,16 @@ int g6_ReadGraph(G6ReadIteratorP theG6ReadIterator)
     const int order = theG6ReadIterator == NULL ? 0 : theG6ReadIterator->order;
     const int numCharsForOrder = theG6ReadIterator == NULL ? 0 : theG6ReadIterator->numCharsForOrder;
     const size_t numCharsForGraphEncoding = theG6ReadIterator == NULL ? 0 : theG6ReadIterator->numCharsForGraphEncoding;
-    const int currGraphBuffSize = theG6ReadIterator == NULL ? 0 : theG6ReadIterator->currGraphBuffSize;
+    const size_t currGraphBuffSize = theG6ReadIterator == NULL ? 0 : theG6ReadIterator->currGraphBuffSize;
 
     if (!_g6_IsReaderInitialized(theG6ReadIterator, TRUE))
     {
         gp_ErrorMessage("G6ReadIterator is not initialized.");
+        return NOTOK;
+    }
+    if (numCharsForGraphEncoding > INT_MAX || currGraphBuffSize > INT_MAX)
+    {
+        gp_ErrorMessage("Integer overflow.");
         return NOTOK;
     }
 
@@ -489,7 +494,7 @@ int g6_ReadGraph(G6ReadIteratorP theG6ReadIterator)
     currGraphBuff = theG6ReadIterator->currGraphBuff;
     currGraph = theG6ReadIterator->currGraph;
 
-    if (sf_fgets(currGraphBuff, currGraphBuffSize, inputContainer) != NULL)
+    if (sf_fgets(currGraphBuff, (int)currGraphBuffSize, inputContainer) != NULL)
     {
         firstChar = currGraphBuff[0];
 
@@ -564,7 +569,7 @@ int g6_ReadGraph(G6ReadIteratorP theG6ReadIterator)
 // are incremented such that row ranges from 0 to one less than the column index.
 int _g6_DecodeGraph(char *graphBuff, const int order, const size_t numChars, graphP theGraph)
 {
-    int numPaddingZeroes = _g6_GetExpectedNumPaddingZeroes(order, numChars);
+    size_t numPaddingZeroes = _g6_GetExpectedNumPaddingZeroes(order, numChars);
 
     char currByte = '\0';
     int bitValue = 0;
@@ -578,9 +583,9 @@ int _g6_DecodeGraph(char *graphBuff, const int order, const size_t numChars, gra
         return NOTOK;
     }
 
-    if (numChars > INT_MAX)
+    if (numChars > INT_MAX || numPaddingZeroes > INT_MAX)
     {
-        gp_ErrorMessage("Unsupported number of characters to decode.");
+        gp_ErrorMessage("Integer overflow.");
         return NOTOK;
     }
 
@@ -593,7 +598,7 @@ int _g6_DecodeGraph(char *graphBuff, const int order, const size_t numChars, gra
         {
             // If we are on the final byte, we know that the final
             // numPaddingZeroes bits can be ignored, so we break out of the loop
-            if ((i == (int)numChars) && j == numPaddingZeroes - 1)
+            if ((i == (int)numChars) && j == ((int)numPaddingZeroes) - 1)
                 break;
 
             if (row == col)

--- a/c/graphLib/io/strOrFile.c
+++ b/c/graphLib/io/strOrFile.c
@@ -448,14 +448,14 @@ int sf_ReadInteger(int *intToRead, strOrFileP theStrOrFile)
                 }
                 else
                 {
-                    intCandidateStr[intCandidateIndex++] = currChar;
+                    intCandidateStr[intCandidateIndex++] = (char)currChar;
                     isNegative = TRUE;
                 }
             }
         }
         else if (isdigit(currChar))
         {
-            intCandidateStr[intCandidateIndex++] = currChar;
+            intCandidateStr[intCandidateIndex++] = (char)currChar;
             startedReadingInt = TRUE;
         }
         else
@@ -497,7 +497,7 @@ int sf_ReadInteger(int *intToRead, strOrFileP theStrOrFile)
 
                     if (exitCode == OK)
                     {
-                        intCandidateStr[intCandidateIndex++] = nextChar;
+                        intCandidateStr[intCandidateIndex++] = (char)nextChar;
                     }
                 }
                 else if (sf_ungetc(nextChar, theStrOrFile) != nextChar)

--- a/c/graphLib/io/strOrFile.c
+++ b/c/graphLib/io/strOrFile.c
@@ -601,12 +601,15 @@ int sf_ungetc(int theChar, strOrFileP theStrOrFile)
 
 int sf_ungets(char *strToUnget, strOrFileP theStrOrFile)
 {
+    if (strToUnget == NULL || strlen(strToUnget) > INT_MAX)
+        return NOTOK;
+
     if (!sf_IsValidStrOrFile(theStrOrFile) ||
         theStrOrFile->containerType != INPUT_CONTAINER ||
         (int)strlen(strToUnget) > (sp_GetCapacity(theStrOrFile->ungetBuf) - sp_GetCurrentSize(theStrOrFile->ungetBuf)))
         return NOTOK;
 
-    for (int i = (strlen(strToUnget) - 1); i >= 0; i--)
+    for (int i = ((int)strlen(strToUnget) - 1); i >= 0; i--)
         // N.B. Convert through unsigned char so a 0xFF byte does not enter the
         // unget buffer as EOF on signed-char platforms
         sp_Push(theStrOrFile->ungetBuf, (unsigned char)strToUnget[i]);
@@ -722,9 +725,14 @@ int sf_fputs(char const *strToWrite, strOrFileP theStrOrFile)
     int outputLen = EOF;
 
     if (strToWrite == NULL ||
+        strlen(strToWrite) > INT_MAX ||
         !sf_IsValidStrOrFile(theStrOrFile) ||
         theStrOrFile->containerType != OUTPUT_CONTAINER)
+    {
+        gp_ErrorMessage("Internal error.");
+        sf_SetOutputErrorFlag(theStrOrFile);
         return EOF;
+    }
 
     // N.B. fputs() will fail and return EOF if pFile doesn't correspond
     // to an output stream
@@ -733,7 +741,7 @@ int sf_fputs(char const *strToWrite, strOrFileP theStrOrFile)
     else if (theStrOrFile->theStrBuf != NULL)
     {
         if (sb_ConcatString(theStrOrFile->theStrBuf, strToWrite) == OK)
-            outputLen = strlen(strToWrite);
+            outputLen = (int)strlen(strToWrite);
         else
             outputLen = EOF;
     }
@@ -758,7 +766,11 @@ int sf_WriteInteger(int intToWrite, strOrFileP theStrOrFile)
 
     if (!sf_IsValidStrOrFile(theStrOrFile) ||
         theStrOrFile->containerType != OUTPUT_CONTAINER)
+    {
+        gp_ErrorMessage("Internal error.");
+        sf_SetOutputErrorFlag(theStrOrFile);
         return NOTOK;
+    }
 
     if (theStrOrFile->pFile != NULL)
         result = fprintf(theStrOrFile->pFile, "%d", intToWrite) < 0 ? NOTOK : OK;

--- a/c/graphLib/io/strbuf.c
+++ b/c/graphLib/io/strbuf.c
@@ -22,7 +22,7 @@ strBufP sb_New(int capacity)
 {
     strBufP theStrBuf;
 
-    if (capacity < 0)
+    if (capacity < 0 || capacity == INT_MAX)
         return NULL;
 
     theStrBuf = (strBufP)malloc(sizeof(strBuf));
@@ -184,19 +184,32 @@ void sb_ReadSkipInteger(strBufP theStrBuf)
  ********************************************************************/
 int sb_ConcatString(strBufP theStrBuf, char const *s)
 {
-    int slen = s == NULL ? 0 : strlen(s);
+    // Switched to size_t to fix int overflow and also warnings on 64-bit builds
+    size_t strLen = s == NULL ? 0 : strlen(s);
 
-    if (slen == 0)
+    if (strLen == 0)
         return OK;
 
     if (theStrBuf == NULL || theStrBuf->buf == NULL)
         return NOTOK;
 
-    if (theStrBuf->size + slen > theStrBuf->capacity)
-    {
-        int newLen = theStrBuf->size + slen > 2 * theStrBuf->capacity ? theStrBuf->size + slen : 2 * theStrBuf->capacity;
-        char *newBuf = (char *)malloc((newLen + 1) * sizeof(char));
+    if (theStrBuf->size + strLen > INT_MAX)
+        return NOTOK;
 
+    if ((size_t)theStrBuf->size + strLen > (size_t)theStrBuf->capacity)
+    {
+        size_t newLen = 0, doubleCapacity = 0;
+        char *newBuf = NULL;
+
+        doubleCapacity = ((size_t)theStrBuf->capacity) << 1;
+        newLen = theStrBuf->size + strLen;
+        if (newLen < doubleCapacity && (doubleCapacity + 1) <= INT_MAX)
+            newLen = doubleCapacity;
+
+        if ((newLen + 1) > INT_MAX)
+            return NOTOK;
+
+        newBuf = (char *)malloc((newLen + 1) * sizeof(char));
         if (newBuf == NULL)
             return NOTOK;
 
@@ -207,7 +220,7 @@ int sb_ConcatString(strBufP theStrBuf, char const *s)
     }
 
     strcpy(theStrBuf->buf + theStrBuf->size, s);
-    theStrBuf->size += slen;
+    theStrBuf->size += (int)strLen;
 
     return OK;
 }

--- a/c/graphLib/io/strbuf.c
+++ b/c/graphLib/io/strbuf.c
@@ -216,7 +216,7 @@ int sb_ConcatString(strBufP theStrBuf, char const *s)
         strcpy(newBuf, theStrBuf->buf);
         free(theStrBuf->buf);
         theStrBuf->buf = newBuf;
-        theStrBuf->capacity = newLen;
+        theStrBuf->capacity = (int)newLen;
     }
 
     strcpy(theStrBuf->buf + theStrBuf->size, s);

--- a/c/planarityApp/planarityCommandLine.c
+++ b/c/planarityApp/planarityCommandLine.c
@@ -629,10 +629,17 @@ int runHighByteRoundTripTest(void)
 {
     int Result = OK;
     int currChar = EOF;
-    char const highByteStr[] = {'a', (char)0xFF, 'b', '\0'};
+    unsigned char eofChar = 0xFF;
+    char highByteStr[4];
+    // char const highByteStr[] = {'a', (char)0xFF, 'b', '\0'};
     strOrFileP inputContainer = NULL;
 
     gp_Message("Test Support of 0xFF Byte.");
+
+    highByteStr[0] = 'a';
+    highByteStr[1] = (char)eofChar;
+    highByteStr[2] = 'b';
+    highByteStr[3] = '\0';
 
     if ((inputContainer = sf_NewInputContainer(highByteStr, NULL)) == NULL)
         Result = NOTOK;

--- a/c/planarityApp/planarityTestAllGraphs.c
+++ b/c/planarityApp/planarityTestAllGraphs.c
@@ -250,6 +250,7 @@ int outputTestAllGraphsResults(char command, char modifier, testAllStatsP stats,
 
     char *theOutputStr = NULL;
     int headerStrLen = 0, resultStrLen = 0;
+    size_t headerStrLenWide = 0;
     char *resultsStr = NULL;
 
     if (outfileName == NULL && (pOutputStr == NULL || *pOutputStr != NULL))
@@ -259,11 +260,18 @@ int outputTestAllGraphsResults(char command, char modifier, testAllStatsP stats,
         return NOTOK;
     }
 
-    headerStrLen =
+    headerStrLenWide =
         strlen(headerFormat) +
         strlen(infileBasename) +
         strlen("-1.7976931348623158e+308") + // -DBL_MAX from float.h
         3;
+
+    if (headerStrLenWide > INT_MAX)
+    {
+        gp_ErrorMessage("Integer overflow.");
+        return NOTOK;
+    }
+    headerStrLen = (int)headerStrLenWide;
 
     if (GetNumCharsToReprInt(stats->numGraphsTested, &numCharsToReprNumGraphsTested) != OK ||
         GetNumCharsToReprInt(stats->numOK, &numCharsToReprNumOK) != OK ||

--- a/c/planarityApp/planarityUtils.c
+++ b/c/planarityApp/planarityUtils.c
@@ -296,10 +296,23 @@ char *ReadTextFileIntoString(char const *infileName)
         fileSize = ftell(infile);
         fseek(infile, filePos, SEEK_SET);
 
-        if ((inputString = (char *)malloc((fileSize + 1) * sizeof(char))) != NULL)
+        if (fileSize >= INT_MAX)
+            gp_ErrorMessage("The file is too large.");
+        else
         {
-            long bytesRead = fread((void *)inputString, 1, fileSize, infile);
-            inputString[bytesRead] = '\0';
+            if ((inputString = (char *)malloc((fileSize + 1) * sizeof(char))) != NULL)
+            {
+                size_t bytesRead = fread((void *)inputString, 1, fileSize, infile);
+
+                if (bytesRead != (size_t)fileSize)
+                {
+                    gp_ErrorMessage("A read error occurred.");
+                    free(inputString);
+                    inputString = NULL;
+                }
+                else
+                    inputString[bytesRead] = '\0';
+            }
         }
 
         fclose(infile);

--- a/c/planarityApp/planarityUtils.c
+++ b/c/planarityApp/planarityUtils.c
@@ -979,22 +979,35 @@ int ConstructTransformationExpectedResultFileName(char const *infileName, char *
 
     char const *baseName = GetBaseName(baseFlag);
     char const *transformationName = GetTransformationName(command);
-    int infileNameLen = -1;
 
-    if (infileName == NULL || (infileNameLen = strlen(infileName)) < 1)
+    if (infileName == NULL || strlen(infileName) < 1)
     {
         gp_ErrorMessage("Cannot construct transformation output file name for "
                         "empty infileName.");
         return NOTOK;
     }
 
+    if (baseName == NULL || transformationName == NULL)
+    {
+        gp_ErrorMessage("Cannot construct transformation output file name due "
+                        "to an internal error.");
+        return NOTOK;
+    }
+
     if ((*outfileName) == NULL)
     {
-        (*outfileName) = (char *)calloc(
-            infileNameLen + 1 + strlen(baseName) + 1 + strlen(transformationName) +
-                ((command == 'g') ? strlen(".out.g6") : strlen(".out.txt")) + 1,
-            sizeof(char));
+        size_t outfileNameLen = strlen(infileName) + 1 +
+                                strlen(baseName) + 1 + strlen(transformationName) +
+                                ((command == 'g') ? strlen(".out.g6") : strlen(".out.txt"));
 
+        if (outfileNameLen + 1 > INT_MAX)
+        {
+            gp_ErrorMessage("Cannot construct transformation output file name "
+                            "because the output file name would be too long.");
+            return NOTOK;
+        }
+
+        (*outfileName) = (char *)calloc(outfileNameLen + 1, sizeof(char));
         if ((*outfileName) == NULL)
         {
             gp_ErrorMessage("Unable to allocate memory for output file name.");
@@ -1010,7 +1023,8 @@ int ConstructTransformationExpectedResultFileName(char const *infileName, char *
     }
     else
     {
-        gp_ErrorMessage("outfileName already allocated.");
+        gp_ErrorMessage("Cannot construct transformation output file name "
+                        " because the output file name already allocated.");
         Result = NOTOK;
     }
 

--- a/devEnvSetupAndDefaults/.vscode/tasks.json
+++ b/devEnvSetupAndDefaults/.vscode/tasks.json
@@ -386,6 +386,7 @@
                 "/DDEBUG", // Added so that _DEBUG is defined; see appconst.h
                 //"/DUSE_0BASEDARRAYS", // Commented out to use default of 1-based array indexing
                 "/Wall",
+                "/WX",
                 "/wd4464", // Ignore warnings about relative paths
                 "/wd4710", // Ignore warnings about not inlining scanf, sprintf, printf, fprintf, etc.
                 "/wd4711", // Ignore warnings about automatic inline expansion, as we are not concerned with code size
@@ -429,6 +430,7 @@
                 "/DDEBUG", // Added so that _DEBUG is defined; see appconst.h
                 //"/DUSE_0BASEDARRAYS", // Commented out to use default of 1-based array indexing
                 "/Wall",
+                "/WX",
                 "/wd4464", // Ignore warnings about relative paths
                 "/wd4710", // Ignore warnings about not inlining scanf, sprintf, printf, fprintf, etc.
                 "/wd4711", // Ignore warnings about automatic inline expansion, as we are not concerned with code size
@@ -468,6 +470,7 @@
                 "/nologo",
                 //"/DUSE_0BASEDARRAYS", // Commented out to use default of 1-based array indexing
                 "/Wall",
+                "/WX",
                 "/wd4464", // Ignore warnings about relative paths
                 "/wd4710", // Ignore warnings about not inlining scanf, sprintf, printf, fprintf, etc.
                 "/wd4711", // Ignore warnings about automatic inline expansion, as we are not concerned with code size


### PR DESCRIPTION
Resolves #323 

## Type of change

Please indicate the type of change by deleting non-relevant list items below:

- Bug fix (non-breaking change which fixes an issue)

## Changes

Changes to various source files to fix signed integer overflow issues highlighted by MSVC `cl` warnings when `/WX` is added to the MSVC jobs.

Added the MSVC jobs (matrix of 4) to `compiler-warnings.yml` (due to importance of MSVC `cl` as the default compiler used by Python to compile Cython on Windows).

Added running of `test-samples.sh` in `compiler-warnings.yml` (because code should not only compile but also work). 

## Testing

All GitHub actions, which include functional testing via `planarity -tests` and sanitizers