### PR TITLE
Add a missing const qualifier

### DIFF
--- a/c/planarityApp/planarityTestAllGraphs.c
+++ b/c/planarityApp/planarityTestAllGraphs.c
@@ -242,7 +242,7 @@ int outputTestAllGraphsResults(char command, char modifier, testAllStatsP stats,
 {
     int Result = OK;
 
-    char *finalSlash = strrchr(infileName, FILE_DELIMITER);
+    char const *finalSlash = strrchr(infileName, FILE_DELIMITER);
     char const *infileBasename = finalSlash ? (finalSlash + 1) : infileName;
 
     char const *headerFormat = "FILENAME=\"%s\" DURATION=\"%.3lf\"\n";


### PR DESCRIPTION
## Type of change

Please indicate the type of change by deleting non-relevant list items below:

- Bug fix (non-breaking change which fixes an issue)

## Changes

### Updated

* `c/planarityApp/planarityTestAllGraphs.c`: fixes this warning (enabled by `-Wall` on recent versions of GCC):
```
c/planarityApp/planarityTestAllGraphs.c: In function ‘outputTestAllGraphsResults’:
c/planarityApp/planarityTestAllGraphs.c:245:24: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  245 |     char *finalSlash = strrchr(infileName, FILE_DELIMITER);
      |                        ^~~~~~~
```
