### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,12 @@
+cff-version: 1.2.0
+message: If you use this software, please cite it as below.
+title: Edge Addition Planarity Suite and Generalized Graph Library
+type: software
+authors:
+- given-names: John M.
+  family-names: Boyer
+  orcid: https://orcid.org/0000-0002-4755-5535
+- given-names: Wanda B. K.
+  family-names: Boyer
+repository-code: https://github.com/graph-algorithms/edge-addition-planarity-suite
+license: BSD-3-Clause


### PR DESCRIPTION
Adds a `CITATION.cff` so GitHub shows a "Cite this repository" button and citation tooling can read machine-readable metadata.

Author names and ORCIDs come from `paper.md`, and the licence from the LICENSE file. Validated with `cffconvert --validate` against schema 1.2.0.

Worth checking the given-name/family-name split per author, since some papers give a single `name` field.