### PR TITLE
Run distcheck for manually dispatched test workflows

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -39,7 +39,6 @@ jobs:
   distcheck:
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
     env:
       CC: gcc
     steps:


### PR DESCRIPTION
Resolves #330

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Changes

### Updated

- `.github/workflows/runtests.yml` — remove the stale pull-request-only condition from the `distcheck` job. The workflow currently enables only `workflow_dispatch`, so the old condition made the job unconditionally skip on every available trigger.

## Testing

- Confirmed [Tests run 34053173815](https://github.com/graph-algorithms/edge-addition-planarity-suite/actions/runs/34053173815) used `workflow_dispatch` and reported `distcheck` as skipped with no steps.
- Parsed `.github/workflows/runtests.yml` successfully with Ruby Psych.
- Confirmed the `distcheck` job no longer contains an `if` event guard.
- Ran the exact job commands in an isolated source archive: `mkdir -p m4`, `autoreconf -if`, `./configure CC=gcc`, and `make distcheck -j4`; all completed successfully and produced the `planarity-5.1.0.0.tar.gz` distribution archive.
- `git diff --check`

The pull-request trigger remains disabled, preserving the repository's current Actions-minutes policy; this only makes `distcheck` participate in manually dispatched Tests runs.